### PR TITLE
Fix MockInterface

### DIFF
--- a/src/interface/BaseHardwareInterface.py
+++ b/src/interface/BaseHardwareInterface.py
@@ -21,7 +21,88 @@ class BaseHardwareInterface(object):
 
     # returns the elapsed milliseconds since the start of the program
     def milliseconds(self):
-       return 1000*(monotonic() - self.start_time)
+        return 1000*(monotonic() - self.start_time)
+
+    def log(self, message):
+        '''Hardware log of messages.'''
+        if callable(self.hardware_log_callback):
+            string = 'Interface: {0}'.format(message)
+            self.hardware_log_callback(string)
+
+    def process_lap_stats(self, node, readtime, lap_id, ms_val, cross_flag, pn_history, cross_list, upd_list):
+        if cross_flag and cross_flag != node.crossing_flag:  # if 'crossing' status changed
+            node.crossing_flag = cross_flag
+            if callable(self.node_crossing_callback):
+                cross_list.append(node)
+
+        # calc lap timestamp
+        if ms_val < 0 or ms_val > 9999999:
+            ms_val = 0  # don't allow negative or too-large value
+            node.lap_timestamp = 0
+        else:
+            node.lap_timestamp = readtime - (ms_val / 1000.0)
+
+        # if new lap detected for node then append item to updates list
+        if lap_id != node.last_lap_id:
+            upd_list.append((node, lap_id, node.lap_timestamp))
+
+        # check if capturing enter-at level for node
+        if node.cap_enter_at_flag:
+            node.cap_enter_at_total += node.current_rssi
+            node.cap_enter_at_count += 1
+            if self.milliseconds() >= node.cap_enter_at_millis:
+                node.enter_at_level = int(round(node.cap_enter_at_total / node.cap_enter_at_count))
+                node.cap_enter_at_flag = False
+                # if too close node peak then set a bit below node-peak RSSI value:
+                if node.node_peak_rssi > 0 and node.node_peak_rssi - node.enter_at_level < ENTER_AT_PEAK_MARGIN:
+                    node.enter_at_level = node.node_peak_rssi - ENTER_AT_PEAK_MARGIN
+                if callable(self.new_enter_or_exit_at_callback):
+                    self.new_enter_or_exit_at_callback(node, True)
+
+        # check if capturing exit-at level for node
+        if node.cap_exit_at_flag:
+            node.cap_exit_at_total += node.current_rssi
+            node.cap_exit_at_count += 1
+            if self.milliseconds() >= node.cap_exit_at_millis:
+                node.exit_at_level = int(round(node.cap_exit_at_total / node.cap_exit_at_count))
+                node.cap_exit_at_flag = False
+                if callable(self.new_enter_or_exit_at_callback):
+                    self.new_enter_or_exit_at_callback(node, False)
+
+        # prune history data if race is not running (keep last 60s)
+        if self.race_status is BaseHardwareInterface.RACE_STATUS_READY:
+            if len(node.history_times):
+                while node.history_times[0] < (monotonic() - 60):
+                    node.history_values.pop(0)
+                    node.history_times.pop(0)
+                    if not len(node.history_times): #prevent while from destroying itself
+                        break
+
+        if pn_history and self.race_status != BaseHardwareInterface.RACE_STATUS_DONE:
+            # get and process history data (except when race is over)
+            pn_history.addTo(readtime, node.history_values, node.history_times, self)
+
+    def process_crossings(self, cross_list):
+        if len(cross_list) > 0:
+            for node in cross_list:
+                self.node_crossing_callback(node)
+
+    def process_updates(self, upd_list):
+        if len(upd_list) > 0:
+            if len(upd_list) == 1:  # list contains single item
+                item = upd_list[0]
+                node = item[0]
+                if node.last_lap_id != -1 and callable(self.pass_record_callback):
+                    self.pass_record_callback(node, item[2], BaseHardwareInterface.LAP_SOURCE_REALTIME)  # (node, lap_time_absolute)
+                node.last_lap_id = item[1]  # new_lap_id
+
+            else:  # list contains multiple items; sort so processed in order by lap time
+                upd_list.sort(key = lambda i: i[0].lap_timestamp)
+                for item in upd_list:
+                    node = item[0]
+                    if node.last_lap_id != -1 and callable(self.pass_record_callback):
+                        self.pass_record_callback(node, item[2], BaseHardwareInterface.LAP_SOURCE_REALTIME)  # (node, lap_time_absolute)
+                    node.last_lap_id = item[1]  # new_lap_id
 
     #
     # External functions for setting data
