### PR TITLE
Add colorama to requirements.txt

### DIFF
--- a/src/server/requirements.txt
+++ b/src/server/requirements.txt
@@ -11,3 +11,4 @@ gevent
 gevent-websocket
 flask_sqlalchemy
 monotonic
+colorama


### PR DESCRIPTION
Colorama is missing from requirements.txt but is needed for the server to run.
Adding to the file so it gets installed.