### PR TITLE
Update CORS settings in Flask_SocketIO to allow connections from any host.

### DIFF
--- a/src/server/config-dist.json
+++ b/src/server/config-dist.json
@@ -5,7 +5,8 @@
 		"ADMIN_USERNAME": "admin",
 		"ADMIN_PASSWORD": "rotorhazard",
 		"DEBUG": false,
-		"NODE_RESYNC_INTERVAL": 60
+		"NODE_RESYNC_INTERVAL": 60,
+		"CORS_ALLOWED_HOSTS": "*"
 	},
 	"LED": {
 		"LED_COUNT": 150,

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -39,7 +39,6 @@ from RHRace import get_race_state
 
 APP = Flask(__name__, static_url_path='/static')
 APP.config['SECRET_KEY'] = 'secret!'
-SOCKET_IO = SocketIO(APP, async_mode='gevent')
 
 HEARTBEAT_THREAD = None
 
@@ -88,6 +87,7 @@ Config['GENERAL']['HTTP_PORT'] = 5000
 Config['GENERAL']['ADMIN_USERNAME'] = 'admin'
 Config['GENERAL']['ADMIN_PASSWORD'] = 'rotorhazard'
 Config['GENERAL']['DEBUG'] = False
+Config['GENERAL']['CORS_ALLOWED_HOSTS'] = '*'
 
 Config['GENERAL']['NODE_DRIFT_CALC_TIME'] = 10
 
@@ -107,6 +107,8 @@ except ValueError:
     Config['GENERAL']['configFile'] = -1
     print 'Configuration file invalid, using defaults'
 
+# start SocketIO service
+SOCKET_IO = SocketIO(APP, async_mode='gevent', cors_allowed_origins=Config['GENERAL']['CORS_ALLOWED_HOSTS'])
 
 try:
     interfaceModule = importlib.import_module('RHInterface')


### PR DESCRIPTION
This addresses the recent problems seen when trying to connect from LiveTime and RotorMatch applications. Both have the same issue where there connections get rejections as the response header does not authorize the client to make requests.

Reason:
Version 4.2.0 of Flask_SocketIO introduced a change (https://github.com/miguelgrinberg/python-engineio/issues/128)  )that aims to prevent Cross-Site Request Forgery (CSRF) attacks, it does that by changing the default CORS header settings from allowing connection from all host to only requests from the server address.

Due to the way RotorHazard is used there should not exist this problem as this is not meant to be used a public server, so the solution is manually defining the cors_allowed_origins param of EngineIO to allow connections from any host ( cors_allowed_origins='*').