@@ -81,3 +162,60 @@ class BaseHardwareInterface(object):
             'node': node.index,
             'frequency': node.frequency
         }
+
+
+class PeakNadirHistory:
+    def addTo(self, readtime, history_values, history_times, interface):
+        if self.peakRssi > 0:
+            if self.nadirRssi > 0:
+                # both
+                if self.peakLastTime > self.nadirTime:
+                    # process peak first
+                    if self.peakFirstTime > self.peakLastTime:
+                        history_values.append(self.peakRssi)
+                        history_times.append(readtime - (self.peakFirstTime / 1000.0))
+                        history_values.append(self.peakRssi)
+                        history_times.append(readtime - (self.peakLastTime / 1000.0))
+                    elif self.peakFirstTime == self.peakLastTime:
+                        history_values.append(self.peakRssi)
+                        history_times.append(readtime - (self.peakLastTime / 1000.0))
+                    else:
+                        interface.log('Ignoring corrupted peak history times ({0} < {1})'.format(self.peakFirstTime, self.peakLastTime))
+
+                    history_values.append(self.nadirRssi)
+                    history_times.append(readtime - (self.nadirTime / 1000.0))
+
+                else:
+                    # process nadir first
+                    history_values.append(self.nadirRssi)
+                    history_times.append(readtime - (self.nadirTime / 1000.0))
+                    if self.peakFirstTime > self.peakLastTime:
+                        history_values.append(self.peakRssi)
+                        history_times.append(readtime - (self.peakFirstTime / 1000.0))
+                        history_values.append(self.peakRssi)
+                        history_times.append(readtime - (self.peakLastTime / 1000.0))
+                    elif self.peakFirstTime == self.peakLastTime:
+                        history_values.append(self.peakRssi)
+                        history_times.append(readtime - (self.peakLastTime / 1000.0))
+                    else:
+                        interface.log('Ignoring corrupted peak history times ({0} < {1})'.format(self.peakFirstTime, self.peakLastTime))
+
+            else:
+                # peak, no nadir
+                # process peak only
+                if self.peakFirstTime > self.peakLastTime:
+                    history_values.append(self.peakRssi)
+                    history_times.append(readtime - (self.peakFirstTime / 1000.0))
+                    history_values.append(self.peakRssi)
+                    history_times.append(readtime - (self.peakLastTime / 1000.0))
+                elif self.peakFirstTime == self.peakLastTime:
+                    history_values.append(self.peakRssi)
+                    history_times.append(readtime - (self.peakLastTime / 1000.0))
+                else:
+                    interface.log('Ignoring corrupted peak history times ({0} < {1})'.format(self.peakFirstTime, self.peakLastTime))
+
+        elif self.nadirRssi > 0:
+            # no peak, nadir
+            # process nadir only
+            history_values.append(self.nadirRssi)
+            history_times.append(readtime - (self.nadirTime / 1000.0))

--- a/src/interface/BaseHardwareInterface.py
+++ b/src/interface/BaseHardwareInterface.py
@@ -1,16 +1,39 @@
 from monotonic import monotonic
 
 class BaseHardwareInterface(object):
+
+    LAP_SOURCE_REALTIME = 0
+    LAP_SOURCE_MANUAL = 1
+    LAP_SOURCE_RECALC = 2
+
+    RACE_STATUS_READY = 0
+    RACE_STATUS_STAGING = 3
+    RACE_STATUS_RACING = 1
+    RACE_STATUS_DONE = 2
+
     def __init__(self):
         self.calibration_threshold = 20
         self.calibration_offset = 10
         self.trigger_threshold = 20
         self.start_time = 1000*monotonic() # millis
         self.filter_ratio = 50
+        self.race_status = BaseHardwareInterface.RACE_STATUS_READY
 
     # returns the elapsed milliseconds since the start of the program
     def milliseconds(self):
        return 1000*(monotonic() - self.start_time)
+
+    #
+    # External functions for setting data
+    #
+
+    def intf_simulate_lap(self, node_index, ms_val):
+        node = self.nodes[node_index]
+        node.lap_timestamp = monotonic() - (ms_val / 1000.0)
+        self.pass_record_callback(node, node.lap_timestamp, BaseHardwareInterface.LAP_SOURCE_MANUAL)
+
+    def set_race_status(self, race_status):
+        self.race_status = race_status
 
     #
     # Get Json Node Data Functions

