### PR TITLE
Dynamically load Pi specific libraries with non-Pi fallbacks.

### DIFF
--- a/src/interface/MockInterface.py
+++ b/src/interface/MockInterface.py
@@ -1,0 +1,188 @@
+'''Mock interface layer.'''
+
+import gevent # For threads and timing
+import random
+from gevent.lock import BoundedSemaphore # To limit i2c calls
+from monotonic import monotonic # to capture read timing
+
+from Node import Node
+from BaseHardwareInterface import BaseHardwareInterface
+
+UPDATE_SLEEP = 0.1 # Main update loop delay
+
+MIN_RSSI_VALUE = 1               # reject RSSI readings below this value
+MAX_RSSI_VALUE = 999             # reject RSSI readings above this value
+CAP_ENTER_EXIT_AT_MILLIS = 3000  # number of ms for capture of enter/exit-at levels
+ENTER_AT_PEAK_MARGIN = 5         # closest that captured enter-at level can be to node peak RSSI
+
+class MockInterface(BaseHardwareInterface):
+    def __init__(self):
+        BaseHardwareInterface.__init__(self)
+        self.update_thread = None # Thread for running the main update loop
+        self.pass_record_callback = None # Function added in server.py
+        self.hardware_log_callback = None # Function added in server.py
+        self.new_enter_or_exit_at_callback = None # Function added in server.py
+        self.node_crossing_callback = None # Function added in server.py
+
+        # Scans all i2c_addrs to populate nodes array
+        self.nodes = [] # Array to hold each node object
+        i2c_addrs = [8, 10, 12, 14, 16, 18, 20, 22] # Software limited to 8 nodes
+        for index, addr in enumerate(i2c_addrs):
+            node = Node() # New node instance
+            node.i2c_addr = addr # Set current loop i2c_addr
+            node.index = index
+            node.api_valid_flag = True
+            node.api_level = 17
+            node.enter_at_level = 50
+            node.exit_at_level = 100
+            self.nodes.append(node) # Add new node to RHInterface
+
+        # Core temperature
+        self.core_temp = 30
+
+        # Scan for BME280 devices
+        self.bme280_addrs = []
+        self.bme280_data = []
+
+
+    #
+    # Class Functions
+    #
+
+    def log(self, message):
+        '''Hardware log of messages.'''
+        if callable(self.hardware_log_callback):
+            string = 'Interface: {0}'.format(message)
+            self.hardware_log_callback(string)
+
+    #
+    # Update Loop
+    #
+
+    def start(self):
+        if self.update_thread is None:
+            self.log('Starting background thread.')
+            self.update_thread = gevent.spawn(self.update_loop)
+
+    def update_loop(self):
+        try:
+            while True:
+                self.update()
+                gevent.sleep(UPDATE_SLEEP)
+        except KeyboardInterrupt:
+            print "Update thread terminated by keyboard interrupt"
+
+    def update(self):
+        upd_list = []  # list of nodes with new laps (node, new_lap_id, lap_time_ms)
+        cross_list = []  # list of nodes with crossing-flag changes
+        for node in self.nodes:
+            if node.frequency:
+                node.current_rssi = 30 + random.randrange(-10, 10)
+
+        # process any nodes with crossing-flag changes
+        if len(cross_list) > 0:
+            for node in cross_list:
+                self.node_crossing_callback(node)
+
+        # process any nodes with new laps detected
+        if len(upd_list) > 0:
+            if len(upd_list) == 1:  # list contains single item
+                item = upd_list[0]
+                node = item[0]
+                if node.last_lap_id != -1 and callable(self.pass_record_callback):
+                    self.pass_record_callback(node, item[2])  # (node, lap_time_ms)
+                node.last_lap_id = item[1]  # new_lap_id
+
+            else:  # list contains multiple items; sort so processed in order by lap time
+                upd_list.sort(key = lambda i: i[0].lap_ms_since_start)
+                for item in upd_list:
+                    node = item[0]
+                    if node.last_lap_id != -1 and callable(self.pass_record_callback):
+                        self.pass_record_callback(node, item[2])  # (node, lap_time_ms)
+                    node.last_lap_id = item[1]  # new_lap_id
+
+
+
+    #
+    # External functions for setting data
+    #
+
+    def set_frequency(self, node_index, frequency):
+        node = self.nodes[node_index]
+        node.debug_pass_count = 0  # reset debug pass count on frequency change
+        if frequency:
+            node.frequency = frequency
+        else:  # if freq=0 (node disabled) then write default freq, but save 0 value
+            node.frequency = 0
+
+    def transmit_enter_at_level(self, node, level):
+        return level
+
+    def set_enter_at_level(self, node_index, level):
+        node = self.nodes[node_index]
+        if node.api_valid_flag:
+            node.enter_at_level = self.transmit_enter_at_level(node, level)
+
+    def transmit_exit_at_level(self, node, level):
+        return level
+
+    def set_exit_at_level(self, node_index, level):
+        node = self.nodes[node_index]
+        if node.api_valid_flag:
+            node.exit_at_level = self.transmit_exit_at_level(node, level)
+
+    def set_calibration_threshold_global(self, threshold):
+        return threshold  # dummy function; no longer supported
+
+    def enable_calibration_mode(self):
+        pass  # dummy function; no longer supported
+
+    def set_calibration_offset_global(self, offset):
+        return offset  # dummy function; no longer supported
+
+    def set_trigger_threshold_global(self, threshold):
+        return threshold  # dummy function; no longer supported
+
+    def mark_start_time(self, node_index, start_time):
+        node = self.nodes[node_index]
+
+    def mark_start_time_global(self, pi_time):
+        bcast_flag = False
+        start_time = int(round(pi_time * 1000)) # convert to ms
+
+    def start_capture_enter_at_level(self, node_index):
+        node = self.nodes[node_index]
+        if node.cap_enter_at_flag is False and node.api_valid_flag:
+            node.cap_enter_at_total = 0
+            node.cap_enter_at_count = 0
+                   # set end time for capture of RSSI level:
+            node.cap_enter_at_millis = self.milliseconds() + CAP_ENTER_EXIT_AT_MILLIS
+            node.cap_enter_at_flag = True
+            return True
+        return False
+
+    def start_capture_exit_at_level(self, node_index):
+        node = self.nodes[node_index]
+        if node.cap_exit_at_flag is False and node.api_valid_flag:
+            node.cap_exit_at_total = 0
+            node.cap_exit_at_count = 0
+                   # set end time for capture of RSSI level:
+            node.cap_exit_at_millis = self.milliseconds() + CAP_ENTER_EXIT_AT_MILLIS
+            node.cap_exit_at_flag = True
+            return True
+        return False
+
+    def intf_simulate_lap(self, node_index, ms_val):
+        node = self.nodes[node_index]
+        node.lap_ms_since_start = ms_val
+        self.pass_record_callback(node, 100)
+
+    def force_end_crossing(self, node_index):
+        node = self.nodes[node_index]
+
+    def update_environmental_data(self):
+        '''Updates environmental data.'''
+
+def get_hardware_interface():
+    '''Returns the interface object.'''
+    return MockInterface()