--- a/src/interface/MockInterface.py
+++ b/src/interface/MockInterface.py
@@ -16,10 +16,6 @@ MAX_RSSI_VALUE = 999             # reject RSSI readings above this value
 CAP_ENTER_EXIT_AT_MILLIS = 3000  # number of ms for capture of enter/exit-at levels
 ENTER_AT_PEAK_MARGIN = 5         # closest that captured enter-at level can be to node peak RSSI
 
-LAP_SOURCE_REALTIME = 0
-LAP_SOURCE_MANUAL = 1
-LAP_SOURCE_RECALC = 2
-
 class MockInterface(BaseHardwareInterface):
     def __init__(self):
         BaseHardwareInterface.__init__(self)
@@ -213,7 +209,7 @@ class MockInterface(BaseHardwareInterface):
                 item = upd_list[0]
                 node = item[0]
                 if node.last_lap_id != -1 and callable(self.pass_record_callback):
-                    self.pass_record_callback(node, item[2], LAP_SOURCE_REALTIME)  # (node, lap_time_ms)
+                    self.pass_record_callback(node, item[2], BaseHardwareInterface.LAP_SOURCE_REALTIME)  # (node, lap_time_absolute)
                 node.last_lap_id = item[1]  # new_lap_id
 
             else:  # list contains multiple items; sort so processed in order by lap time
@@ -221,7 +217,7 @@ class MockInterface(BaseHardwareInterface):
                 for item in upd_list:
                     node = item[0]
                     if node.last_lap_id != -1 and callable(self.pass_record_callback):
-                        self.pass_record_callback(node, item[2], LAP_SOURCE_REALTIME)  # (node, lap_time_ms)
+                        self.pass_record_callback(node, item[2], BaseHardwareInterface.LAP_SOURCE_REALTIME)  # (node, lap_time_absolute)
                     node.last_lap_id = item[1]  # new_lap_id
 
 
@@ -294,11 +290,6 @@ class MockInterface(BaseHardwareInterface):
             node.cap_exit_at_flag = True
             return True
         return False
-
-    def intf_simulate_lap(self, node_index, ms_val):
-        node = self.nodes[node_index]
-        node.lap_ms_since_start = ms_val
-        self.pass_record_callback(node, 100)
 
     def force_end_crossing(self, node_index):
         node = self.nodes[node_index]

--- a/src/interface/MockInterface.py
+++ b/src/interface/MockInterface.py
@@ -7,7 +7,7 @@ from gevent.lock import BoundedSemaphore # To limit i2c calls
 from monotonic import monotonic # to capture read timing
 
 from Node import Node
-from BaseHardwareInterface import BaseHardwareInterface
+from BaseHardwareInterface import BaseHardwareInterface, PeakNadirHistory
 
 UPDATE_SLEEP = float(os.environ.get('RH_UPDATE_INTERVAL', '0.5')) # Main update loop delay
 
@@ -85,7 +85,7 @@ class MockInterface(BaseHardwareInterface):
             print "Update thread terminated by keyboard interrupt"
 
     def update(self):
-        upd_list = []  # list of nodes with new laps (node, new_lap_id, lap_time_ms)
+        upd_list = []  # list of nodes with new laps (node, new_lap_id, lap_timestamp)
         cross_list = []  # list of nodes with crossing-flag changes
         for index, node in enumerate(self.nodes):
             if node.frequency:
@@ -101,125 +101,32 @@ class MockInterface(BaseHardwareInterface):
                     data_line = node_data.readline()
                 data_columns = data_line.split(',')
                 lap_id = int(data_columns[1])
-                lap_time_ms = int(data_columns[2])
-                node.current_rssi = int(data_columns[3])
+                ms_val = int(data_columns[2])
+                rssi_val = int(data_columns[3])
                 node.node_peak_rssi = int(data_columns[4])
                 node.pass_peak_rssi = int(data_columns[5])
                 node.loop_time = int(data_columns[6])
                 cross_flag = True if data_columns[7]=='T' else False
                 node.pass_nadir_rssi = int(data_columns[8])
                 node.node_nadir_rssi = int(data_columns[9])