--- a/src/server/ANSIPixel.py
+++ b/src/server/ANSIPixel.py
@@ -1,0 +1,60 @@
+'''Dummy LED layer.'''
+
+from colorama import init, Fore, Cursor
+
+def Color(red, green, blue):
+	"""Convert the provided red, green, blue color to a 24-bit color value.
+	Each color component should be a value 0-255 where 0 is the lowest intensity
+	and 255 is the highest intensity.
+	"""
+	return (red << 16) | (green << 8) | blue
+
+class ANSIPixel:
+	def __init__(self, count, pin, freq, dma, invert, brightness, channel, strip):
+		'''Constructor'''
+		self.pixels = [0 for i in range(count)]
+
+	def begin(self):
+		init(autoreset=True)
+
+	def numPixels(self):
+		return len(self.pixels)
+
+	def setPixelColor(self, i, color):
+		r = color >> 16 & 0xff
+		g = color >> 8  & 0xff
+		b = color & 0xff
+		if color == 0:
+			c = Fore.BLACK
+		elif r == 255 and g == 255 and b == 255:
+			c = Fore.WHITE
+		elif r == 255 and g == 0 and b == 0:
+			c = Fore.LIGHTRED_EX
+		elif r == 0 and g == 255 and b == 0:
+			c = Fore.LIGHTGREEN_EX
+		elif r == 0 and g == 0 and b == 255:
+			c = Fore.LIGHTBLUE_EX
+		elif r > 128 and g > 128 and b < 128:
+			c = Fore.LIGHTYELLOW_EX
+		elif r > 128 and g < 128 and b > 128:
+			c = Fore.LIGHTMAGENTA_EX
+		elif r < 128 and g > 128 and b > 128:
+			c = Fore.LIGHTCYAN_EX
+		elif r > 0 and g == 0 and b == 0:
+			c = Fore.RED
+		elif r == 0 and g > 0 and b == 0:
+			c = Fore.GREEN
+		elif r == 0 and g == 0 and b > 0:
+			c = Fore.BLUE
+		elif r > 0 and g > 0 and b == 0:
+			c = Fore.YELLOW
+		elif r > 0 and g == 0 and b > 0:
+			c = Fore.MAGENTA
+		elif r == 0 and g > 0 and b > 0:
+			c = Fore.CYAN
+		else:
+			return
+		self.pixels[i] = c
+
+	def show(self):
+		print Cursor.POS() + ''.join(p+'*' for p in self.pixels)

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -9,6 +9,7 @@ import sys
 import shutil
 import base64
 import subprocess