-                peakRssi = int(data_columns[10])
-                peakFirstTime = int(data_columns[11])
-                peakLastTime = int(data_columns[12])
-                nadirRssi = int(data_columns[13])
-                nadirTime = int(data_columns[14])
+                pn_history = PeakNadirHistory()
+                pn_history.peakRssi = int(data_columns[10])
+                pn_history.peakFirstTime = int(data_columns[11])
+                pn_history.peakLastTime = int(data_columns[12])
+                pn_history.nadirRssi = int(data_columns[13])
+                pn_history.nadirTime = int(data_columns[14])
 
-                if cross_flag != node.crossing_flag:  # if 'crossing' status changed
-                    node.crossing_flag = cross_flag
-                    if callable(self.node_crossing_callback):
-                        cross_list.append(node)
-
-                # if new lap detected for node then append item to updates list
-                if lap_id != node.last_lap_id:
-                    upd_list.append((node, lap_id, lap_time_ms))
-
-                # check if capturing enter-at level for node
-                if node.cap_enter_at_flag:
-                    node.cap_enter_at_total += node.current_rssi
-                    node.cap_enter_at_count += 1
-                    if self.milliseconds() >= node.cap_enter_at_millis:
-                        node.enter_at_level = int(round(node.cap_enter_at_total / node.cap_enter_at_count))
-                        node.cap_enter_at_flag = False
-                              # if too close node peak then set a bit below node-peak RSSI value:
-                        if node.node_peak_rssi > 0 and node.node_peak_rssi - node.enter_at_level < ENTER_AT_PEAK_MARGIN:
-                            node.enter_at_level = node.node_peak_rssi - ENTER_AT_PEAK_MARGIN
-                        self.transmit_enter_at_level(node, node.enter_at_level)
-                        if callable(self.new_enter_or_exit_at_callback):
-                            self.new_enter_or_exit_at_callback(node, True)
-
-                # check if capturing exit-at level for node
-                if node.cap_exit_at_flag:
-                    node.cap_exit_at_total += node.current_rssi
-                    node.cap_exit_at_count += 1
-                    if self.milliseconds() >= node.cap_exit_at_millis:
-                        node.exit_at_level = int(round(node.cap_exit_at_total / node.cap_exit_at_count))
-                        node.cap_exit_at_flag = False
-                        self.transmit_exit_at_level(node, node.exit_at_level)
-                        if callable(self.new_enter_or_exit_at_callback):
-                            self.new_enter_or_exit_at_callback(node, False)
-
-                # process history data
-                if peakRssi > 0:
-                    if nadirRssi > 0:
-                        # both
-                        if peakLastTime < nadirTime:
-                            # process peak first
-                            if peakFirstTime < peakLastTime:
-                                node.history_values.append(peakRssi)
-                                node.history_times.append(readtime - (peakFirstTime / 1000.0))
-                                node.history_values.append(peakRssi)
-                                node.history_times.append(readtime - (peakLastTime / 1000.0))
-                            else:
-                                node.history_values.append(peakRssi)
-                                node.history_times.append(readtime - (peakLastTime / 1000.0))
-
-                            node.history_values.append(nadirRssi)
-                            node.history_times.append(readtime - (nadirTime / 1000.0))
-
-                        else:
-                            # process nadir first
-                            node.history_values.append(nadirRssi)
-                            node.history_times.append(readtime - (nadirTime / 1000.0))
-                            if peakFirstTime < peakLastTime:
-                                node.history_values.append(peakRssi)
-                                node.history_times.append(readtime - (peakFirstTime / 1000.0))
-                                node.history_values.append(peakRssi)
-                                node.history_times.append(readtime - (peakLastTime / 1000.0))
-                            else:
-                                node.history_values.append(peakRssi)
-                                node.history_times.append(readtime - (peakLastTime / 1000.0))
-
-                    else:
-                        # peak, no nadir
-                        # process peak only
-                        if peakFirstTime < peakLastTime:
-                            node.history_values.append(peakRssi)
-                            node.history_times.append(readtime - (peakFirstTime / 1000.0))
-                            node.history_values.append(peakRssi)
-                            node.history_times.append(readtime - (peakLastTime / 1000.0))
-                        else:
-                            node.history_values.append(peakRssi)
-                            node.history_times.append(readtime - (peakLastTime / 1000.0))
-
-                elif nadirRssi > 0:
-                    # no peak, nadir
-                    # process nadir only
-                    node.history_values.append(nadirRssi)
-                    node.history_times.append(readtime - (nadirTime / 1000.0))
+                if node.is_valid_rssi(rssi_val):
+                    node.current_rssi = rssi_val
+                    self.process_lap_stats(node, readtime, lap_id, ms_val, cross_flag, pn_history, cross_list, upd_list)
+                else:
+                    self.log('RSSI reading ({0}) out of range on Node {1}; rejected'.format(rssi_val, node.index+1))
 
         # process any nodes with crossing-flag changes