+import importlib
 from monotonic import monotonic
 from datetime import datetime
 from functools import wraps
@@ -27,13 +28,11 @@ import json
 
 # LED imports
 import time
-from neopixel import *
 import signal
 
 sys.path.append('../interface')
 sys.path.append('/home/pi/RotorHazard/src/interface')  # Needed to run on startup
 
-from RHInterface import get_hardware_interface
 from RHRace import get_race_state
 
 APP = Flask(__name__, static_url_path='/static')
@@ -80,7 +79,13 @@ Config['LED']['LED_DMA']        = 10      # DMA channel to use for generating si
 Config['LED']['LED_BRIGHTNESS'] = 255     # Set to 0 for darkest and 255 for brightest
 Config['LED']['LED_INVERT']     = False   # True to invert the signal (when using NPN transistor level shift)
 Config['LED']['LED_CHANNEL']    = 0       # set to '1' for GPIOs 13, 19, 41, 45 or 53
-Config['LED']['LED_STRIP']      = ws.WS2811_STRIP_GRB   # Strip type and colour ordering
+WS2811_STRIP_RGB = 0x00100800
+WS2811_STRIP_RBG = 0x00100008
+WS2811_STRIP_GRB = 0x00081000
+WS2811_STRIP_GBR = 0x00080010
+WS2811_STRIP_BRG = 0x00001008
+WS2811_STRIP_BGR = 0x00000810
+Config['LED']['LED_STRIP']      = WS2811_STRIP_GRB   # Strip type and colour ordering
 
 # other default configurations
 Config['GENERAL']['HTTP_PORT'] = 5000
@@ -107,7 +112,11 @@ except ValueError:
     print 'Configuration file invalid, using defaults'
 
 
-INTERFACE = get_hardware_interface()
+try:
+    interfaceModule = importlib.import_module('RHInterface')
+except ImportError:
+    interfaceModule = importlib.import_module('MockInterface')
+INTERFACE = interfaceModule.get_hardware_interface()
 RACE = get_race_state() # For storing race management variables
 
 def diff_milliseconds(t2, t1):
@@ -310,7 +319,15 @@ def theaterChaseRainbow(strip, wait_ms=25):
                 strip.setPixelColor(i+q, 0)
 
 # Create NeoPixel object with appropriate configuration.