-        if len(cross_list) > 0:
-            for node in cross_list:
-                self.node_crossing_callback(node)
+        self.process_crossings(cross_list)
 
         # process any nodes with new laps detected
-        if len(upd_list) > 0:
-            if len(upd_list) == 1:  # list contains single item
-                item = upd_list[0]
-                node = item[0]
-                if node.last_lap_id != -1 and callable(self.pass_record_callback):
-                    self.pass_record_callback(node, item[2], BaseHardwareInterface.LAP_SOURCE_REALTIME)  # (node, lap_time_absolute)
-                node.last_lap_id = item[1]  # new_lap_id
-
-            else:  # list contains multiple items; sort so processed in order by lap time
-                upd_list.sort(key = lambda i: i[0].lap_ms_since_start)
-                for item in upd_list:
-                    node = item[0]
-                    if node.last_lap_id != -1 and callable(self.pass_record_callback):
-                        self.pass_record_callback(node, item[2], BaseHardwareInterface.LAP_SOURCE_REALTIME)  # (node, lap_time_absolute)
-                    node.last_lap_id = item[1]  # new_lap_id
-
+        self.process_updates(upd_list)
 
 
     #

--- a/src/interface/RHInterface.py
+++ b/src/interface/RHInterface.py
@@ -9,7 +9,7 @@ from gevent.lock import BoundedSemaphore # To limit i2c calls
 from monotonic import monotonic # to capture read timing
 
 from Node import Node
-from BaseHardwareInterface import BaseHardwareInterface
+from BaseHardwareInterface import BaseHardwareInterface, PeakNadirHistory
 
 READ_ADDRESS = 0x00         # Gets i2c address of arduino (1 byte)
 READ_FREQUENCY = 0x03       # Gets channel frequency (2 byte)
@@ -196,16 +196,6 @@ class RHInterface(BaseHardwareInterface):
 
 
     #
-    # Class Functions
-    #
-
-    def log(self, message):
-        '''Hardware log of messages.'''
-        if callable(self.hardware_log_callback):
-            string = 'Interface: {0}'.format(message)
-            self.hardware_log_callback(string)
-
-    #
     # Update Loop
     #
 
@@ -280,9 +270,17 @@ class RHInterface(BaseHardwareInterface):
                     if node.is_valid_rssi(rssi_val):
                         node.current_rssi = rssi_val
 
+                        cross_flag = None
+                        pn_history = None
                         if node.api_valid_flag:  # if newer API functions supported
                             if node.api_level >= 18:
                                 ms_val = unpack_16(data[1:])
+                                pn_history = PeakNadirHistory()
+                                pn_history.peakRssi = unpack_rssi(node, data[offset_peakRssi:])
+                                pn_history.peakFirstTime = unpack_16(data[offset_peakFirstTime:]) # ms *since* the first peak time
+                                pn_history.peakLastTime = unpack_16(data[offset_peakLastTime:])   # ms *since* the last peak time
+                                pn_history.nadirRssi = unpack_rssi(node, data[offset_nadirRssi:])
+                                pn_history.nadirTime = unpack_16(data[offset_nadirTime:])
                             else:
                                 ms_val = unpack_32(data[1:])
 
@@ -293,157 +291,31 @@ class RHInterface(BaseHardwareInterface):
                                 cross_flag = True
                             else:
                                 cross_flag = False
-                            if cross_flag != node.crossing_flag:  # if 'crossing' status changed
-                                node.crossing_flag = cross_flag
-                                if callable(self.node_crossing_callback):
-                                    cross_list.append(node)
                             node.pass_nadir_rssi = unpack_rssi(node, data[offset_passNadirRssi:])
 
                             if node.api_level >= 13:
                                 node.node_nadir_rssi = unpack_rssi(node, data[offset_nodeNadirRssi:])
+
+                            if node.api_level >= 18:
+                                data_logger = self.data_loggers[node.index]
+                                if data_logger:
+                                    data_logger.write("{0},{1},{2},{3},{4},{5},{6},{7},{8},{9},{10},{11},{12},{13},{14}\n".format(readtime,lap_id, int(ms_val), node.current_rssi, node.node_peak_rssi, node.pass_peak_rssi, node.loop_time, 'T' if cross_flag else 'F', node.pass_nadir_rssi, node.node_nadir_rssi, peakRssi, peakFirstTime, peakLastTime, nadirRssi, nadirTime))
 
                         else:  # if newer API functions not supported
                             ms_val = unpack_32(data[1:])
                             node.pass_peak_rssi = unpack_rssi(node, data[11:])
                             node.loop_time = unpack_32(data[13:])
 
-                        # calc lap timestamp
-                        if ms_val < 0 or ms_val > 9999999:
-                            ms_val = 0  # don't allow negative or too-large value
-                            node.lap_timestamp = 0
-                        else:
-                            node.lap_timestamp = readtime - (ms_val / 1000.0)
-
-                        # if new lap detected for node then append item to updates list
-                        if lap_id != node.last_lap_id:
-                            upd_list.append((node, lap_id, node.lap_timestamp))
-
-                        # check if capturing enter-at level for node
-                        if node.cap_enter_at_flag:
-                            node.cap_enter_at_total += node.current_rssi
-                            node.cap_enter_at_count += 1
-                            if self.milliseconds() >= node.cap_enter_at_millis:
-                                node.enter_at_level = int(round(node.cap_enter_at_total / node.cap_enter_at_count))
-                                node.cap_enter_at_flag = False
-                                      # if too close node peak then set a bit below node-peak RSSI value:
-                                if node.node_peak_rssi > 0 and node.node_peak_rssi - node.enter_at_level < ENTER_AT_PEAK_MARGIN:
-                                    node.enter_at_level = node.node_peak_rssi - ENTER_AT_PEAK_MARGIN
-                                # self.transmit_enter_at_level(node, node.enter_at_level)
-                                if callable(self.new_enter_or_exit_at_callback):
-                                    self.new_enter_or_exit_at_callback(node, True)
-
-                        # check if capturing exit-at level for node
-                        if node.cap_exit_at_flag:
-                            node.cap_exit_at_total += node.current_rssi
-                            node.cap_exit_at_count += 1
-                            if self.milliseconds() >= node.cap_exit_at_millis:
-                                node.exit_at_level = int(round(node.cap_exit_at_total / node.cap_exit_at_count))
-                                node.cap_exit_at_flag = False
-                                # self.transmit_exit_at_level(node, node.exit_at_level)
-                                if callable(self.new_enter_or_exit_at_callback):
-                                    self.new_enter_or_exit_at_callback(node, False)
-
-                        # prune history data if race is not running (keep last 60s)
-                        if self.race_status is BaseHardwareInterface.RACE_STATUS_READY:
-                            if len(node.history_times):
-                                while node.history_times[0] < (monotonic() - 60):
-                                    node.history_values.pop(0)
-                                    node.history_times.pop(0)
-                                    if not len(node.history_times): #prevent while from destroying itself
-                                        break
-
-                        if self.race_status != BaseHardwareInterface.RACE_STATUS_DONE:
-                            # get and process history data (except when race is over)
-                            if node.api_level >= 18:
-                                peakRssi = unpack_rssi(node, data[offset_peakRssi:])
-                                peakFirstTime = unpack_16(data[offset_peakFirstTime:]) # ms *since* the first peak time
-                                peakLastTime = unpack_16(data[offset_peakLastTime:])   # ms *since* the last peak time
-                                nadirRssi = unpack_rssi(node, data[offset_nadirRssi:])
-                                nadirTime = unpack_16(data[offset_nadirTime:])
-
-                                data_logger = self.data_loggers[node.index]
-                                if data_logger:
-                                    data_logger.write("{0},{1},{2},{3},{4},{5},{6},{7},{8},{9},{10},{11},{12},{13},{14}\n".format(readtime,lap_id, int(lap_time_ms), node.current_rssi, node.node_peak_rssi, node.pass_peak_rssi, node.loop_time, 'T' if cross_flag else 'F', node.pass_nadir_rssi, node.node_nadir_rssi, peakRssi, peakFirstTime, peakLastTime, nadirRssi, nadirTime))
-
-                                if peakRssi > 0:
-                                    if nadirRssi > 0:
-                                        # both
-                                        if peakLastTime > nadirTime:
-                                            # process peak first
-                                            if peakFirstTime > peakLastTime:
-                                                node.history_values.append(peakRssi)
-                                                node.history_times.append(readtime - (peakFirstTime / 1000.0))
-                                                node.history_values.append(peakRssi)
-                                                node.history_times.append(readtime - (peakLastTime / 1000.0))
-                                            elif peakFirstTime == peakLastTime:
-                                                node.history_values.append(peakRssi)
-                                                node.history_times.append(readtime - (peakLastTime / 1000.0))
-                                            else:
-                                                self.log('Ignoring corrupted peak history times ({0} < {1})'.format(peakFirstTime, peakLastTime))
-
-                                            node.history_values.append(nadirRssi)
-                                            node.history_times.append(readtime - (nadirTime / 1000.0))
-
-                                        else:
-                                            # process nadir first
-                                            node.history_values.append(nadirRssi)
-                                            node.history_times.append(readtime - (nadirTime / 1000.0))
-                                            if peakFirstTime > peakLastTime:
-                                                node.history_values.append(peakRssi)
-                                                node.history_times.append(readtime - (peakFirstTime / 1000.0))
-                                                node.history_values.append(peakRssi)
-                                                node.history_times.append(readtime - (peakLastTime / 1000.0))
-                                            elif peakFirstTime == peakLastTime:
-                                                node.history_values.append(peakRssi)
-                                                node.history_times.append(readtime - (peakLastTime / 1000.0))
-                                            else:
-                                                self.log('Ignoring corrupted peak history times ({0} < {1})'.format(peakFirstTime, peakLastTime))
-
-                                    else:
-                                        # peak, no nadir
-                                        # process peak only
-                                        if peakFirstTime > peakLastTime:
-                                            node.history_values.append(peakRssi)
-                                            node.history_times.append(readtime - (peakFirstTime / 1000.0))
-                                            node.history_values.append(peakRssi)
-                                            node.history_times.append(readtime - (peakLastTime / 1000.0))
-                                        elif peakFirstTime == peakLastTime:
-                                            node.history_values.append(peakRssi)
-                                            node.history_times.append(readtime - (peakLastTime / 1000.0))
-                                        else:
-                                            self.log('Ignoring corrupted peak history times ({0} < {1})'.format(peakFirstTime, peakLastTime))
-
-                                elif nadirRssi > 0:
-                                    # no peak, nadir
-                                    # process nadir only
-                                    node.history_values.append(nadirRssi)
-                                    node.history_times.append(readtime - (nadirTime / 1000.0))
-
+                        self.process_lap_stats(node, readtime, lap_id, ms_val, cross_flag, pn_history, cross_list, upd_list)
 
                     else:
                         self.log('RSSI reading ({0}) out of range on Node {1}; rejected'.format(rssi_val, node.index+1))
 
         # process any nodes with crossing-flag changes