-strip = Adafruit_NeoPixel(Config['LED']['LED_COUNT'], Config['LED']['LED_PIN'], Config['LED']['LED_FREQ_HZ'], Config['LED']['LED_DMA'], Config['LED']['LED_INVERT'], Config['LED']['LED_BRIGHTNESS'], Config['LED']['LED_CHANNEL'], Config['LED']['LED_STRIP'])
+try:
+    pixelModule = importlib.import_module('neopixel')
+    Pixel = getattr(pixelModule, 'Adafruit_NeoPixel')
+    Color = getattr(pixelModule, 'Color')
+except ImportError:
+    pixelModule = importlib.import_module('ANSIPixel')
+    Pixel = getattr(pixelModule, 'ANSIPixel')
+    Color = getattr(pixelModule, 'Color')
+strip = Pixel(Config['LED']['LED_COUNT'], Config['LED']['LED_PIN'], Config['LED']['LED_FREQ_HZ'], Config['LED']['LED_DMA'], Config['LED']['LED_INVERT'], Config['LED']['LED_BRIGHTNESS'], Config['LED']['LED_CHANNEL'], Config['LED']['LED_STRIP'])
 # Intialize the library (must be called once before other functions).
 strip.begin()
 

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -79,13 +79,7 @@ Config['LED']['LED_DMA']        = 10      # DMA channel to use for generating si
 Config['LED']['LED_BRIGHTNESS'] = 255     # Set to 0 for darkest and 255 for brightest
 Config['LED']['LED_INVERT']     = False   # True to invert the signal (when using NPN transistor level shift)
 Config['LED']['LED_CHANNEL']    = 0       # set to '1' for GPIOs 13, 19, 41, 45 or 53
-WS2811_STRIP_RGB = 0x00100800
-WS2811_STRIP_RBG = 0x00100008
-WS2811_STRIP_GRB = 0x00081000
-WS2811_STRIP_GBR = 0x00080010
-WS2811_STRIP_BRG = 0x00001008
-WS2811_STRIP_BGR = 0x00000810
-Config['LED']['LED_STRIP']      = WS2811_STRIP_GRB   # Strip type and colour ordering
+Config['LED']['LED_STRIP']      = 'GRB'   # Strip type and colour ordering
 
 # other default configurations
 Config['GENERAL']['HTTP_PORT'] = 5000
@@ -323,11 +317,27 @@ try:
     pixelModule = importlib.import_module('neopixel')
     Pixel = getattr(pixelModule, 'Adafruit_NeoPixel')
     Color = getattr(pixelModule, 'Color')
+    led_strip_config = Config['LED']['LED_STRIP']
+    if led_strip_config == 'RGB':
+        led_strip = 0x00100800
+    elif led_strip_config == 'RBG':
+        led_strip = 0x00100008
+    elif led_strip_config == 'GRB':
+        led_strip = 0x00081000
+    elif led_strip_config == 'GBR':
+        led_strip = 0x00080010
+    elif led_strip_config == 'BRG':
+        led_strip = 0x00001008
+    elif led_strip_config == 'BGR':
+        led_strip = 0x00000810
+    else:
+        raise ValueError('Invalid LED_STRIP value: {0}'.format(led_strip_config))
 except ImportError:
     pixelModule = importlib.import_module('ANSIPixel')
     Pixel = getattr(pixelModule, 'ANSIPixel')
     Color = getattr(pixelModule, 'Color')
-strip = Pixel(Config['LED']['LED_COUNT'], Config['LED']['LED_PIN'], Config['LED']['LED_FREQ_HZ'], Config['LED']['LED_DMA'], Config['LED']['LED_INVERT'], Config['LED']['LED_BRIGHTNESS'], Config['LED']['LED_CHANNEL'], Config['LED']['LED_STRIP'])
+    led_strip = None
+strip = Pixel(Config['LED']['LED_COUNT'], Config['LED']['LED_PIN'], Config['LED']['LED_FREQ_HZ'], Config['LED']['LED_DMA'], Config['LED']['LED_INVERT'], Config['LED']['LED_BRIGHTNESS'], Config['LED']['LED_CHANNEL'], led_strip)
 # Intialize the library (must be called once before other functions).
 strip.begin()
 


### PR DESCRIPTION
These changes make it possible to run without the LED library, and more than that, run on non-Pi platforms albeit with a mock delta 5 interface layer. This makes development and testing alot easier, and should mean it is possible to write automated tests.

Also fixes #7 