-        if len(cross_list) > 0:
-            for node in cross_list:
-                self.node_crossing_callback(node)
+        self.process_crossings(cross_list)
 
         # process any nodes with new laps detected
-        if len(upd_list) > 0:
-            if len(upd_list) == 1:  # list contains single item
-                item = upd_list[0]
-                node = item[0]
-                if node.last_lap_id != -1 and callable(self.pass_record_callback):
-                    self.pass_record_callback(node, item[2], BaseHardwareInterface.LAP_SOURCE_REALTIME)  # (node, lap_timestamp)
-                node.last_lap_id = item[1]  # new_lap_id
-
-            else:  # list contains multiple items; sort so processed in order by lap time
-                upd_list.sort(key = lambda i: i[0].lap_timestamp)
-                for item in upd_list:
-                    node = item[0]
-                    if node.last_lap_id != -1 and callable(self.pass_record_callback):
-                        self.pass_record_callback(node, item[2], BaseHardwareInterface.LAP_SOURCE_REALTIME)  # (node, lap_timestamp)
-                    node.last_lap_id = item[1]  # new_lap_id
+        self.process_updates(upd_list)
 
 
     #


### PR DESCRIPTION
The latest round of changes have broken MockInterface. This PR pushes all duplicate, non-hardware related code into BaseHardwareInterface. This greatly improves code maintability and testability.