### PR TITLE
Advanced heat generator

### DIFF
--- a/src/server/server.py
+++ b/src/server/server.py
@@ -1733,6 +1733,7 @@ def on_stage_race():
 
         SOCKET_IO.emit('stage_ready', {
             'hide_stage_timer': MIN != MAX,
+            'silent_countdown': MAX == 0,
             'race_mode': race_format.race_mode,
             'race_time_sec': race_format.race_time_sec,
             'pi_starts_at_s': RACE_START
@@ -2199,6 +2200,7 @@ def emit_race_status(**params):
             'race_mode': race_format.race_mode,
             'race_time_sec': race_format.race_time_sec,
             'hide_stage_timer': race_format.start_delay_min != race_format.start_delay_max,
+            'silent_countdown': race_format.start_delay_max == 0,
             'pi_starts_at_s': RACE_START
         }
     if ('nobroadcast' in params):

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -1814,7 +1814,6 @@ def on_stage_race():
 
         SOCKET_IO.emit('stage_ready', {
             'hide_stage_timer': MIN != MAX,
-            'silent_countdown': MAX == 0,
             'race_mode': race_format.race_mode,
             'race_time_sec': race_format.race_time_sec,
             'pi_starts_at_s': RACE_START

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -49,12 +49,11 @@ HEAT_ID_NONE = 0  # indicator value for practice heat
 CLASS_ID_NONE = 0  # indicator value for unclassified heat
 FREQUENCY_ID_NONE = 0  # indicator value for node disabled
 
-EVENT_RESULTS_CACHE = {} # Cache of results page leaderboards
-EVENT_RESULTS_CACHE_VALID = False # Whether cache is valid (False = regenerate cache)
-
 LAST_RACE_CACHE = {} # Cache of current race after clearing
 LAST_RACE_LAPS_CACHE = {} # Cache of current race after clearing
 LAST_RACE_CACHE_VALID = False # Whether cache is valid (False = regenerate cache)
+
+GENERAL_RESULTS_CACHE = {} # This is an array that saves all of the various cache data, event_results, race_list, and class results.
 
 DB_FILE_NAME = 'database.db'
 DB_BKP_DIR_NAME = 'db_bkp'
@@ -1331,8 +1330,10 @@ def on_alter_heat(data):
     if 'pilot' in data:
         db_update.pilot_id = data['pilot']
     if 'note' in data:
-        global EVENT_RESULTS_CACHE_VALID
-        EVENT_RESULTS_CACHE_VALID = False
+        global GENERAL_RESULTS_CACHE
+        cachekey='event_results'
+        if cachekey in GENERAL_RESULTS_CACHE.keys():
+            GENERAL_RESULTS_CACHE[cachekey]['isvalid'] = 0
         db_update.note = data['note']
     if 'class' in data:
         db_update.class_id = data['class']
@@ -1360,8 +1361,10 @@ def on_alter_race_class(data):
     race_class = data['class_id']
     db_update = RaceClass.query.get(race_class)
     if 'class_name' in data:
-        global EVENT_RESULTS_CACHE_VALID
-        EVENT_RESULTS_CACHE_VALID = False
+        global GENERAL_RESULTS_CACHE 
+        cachekey='event_results'
+        if cachekey in GENERAL_RESULTS_CACHE.keys():
+            GENERAL_RESULTS_CACHE[cachekey]['isvalid'] = 0
         db_update.name = data['class_name']
     if 'class_format' in data:
         db_update.format_id = data['class_format']
@@ -1396,18 +1399,22 @@ def on_add_pilot():
 @SOCKET_IO.on('alter_pilot')
 def on_alter_pilot(data):
     '''Update pilot.'''
-    global EVENT_RESULTS_CACHE_VALID
+    global GENERAL_RESULTS_CACHE 
     pilot_id = data['pilot_id']
     db_update = Pilot.query.get(pilot_id)
     if 'callsign' in data:
-        EVENT_RESULTS_CACHE_VALID = False
+        cachekey='event_results'
+        if cachekey in GENERAL_RESULTS_CACHE.keys():
+            GENERAL_RESULTS_CACHE[cachekey]['isvalid'] = 0
         db_update.callsign = data['callsign']
     if 'team_name' in data:
         db_update.team = data['team_name']
     if 'phonetic' in data:
         db_update.phonetic = data['phonetic']
     if 'name' in data:
-        EVENT_RESULTS_CACHE_VALID = False
+        cachekey='event_results'
+        if cachekey in GENERAL_RESULTS_CACHE.keys():
+            GENERAL_RESULTS_CACHE[cachekey]['isvalid'] = 0
         db_update.name = data['name']
     DB.session.commit()
     server_log('Altered pilot {0} to {1}'.format(pilot_id, data))
@@ -1525,8 +1532,10 @@ def on_backup_database():
 @SOCKET_IO.on('reset_database')
 def on_reset_database(data):
     '''Reset database.'''
-    global EVENT_RESULTS_CACHE_VALID
-    EVENT_RESULTS_CACHE_VALID = False
+    global GENERAL_RESULTS_CACHE
+    cachekey='event_results'
+    if cachekey in GENERAL_RESULTS_CACHE.keys():
+        GENERAL_RESULTS_CACHE[cachekey]['isvalid'] = 0
 
     reset_type = data['reset_type']
     if reset_type == 'races':
@@ -1811,10 +1820,21 @@ def on_stop_race():
 @SOCKET_IO.on('save_laps')
 def on_save_laps():
     '''Save current laps data to the database.'''
-    global EVENT_RESULTS_CACHE_VALID
-    EVENT_RESULTS_CACHE_VALID = False
+    global GENERAL_RESULTS_CACHE
+    cachekey='event_results'
+    if cachekey in GENERAL_RESULTS_CACHE.keys():
+        GENERAL_RESULTS_CACHE[cachekey]['isvalid'] = 0
     race_format = getCurrentRaceFormat()
-    heat = Heat.query.filter_by(heat_id=RACE.current_heat, node_index=0).one()
+    heat = Heat.query.filter_by(heat_id=RACE.current_heat, node_index=0).first()
+
+    cachekey='class'+str(heat.class_id)
+    if cachekey in GENERAL_RESULTS_CACHE.keys():
+        GENERAL_RESULTS_CACHE[cachekey]['isvalid'] = 0
+
+    cachekey='race_list'
+    if cachekey in GENERAL_RESULTS_CACHE.keys():
+        GENERAL_RESULTS_CACHE[cachekey]['isvalid'] = 0
+
     # Get the last saved round for the current heat
     max_round = DB.session.query(DB.func.max(SavedRaceMeta.round_id)) \
             .filter_by(heat_id=RACE.current_heat).scalar()
@@ -1876,8 +1896,11 @@ def on_save_laps():
 
 @SOCKET_IO.on('resave_laps')
 def on_resave_laps(data):
-    global EVENT_RESULTS_CACHE_VALID
-    EVENT_RESULTS_CACHE_VALID = False
+
+    global GENERAL_RESULTS_CACHE
+    cachekey='event_results'
+    if cachekey in GENERAL_RESULTS_CACHE.keys():
+        GENERAL_RESULTS_CACHE[cachekey]['isvalid'] = 0
 
     heat_id = data['heat_id']
     round_id = data['round_id']
@@ -1890,6 +1913,16 @@ def on_resave_laps(data):
     laps = data['laps']
     enter_at = data['enter_at']
     exit_at = data['exit_at']
+
+    heat = Heat.query.filter_by(heat_id=heat_id, node_index=0).first()
+    print 'heat classid ' + str(heat.class_id)
+    cachekey='class'+str(heat.class_id)
+    if cachekey in GENERAL_RESULTS_CACHE.keys():
+        GENERAL_RESULTS_CACHE[cachekey]['isvalid'] = 0
+
+    cachekey='race_list'
+    if cachekey in GENERAL_RESULTS_CACHE.keys():
+        GENERAL_RESULTS_CACHE[cachekey]['isvalid'] = 0
 
     Pilotrace = SavedPilotRace.query.filter_by(id=pilotrace_id).one()
     Pilotrace.enter_at = enter_at
@@ -2406,6 +2439,16 @@ def get_splits(node, lap_id, lapCompleted):
 
 def emit_race_list(**params):
     '''Emits race listing'''
+    # if the report is cached and valid, return that
+    cachekey='race_list'
+    if cachekey in GENERAL_RESULTS_CACHE.keys():
+        if (GENERAL_RESULTS_CACHE[cachekey]['isvalid'] == 1):
+            if ('nobroadcast' in params):
+                emit('race_list', GENERAL_RESULTS_CACHE[cachekey]['content'])
+            else:
+                SOCKET_IO.emit('race_list', GENERAL_RESULTS_CACHE[cachekey]['content'])
+            return
+   
     heats = {}
     for heat in SavedRaceMeta.query.with_entities(SavedRaceMeta.heat_id).distinct().order_by(SavedRaceMeta.heat_id):
         heatnote = Heat.query.filter_by( heat_id=heat.heat_id ).first().note
@@ -2476,6 +2519,17 @@ def emit_race_list(**params):
         # 'heats_by_class': heats_by_class,
         # 'classes': current_classes,
     }
+    cachekey='race_list'
+    if cachekey in GENERAL_RESULTS_CACHE.keys():
+        GENERAL_RESULTS_CACHE[cachekey]['isvalid'] = 1
+        GENERAL_RESULTS_CACHE[cachekey]['content'] = emit_payload
+    else:
+        newReport = {}
+        newReport[cachekey] = {}
+        newReport[cachekey]['isvalid'] = 1
+        newReport[cachekey]['content'] = emit_payload
+        GENERAL_RESULTS_CACHE.update(newReport)
+
 
     if ('nobroadcast' in params):
         emit('race_list', emit_payload)
@@ -2488,11 +2542,11 @@ def emit_round_data_notify(**params):
 
 def emit_round_data(**params):
     '''Emits saved races to rounds page.'''
-    global EVENT_RESULTS_CACHE
-    global EVENT_RESULTS_CACHE_VALID
+    global GENERAL_RESULTS_CACHE
 
-    if EVENT_RESULTS_CACHE_VALID:
-        emit_payload = EVENT_RESULTS_CACHE
+    cachekey='event_results'
+    if (cachekey in GENERAL_RESULTS_CACHE.keys()) and  (GENERAL_RESULTS_CACHE[cachekey]['isvalid'] == 1):
+       emit_payload = GENERAL_RESULTS_CACHE[cachekey]['content']
 
     else:
         heats = {}
@@ -2560,13 +2614,116 @@ def emit_round_data(**params):
             'event_leaderboard': calc_leaderboard()
         }
 
-        EVENT_RESULTS_CACHE = emit_payload
-        EVENT_RESULTS_CACHE_VALID = True
+        cachekey='event_results'
+        if cachekey in GENERAL_RESULTS_CACHE.keys():
+            GENERAL_RESULTS_CACHE[cachekey]['isvalid'] = 1
+            GENERAL_RESULTS_CACHE[cachekey]['content'] = emit_payload
+        else:
+            newReport = {}
+            newReport[cachekey] = {}
+            newReport[cachekey]['isvalid'] = 1
+            newReport[cachekey]['content'] = emit_payload
+            GENERAL_RESULTS_CACHE.update(newReport)
 
     if ('nobroadcast' in params):
         emit('round_data', emit_payload)
     else:
         SOCKET_IO.emit('round_data', emit_payload)
+
+def emit_specific_class_round_data(**params):
+    '''Emits saved races to rounds page.'''
+    global GENERAL_RESULTS_CACHE 
+
+    if ('specific_class' in params):
+        specific_class = params['specific_class']
+    else:
+        specific_class = CLASS_ID_NONE
+ 
+    cachekey='class'+specific_class
+    # if the report is cached and valid, return that
+    if cachekey in GENERAL_RESULTS_CACHE.keys():
+        if (GENERAL_RESULTS_CACHE[cachekey]['isvalid'] == 1):
+            if ('nobroadcast' in params):
+                emit('class_round_data', GENERAL_RESULTS_CACHE[cachekey]['content'])
+            else:
+                SOCKET_IO.emit('class_round_data', GENERAL_RESULTS_CACHE[cachekey]['content'])
+            return
+   
+    heats = {}
+    for heat in SavedRaceMeta.query.with_entities(SavedRaceMeta.heat_id).distinct().filter_by(class_id=specific_class).order_by(SavedRaceMeta.heat_id):
+        heatnote = Heat.query.filter_by( heat_id=heat.heat_id ).first().note
+
+        rounds = []
+        for round in SavedRaceMeta.query.distinct().filter_by(heat_id=heat.heat_id,class_id=specific_class).order_by(SavedRaceMeta.round_id):
+            pilotraces = []
+            for pilotrace in SavedPilotRace.query.filter_by(race_id=round.id).all():
+                laps = []
+                for lap in SavedRaceLap.query.filter_by(pilotrace_id=pilotrace.id).all():
+                    laps.append({
+                                'id': lap.id,
+                                'lap_time_stamp': lap.lap_time_stamp,
+                                'lap_time': lap.lap_time,
+                                'lap_time_formatted': lap.lap_time_formatted,
+                                'source': lap.source,
+                                'deleted': lap.deleted
+                        })
+
+                pilot_data = Pilot.query.filter_by(id=pilotrace.pilot_id).first()
+                if pilot_data:
+                        nodepilot = pilot_data.callsign
+                else:
+                        nodepilot = None
+
+                pilotraces.append({
+                        'callsign': nodepilot,
+                        'pilot_id': pilotrace.pilot_id,
+                        'node_index': pilotrace.node_index,
+                        'laps': laps
+                })
+            rounds.append({
+                'id': round.round_id,
+                'start_time_formatted': round.start_time_formatted,
+                'nodes': pilotraces
+            })
+        heats[heat.heat_id] = {
+            'heat_id': heat.heat_id,
+            'note': heatnote,
+            'rounds': rounds
+        }
+
+    heats_by_class = {}
+    heats_by_class[CLASS_ID_NONE] = [heat.heat_id for heat in Heat.query.filter_by(class_id=CLASS_ID_NONE,node_index=0).all()]
+    for race_class in RaceClass.query.filter_by(id=specific_class).all():
+        heats_by_class[race_class.id] = [heat.heat_id for heat in Heat.query.filter_by(class_id=race_class.id,node_index=0).all()]
+
+    current_classes = {}
+    for race_class in RaceClass.query.filter_by(id=specific_class).all():
+        current_class = {}
+        current_class['id'] = race_class.id
+        current_class['name'] = race_class.name
+        current_class['description'] = race_class.name
+        current_class['leaderboard'] = calc_leaderboard(class_id=race_class.id)
+        current_classes[race_class.id] = current_class
+
+    emit_payload = {
+        'classes': current_classes
+    }
+
+    cachekey='class'+specific_class
+    if cachekey in GENERAL_RESULTS_CACHE.keys():
+        GENERAL_RESULTS_CACHE[cachekey]['isvalid'] = 1
+        GENERAL_RESULTS_CACHE[cachekey]['content'] = emit_payload
+    else:
+        newReport = {}
+        newReport[cachekey] = {}
+        newReport[cachekey]['isvalid'] = 1
+        newReport[cachekey]['content'] = emit_payload
+        GENERAL_RESULTS_CACHE.update(newReport)
+
+    if ('nobroadcast' in params):
+        emit('class_round_data', emit_payload)
+    else:
+        SOCKET_IO.emit('class_round_data', emit_payload)
 
 def calc_leaderboard(**params):
     ''' Generates leaderboards '''

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -2733,14 +2733,20 @@ def calc_leaderboard(**params):
             fastest_lap.append(0) # Add zero if no laps completed
         else:
             if USE_CURRENT:
-                stat_query = DB.session.query(DB.func.min(CurrentLap.lap_time)) \
-                    .filter(CurrentLap.pilot_id == pilot, CurrentLap.lap_id != 0)
+                stat_query = DB.session.query(DB.func.min(CurrentLap.lap_time),CurrentLap.lap_time) \
+                    .filter(CurrentLap.pilot_id == pilot, CurrentLap.lap_id != 0).one()
+                fastest_lap_round.append(0)
+                fastest_lap_heat.append(0)
             else:
                 stat_query = DB.session.query(DB.func.min(SavedRaceLap.lap_time)) \
                     .filter(SavedRaceLap.pilot_id == pilot, \
                         SavedRaceLap.deleted != 1, \
                         SavedRaceLap.race_id.in_(racelist), \
                         ~SavedRaceLap.id.in_(holeshots[i]))
+                fround = DB.session.query(SavedRaceMeta.round_id,SavedRaceMeta.heat_id).filter(SavedRaceMeta.id==stat_query.race_id).first()
+                fheat = DB.session.query( Heat.note).filter_by(heat_id=fround.heat_id).first()
+                fastest_lap_round.append(fround.round_id)
+                fastest_lap_heat.append(fheat.note)
 
             fast_lap = stat_query.scalar()
             fastest_lap.append(fast_lap)

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -1742,6 +1742,7 @@ def on_stage_race():
 
         SOCKET_IO.emit('stage_ready', {
             'hide_stage_timer': MIN != MAX,
+            'silent_countdown': MAX == 0,
             'race_mode': race_format.race_mode,
             'race_time_sec': race_format.race_time_sec,
             'pi_starts_at_s': RACE_START
@@ -2232,6 +2233,7 @@ def emit_race_status(**params):
             'race_mode': race_format.race_mode,
             'race_time_sec': race_format.race_time_sec,
             'hide_stage_timer': race_format.start_delay_min != race_format.start_delay_max,
+            'silent_countdown': race_format.start_delay_max == 0,
             'pi_starts_at_s': RACE_START
         }
     if ('nobroadcast' in params):

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -1122,9 +1122,6 @@ def on_load_data(data):
             emit_pilot_data(nobroadcast=True)
         elif load_type == 'round_data':
             emit_round_data(nobroadcast=True)
-        elif load_type == 'class_round_data':
-            specific_class = data['specific_class']
-            emit_specific_class_round_data(nobroadcast=True,specific_class=specific_class)
         elif load_type == 'race_format':
             emit_race_format(nobroadcast=True)
         elif load_type == 'node_tuning':
@@ -2571,81 +2568,6 @@ def emit_round_data(**params):
     else:
         SOCKET_IO.emit('round_data', emit_payload)
 
-def emit_specific_class_round_data(**params):
-    '''Emits saved races to rounds page.'''
-    global EVENT_RESULTS_CACHE
-    global EVENT_RESULTS_CACHE_VALID
-   
-    if ('specific_class' in params):
-        specific_class = params['specific_class']
-    else:
-        specific_class = CLASS_ID_NONE
-
-    heats = {}
-    for heat in SavedRaceMeta.query.with_entities(SavedRaceMeta.heat_id).distinct().filter_by(class_id=specific_class).order_by(SavedRaceMeta.heat_id):
-        heatnote = Heat.query.filter_by( heat_id=heat.heat_id ).first().note
-
-        rounds = []
-        for round in SavedRaceMeta.query.distinct().filter_by(heat_id=heat.heat_id,class_id=specific_class).order_by(SavedRaceMeta.round_id):
-            pilotraces = []
-            for pilotrace in SavedPilotRace.query.filter_by(race_id=round.id).all():
-                laps = []
-                for lap in SavedRaceLap.query.filter_by(pilotrace_id=pilotrace.id).all():
-                    laps.append({
-                                'id': lap.id,
-                                'lap_time_stamp': lap.lap_time_stamp,
-                                'lap_time': lap.lap_time,
-                                'lap_time_formatted': lap.lap_time_formatted,
-                                'source': lap.source,
-                                'deleted': lap.deleted
-                        })
-
-                pilot_data = Pilot.query.filter_by(id=pilotrace.pilot_id).first()
-                if pilot_data:
-                        nodepilot = pilot_data.callsign
-                else:
-                        nodepilot = None
-
-                pilotraces.append({
-                        'callsign': nodepilot,
-                        'pilot_id': pilotrace.pilot_id,
-                        'node_index': pilotrace.node_index,
-                        'laps': laps
-                })
-            rounds.append({
-                'id': round.round_id,
-                'start_time_formatted': round.start_time_formatted,
-                'nodes': pilotraces
-            })
-        heats[heat.heat_id] = {
-            'heat_id': heat.heat_id,
-            'note': heatnote,
-            'rounds': rounds
-        }
-
-    heats_by_class = {}
-    heats_by_class[CLASS_ID_NONE] = [heat.heat_id for heat in Heat.query.filter_by(class_id=CLASS_ID_NONE,node_index=0).all()]
-    for race_class in RaceClass.query.filter_by(id=specific_class).all():
-        heats_by_class[race_class.id] = [heat.heat_id for heat in Heat.query.filter_by(class_id=race_class.id,node_index=0).all()]
-
-    current_classes = {}
-    for race_class in RaceClass.query.filter_by(id=specific_class).all():
-        current_class = {}
-        current_class['id'] = race_class.id
-        current_class['name'] = race_class.name
-        current_class['description'] = race_class.name
-        current_class['leaderboard'] = calc_leaderboard(class_id=race_class.id)
-        current_classes[race_class.id] = current_class
-
-    emit_payload = {
-        'classes': current_classes
-    }
-
-    if ('nobroadcast' in params):
-        emit('class_round_data', emit_payload)
-    else:
-        SOCKET_IO.emit('class_round_data', emit_payload)
-
 def calc_leaderboard(**params):
     ''' Generates leaderboards '''
     USE_CURRENT = False
@@ -2760,8 +2682,6 @@ def calc_leaderboard(**params):
     average_lap = []
     fastest_lap = []
     consecutives = []
-    fastest_lap_round = []
-    fastest_lap_heat = []
 
     for i, pilot in enumerate(pilot_ids):
         # Get the total race time for each pilot
@@ -2811,26 +2731,19 @@ def calc_leaderboard(**params):
         # Get the fastest lap time for each pilot
         if max_laps[i] is 0:
             fastest_lap.append(0) # Add zero if no laps completed
-            fastest_lap_round.append(0) # Add zero if no laps completed
-            fastest_lap_heat.append(0) # Add zero if no laps completed
         else:
             if USE_CURRENT:
                 stat_query = DB.session.query(DB.func.min(CurrentLap.lap_time)) \
                     .filter(CurrentLap.pilot_id == pilot, CurrentLap.lap_id != 0)
             else:
-                stat_query = DB.session.query(DB.func.min(SavedRaceLap.lap_time),SavedRaceLap.lap_time,SavedRaceLap.race_id) \
+                stat_query = DB.session.query(DB.func.min(SavedRaceLap.lap_time)) \
                     .filter(SavedRaceLap.pilot_id == pilot, \
                         SavedRaceLap.deleted != 1, \
                         SavedRaceLap.race_id.in_(racelist), \
-                        ~SavedRaceLap.id.in_(holeshots[i])).one()
+                        ~SavedRaceLap.id.in_(holeshots[i]))
 
-            fround = DB.session.query(SavedRaceMeta.round_id,SavedRaceMeta.heat_id).filter(SavedRaceMeta.id==stat_query.race_id).first()
-            fheat = DB.session.query( Heat.note).filter_by(heat_id=fround.heat_id).first()
-
-            fastest_lap_round.append(fround.round_id)
-            fastest_lap_heat.append(fheat.note)
-
-            fastest_lap.append(stat_query.lap_time)
+            fast_lap = stat_query.scalar()
+            fastest_lap.append(fast_lap)
 
         # find best consecutive 3 laps
         if max_laps[i] < 3:
@@ -2869,7 +2782,7 @@ def calc_leaderboard(**params):
                 consecutives.append(None)
 
     # Combine for sorting
-    leaderboard = zip(callsigns, max_laps, total_time, average_lap, fastest_lap, team_names, consecutives, fastest_lap_round, fastest_lap_heat)
+    leaderboard = zip(callsigns, max_laps, total_time, average_lap, fastest_lap, team_names, consecutives)
 
     # Reverse sort max_laps x[1], then sort on total time x[2]
     leaderboard_by_race_time = sorted(leaderboard, key = lambda x: (-x[1], x[2]))
@@ -2901,8 +2814,6 @@ def calc_leaderboard(**params):
             'fastest_lap': time_format(row[4]),
             'team_name': row[5],
             'consecutives': time_format(row[6]),
-            'fastest_lap_round': row[7],
-            'fastest_lap_heat': row[8],
         })
 
     # Sort consecutives x[6]

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -1405,6 +1405,13 @@ def on_generate_heats(data):
                     assigned_pilots_in_heat = 1 
                     heat_note= chr(ord(heat_note) + 1 )
 
+            # for odd reasons, the rest of the system wants heats fully populated this gets the last heat generated
+            for checking_index  in range(RACE.num_nodes): 
+                current_node_occupant = DB.session.query(DB.func.max(Heat.heat_id)).filter_by(heat_id=max_heat_id, node_index=checking_index).scalar()
+                if current_node_occupant is  None: # Not taken
+                    DB.session.add(Heat(heat_id=max_heat_id, node_index=checking_index, pilot_id=PILOT_ID_NONE, class_id=CLASS_ID_NONE, note=heat_note+"-Main"))
+                    DB.session.commit()
+
 
     emit_heat_data() 
 

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -1529,6 +1529,11 @@ def on_backup_database():
     }
     SOCKET_IO.emit('database_bkp_done', emit_payload)
 
+@SOCKET_IO.on('delete_last_heat')
+def on_delete_last_heat(data):
+    '''Delete last heat of the db'''
+    db_delete_last_heat()
+
 @SOCKET_IO.on('reset_database')
 def on_reset_database(data):
     '''Reset database.'''
@@ -3972,7 +3977,6 @@ def assign_frequencies():
 
 def db_init():
     '''Initialize database.'''
-    DB.create_all() # Creates tables from database classes/models
     db_reset_pilots()
     db_reset_heats()
     db_reset_current_laps()
@@ -4013,6 +4017,16 @@ def db_reset_heats():
             DB.session.add(Heat(heat_id=1, node_index=node, class_id=CLASS_ID_NONE, pilot_id=node+1))
     DB.session.commit()
     server_log('Database heats reset')
+
+def db_delete_last_heat():
+    '''deletes last heat'''
+    heat_row = DB.session.query(Heat)
+    if heat_row.count() > 1:
+        #DB.session.query(DB.func.max(Heat.id)).delete() 
+        #DB.session.commit()
+        server_log('Database delete last heat')
+    else:
+        server_log('Database can not delete last heat')
 
 def db_reset_classes():
     '''Resets database race classes to default.'''

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -1736,7 +1736,6 @@ def on_stage_race():
 
         SOCKET_IO.emit('stage_ready', {
             'hide_stage_timer': MIN != MAX,
-            'silent_countdown': MAX == 0,
             'race_mode': race_format.race_mode,
             'race_time_sec': race_format.race_time_sec,
             'pi_starts_at_s': RACE_START
@@ -2203,7 +2202,6 @@ def emit_race_status(**params):
             'race_mode': race_format.race_mode,
             'race_time_sec': race_format.race_time_sec,
             'hide_stage_timer': race_format.start_delay_min != race_format.start_delay_max,
-            'silent_countdown': race_format.start_delay_max == 0,
             'pi_starts_at_s': RACE_START
         }
     if ('nobroadcast' in params):

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -1122,6 +1122,9 @@ def on_load_data(data):
             emit_pilot_data(nobroadcast=True)
         elif load_type == 'round_data':
             emit_round_data(nobroadcast=True)
+        elif load_type == 'class_round_data':
+            specific_class = data['specific_class']
+            emit_specific_class_round_data(nobroadcast=True,specific_class=specific_class)
         elif load_type == 'race_format':
             emit_race_format(nobroadcast=True)
         elif load_type == 'node_tuning':
@@ -2570,6 +2573,81 @@ def emit_round_data(**params):
     else:
         SOCKET_IO.emit('round_data', emit_payload)
 
+def emit_specific_class_round_data(**params):
+    '''Emits saved races to rounds page.'''
+    global EVENT_RESULTS_CACHE
+    global EVENT_RESULTS_CACHE_VALID
+   
+    if ('specific_class' in params):
+        specific_class = params['specific_class']
+    else:
+        specific_class = CLASS_ID_NONE
+
+    heats = {}
+    for heat in SavedRaceMeta.query.with_entities(SavedRaceMeta.heat_id).distinct().filter_by(class_id=specific_class).order_by(SavedRaceMeta.heat_id):
+        heatnote = Heat.query.filter_by( heat_id=heat.heat_id ).first().note
+
+        rounds = []
+        for round in SavedRaceMeta.query.distinct().filter_by(heat_id=heat.heat_id,class_id=specific_class).order_by(SavedRaceMeta.round_id):
+            pilotraces = []
+            for pilotrace in SavedPilotRace.query.filter_by(race_id=round.id).all():
+                laps = []
+                for lap in SavedRaceLap.query.filter_by(pilotrace_id=pilotrace.id).all():
+                    laps.append({
+                                'id': lap.id,
+                                'lap_time_stamp': lap.lap_time_stamp,
+                                'lap_time': lap.lap_time,
+                                'lap_time_formatted': lap.lap_time_formatted,
+                                'source': lap.source,
+                                'deleted': lap.deleted
+                        })
+
+                pilot_data = Pilot.query.filter_by(id=pilotrace.pilot_id).first()
+                if pilot_data:
+                        nodepilot = pilot_data.callsign
+                else:
+                        nodepilot = None
+
+                pilotraces.append({
+                        'callsign': nodepilot,
+                        'pilot_id': pilotrace.pilot_id,
+                        'node_index': pilotrace.node_index,
+                        'laps': laps
+                })
+            rounds.append({
+                'id': round.round_id,
+                'start_time_formatted': round.start_time_formatted,
+                'nodes': pilotraces
+            })
+        heats[heat.heat_id] = {
+            'heat_id': heat.heat_id,
+            'note': heatnote,
+            'rounds': rounds
+        }
+
+    heats_by_class = {}
+    heats_by_class[CLASS_ID_NONE] = [heat.heat_id for heat in Heat.query.filter_by(class_id=CLASS_ID_NONE,node_index=0).all()]
+    for race_class in RaceClass.query.filter_by(id=specific_class).all():
+        heats_by_class[race_class.id] = [heat.heat_id for heat in Heat.query.filter_by(class_id=race_class.id,node_index=0).all()]
+
+    current_classes = {}
+    for race_class in RaceClass.query.filter_by(id=specific_class).all():
+        current_class = {}
+        current_class['id'] = race_class.id
+        current_class['name'] = race_class.name
+        current_class['description'] = race_class.name
+        current_class['leaderboard'] = calc_leaderboard(class_id=race_class.id)
+        current_classes[race_class.id] = current_class
+
+    emit_payload = {
+        'classes': current_classes
+    }
+
+    if ('nobroadcast' in params):
+        emit('class_round_data', emit_payload)
+    else:
+        SOCKET_IO.emit('class_round_data', emit_payload)
+
 def calc_leaderboard(**params):
     ''' Generates leaderboards '''
     USE_CURRENT = False
@@ -2684,6 +2762,8 @@ def calc_leaderboard(**params):
     average_lap = []
     fastest_lap = []
     consecutives = []
+    fastest_lap_round = []
+    fastest_lap_heat = []
 
     for i, pilot in enumerate(pilot_ids):
         # Get the total race time for each pilot
@@ -2733,19 +2813,26 @@ def calc_leaderboard(**params):
         # Get the fastest lap time for each pilot
         if max_laps[i] is 0:
             fastest_lap.append(0) # Add zero if no laps completed
+            fastest_lap_round.append(0) # Add zero if no laps completed
+            fastest_lap_heat.append(0) # Add zero if no laps completed
         else:
             if USE_CURRENT:
                 stat_query = DB.session.query(DB.func.min(CurrentLap.lap_time)) \
                     .filter(CurrentLap.pilot_id == pilot, CurrentLap.lap_id != 0)
             else:
-                stat_query = DB.session.query(DB.func.min(SavedRaceLap.lap_time)) \
+                stat_query = DB.session.query(DB.func.min(SavedRaceLap.lap_time),SavedRaceLap.lap_time,SavedRaceLap.race_id) \
                     .filter(SavedRaceLap.pilot_id == pilot, \
                         SavedRaceLap.deleted != 1, \
                         SavedRaceLap.race_id.in_(racelist), \
-                        ~SavedRaceLap.id.in_(holeshots[i]))
+                        ~SavedRaceLap.id.in_(holeshots[i])).one()
 
-            fast_lap = stat_query.scalar()
-            fastest_lap.append(fast_lap)
+            fround = DB.session.query(SavedRaceMeta.round_id,SavedRaceMeta.heat_id).filter(SavedRaceMeta.id==stat_query.race_id).first()
+            fheat = DB.session.query( Heat.note).filter_by(heat_id=fround.heat_id).first()
+
+            fastest_lap_round.append(fround.round_id)
+            fastest_lap_heat.append(fheat.note)
+
+            fastest_lap.append(stat_query.lap_time)
 
         # find best consecutive 3 laps
         if max_laps[i] < 3:
@@ -2784,7 +2871,7 @@ def calc_leaderboard(**params):
                 consecutives.append(None)
 
     # Combine for sorting
-    leaderboard = zip(callsigns, max_laps, total_time, average_lap, fastest_lap, team_names, consecutives)
+    leaderboard = zip(callsigns, max_laps, total_time, average_lap, fastest_lap, team_names, consecutives, fastest_lap_round, fastest_lap_heat)
 
     # Reverse sort max_laps x[1], then sort on total time x[2]
     leaderboard_by_race_time = sorted(leaderboard, key = lambda x: (-x[1], x[2]))
@@ -2816,6 +2903,8 @@ def calc_leaderboard(**params):
             'fastest_lap': time_format(row[4]),
             'team_name': row[5],
             'consecutives': time_format(row[6]),
+            'fastest_lap_round': row[7],
+            'fastest_lap_heat': row[8],
         })
 
     # Sort consecutives x[6]

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -1530,7 +1530,7 @@ def on_backup_database():
     SOCKET_IO.emit('database_bkp_done', emit_payload)
 
 @SOCKET_IO.on('delete_last_heat')
-def on_delete_last_heat(data):
+def on_delete_last_heat():
     '''Delete last heat of the db'''
     db_delete_last_heat()
 
@@ -4020,11 +4020,15 @@ def db_reset_heats():
 
 def db_delete_last_heat():
     '''deletes last heat'''
-    heat_row = DB.session.query(Heat)
-    if heat_row.count() > 1:
-        #DB.session.query(DB.func.max(Heat.id)).delete() 
-        #DB.session.commit()
-        server_log('Database delete last heat')
+
+    heat_count = DB.session.query(DB.func.max(Heat.heat_id)).scalar()
+    has_race = SavedRaceMeta.query.filter_by(heat_id=heat_count).first()
+
+    if (not has_race) and  (heat_count > 1):
+        DB.session.query(Heat).filter(Heat.heat_id == heat_count).delete()
+        DB.session.commit()
+        server_log('Admin deleted last heat ' + str(heat_count))
+        emit_heat_data()
     else:
         server_log('Database can not delete last heat')
 

--- a/src/server/static/rotorhazard.css
+++ b/src/server/static/rotorhazard.css
@@ -97,6 +97,7 @@ th, td {
 	vertical-align: top;
 }
 
+
 input, select, textarea {
 	font: inherit;
 	box-sizing: border-box;
@@ -691,6 +692,9 @@ main.page-home {
 
 .node-controls {
 	margin-top: 0.25em;
+}
+input#pilots_per_heat {
+	width: 2em
 }
 
 .enter-exit-control {

--- a/src/server/static/rotorhazard.js
+++ b/src/server/static/rotorhazard.js
@@ -953,7 +953,7 @@ rotorhazard.timer.race.callbacks.step = function(timer){
 	if (timer.warn_until < window.performance.now()) {
 		$('.timing-clock .warning').hide();
 	}
-	if (timer.time_s < 0) {
+	if (timer.time_s < 0 && !timer.silent_countdown) {
 		if (timer.hidden_staging) {
 			// beep every second during staging if timer is hidden
 			if (timer.time_s * 10 % 10 == 0) {

--- a/src/server/static/rotorhazard.js
+++ b/src/server/static/rotorhazard.js
@@ -566,7 +566,6 @@ function timerModel() {
 	this.time_s = false; // simplified relative time in seconds
 	this.count_up = false; // use fixed-length timer
 	this.duration = 0; // fixed-length duration, in seconds
-	this.silent_countdown = false; // eliminate countdown tones 
 
 	this.drift_history = [];
 	this.drift_history_samples = 10;
@@ -792,7 +791,6 @@ var rotorhazard = {
 	pi_time_diff_samples: [], // stored previously acquired offsets
 
 	timer: {
-		suppress_countdown_beep: false,
 		deferred: new timerModel(),
 		race: new timerModel(),
 		stopAll: function() {

--- a/src/server/static/rotorhazard.js
+++ b/src/server/static/rotorhazard.js
@@ -566,6 +566,7 @@ function timerModel() {
 	this.time_s = false; // simplified relative time in seconds
 	this.count_up = false; // use fixed-length timer
 	this.duration = 0; // fixed-length duration, in seconds
+        this.silent_countdown = false; // eliminate countdown tones
 
 	this.drift_history = [];
 	this.drift_history_samples = 10;
@@ -791,6 +792,7 @@ var rotorhazard = {
 	pi_time_diff_samples: [], // stored previously acquired offsets
 
 	timer: {
+		suppress_countdown_beep: false,
 		deferred: new timerModel(),
 		race: new timerModel(),
 		stopAll: function() {
@@ -951,7 +953,7 @@ rotorhazard.timer.race.callbacks.step = function(timer){
 	if (timer.warn_until < window.performance.now()) {
 		$('.timing-clock .warning').hide();
 	}
-	if (timer.time_s < 0) {
+	if (timer.time_s < 0 && !timer.silent_countdown) {
 		if (timer.hidden_staging) {
 			// beep every second during staging if timer is hidden
 			if (timer.time_s * 10 % 10 == 0) {

--- a/src/server/static/rotorhazard.js
+++ b/src/server/static/rotorhazard.js
@@ -1271,6 +1271,10 @@ function build_leaderboard(leaderboard, display_type, meta) {
 		display_type == 'current') {
 		header_row.append('<th class="fast">' + __('Fastest') + '</th>');
 	}
+	if (display_type == 'by_fastest_lap') { 
+		header_row.append('<th class="fast">' + __('Heat') + '</th>');
+		header_row.append('<th class="fast">' + __('Round') + '</th>');
+	}
 	if (display_type == 'by_consecutives' ||
 		display_type == 'heat' ||
 		display_type == 'round' ||
@@ -1317,6 +1321,12 @@ function build_leaderboard(leaderboard, display_type, meta) {
 			if (!lap || lap == '0:00.000')
 				lap = '&#8212;';
 			row.append('<td class="fast">'+ lap +'</td>');
+		}
+		if (display_type == 'by_fastest_lap') {
+			var lapround = leaderboard[i].fastest_lap_round;
+			var lapheat = leaderboard[i].fastest_lap_heat;
+			row.append('<td class="fast">'+ lapheat +'</td>');
+			row.append('<td class="fast">'+ lapround +'</td>');
 		}
 		if (display_type == 'by_consecutives' ||
 		display_type == 'heat' ||

--- a/src/server/static/rotorhazard.js
+++ b/src/server/static/rotorhazard.js
@@ -953,7 +953,7 @@ rotorhazard.timer.race.callbacks.step = function(timer){
 	if (timer.warn_until < window.performance.now()) {
 		$('.timing-clock .warning').hide();
 	}
-	if (timer.time_s < 0 && !timer.silent_countdown) {
+	if (timer.time_s < 0) {
 		if (timer.hidden_staging) {
 			// beep every second during staging if timer is hidden
 			if (timer.time_s * 10 % 10 == 0) {

--- a/src/server/static/rotorhazard.js
+++ b/src/server/static/rotorhazard.js
@@ -566,6 +566,7 @@ function timerModel() {
 	this.time_s = false; // simplified relative time in seconds
 	this.count_up = false; // use fixed-length timer
 	this.duration = 0; // fixed-length duration, in seconds
+	this.silent_countdown = false; // eliminate countdown tones 
 
 	this.drift_history = [];
 	this.drift_history_samples = 10;
@@ -791,6 +792,7 @@ var rotorhazard = {
 	pi_time_diff_samples: [], // stored previously acquired offsets
 
 	timer: {
+		suppress_countdown_beep: false,
 		deferred: new timerModel(),
 		race: new timerModel(),
 		stopAll: function() {

--- a/src/server/static/rotorhazard.js
+++ b/src/server/static/rotorhazard.js
@@ -1269,10 +1269,6 @@ function build_leaderboard(leaderboard, display_type, meta) {
 		display_type == 'current') {
 		header_row.append('<th class="fast">' + __('Fastest') + '</th>');
 	}
-	if (display_type == 'by_fastest_lap') { 
-		header_row.append('<th class="fast">' + __('Heat') + '</th>');
-		header_row.append('<th class="fast">' + __('Round') + '</th>');
-	}
 	if (display_type == 'by_consecutives' ||
 		display_type == 'heat' ||
 		display_type == 'round' ||
@@ -1319,12 +1315,6 @@ function build_leaderboard(leaderboard, display_type, meta) {
 			if (!lap || lap == '0:00.000')
 				lap = '&#8212;';
 			row.append('<td class="fast">'+ lap +'</td>');
-		}
-		if (display_type == 'by_fastest_lap') {
-			var lapround = leaderboard[i].fastest_lap_round;
-			var lapheat = leaderboard[i].fastest_lap_heat;
-			row.append('<td class="fast">'+ lapheat +'</td>');
-			row.append('<td class="fast">'+ lapround +'</td>');
 		}
 		if (display_type == 'by_consecutives' ||
 		display_type == 'heat' ||

--- a/src/server/templates/race.html
+++ b/src/server/templates/race.html
@@ -17,6 +17,7 @@
 		rotorhazard.race_start_pi = (msg.pi_starts_at_s * 1000); // convert seconds (pi) to millis (JS)
 
 		rotorhazard.timer.race.hidden_staging = Boolean(msg.hide_stage_timer);
+		rotorhazard.timer.race.silent_countdown = Boolean(msg.silent_countdown);
 		rotorhazard.timer.race.count_up = Boolean(msg.race_mode);
 		rotorhazard.timer.race.duration = msg.race_time_sec;
 

--- a/src/server/templates/race.html
+++ b/src/server/templates/race.html
@@ -17,7 +17,6 @@
 		rotorhazard.race_start_pi = (msg.pi_starts_at_s * 1000); // convert seconds (pi) to millis (JS)
 
 		rotorhazard.timer.race.hidden_staging = Boolean(msg.hide_stage_timer);
-		rotorhazard.timer.race.silent_countdown = Boolean(msg.silent_countdown);
 		rotorhazard.timer.race.count_up = Boolean(msg.race_mode);
 		rotorhazard.timer.race.duration = msg.race_time_sec;
 

--- a/src/server/templates/rounds.html
+++ b/src/server/templates/rounds.html
@@ -1,17 +1,10 @@
 {% extends "layout.html" %} {% block title %}Rounds{% endblock %} {% block head %} {% endblock %} {% block content %}
 <script type="text/javascript" charset="utf-8">
-
-	var race_list = {};
-	var race_list_loaded = false;
-	var race_loaded = false;
-	var current_race_data = {};
-	var min_lap = {{ getOption('MinLapSec') }} * 1000;
-        
 	$(document).ready(function () {
 		socket.emit('load_data', {'load_types': [
 			'all_languages',
 			'language',
-			'class_data',
+			'round_data',
 		]});
 
 		socket.on('all_languages', function (msg) {
@@ -26,67 +19,15 @@
 
 		socket.on('round_data_notify', function () {
 			socket.emit('load_data', {'load_types': [
-				'class_round_data',
+				'round_data',
 			]});
 		});
 
-              socket.on('class_data', function (msg) {
-                        $('#set_current_class').empty();
-                        if (msg.classes.length) {
-                            for (var i in msg.classes) {
-                                    var raceclass = msg.classes[i];
-                                    var opt = $('<option value="' + raceclass.id + '">' + raceclass.name + '</option>');
-
-                                    $('#set_current_class').append(opt);
-                            }
-                        }
-
-                });
-
-
-                socket.on('race_list', function (msg) {
-                        race_list = msg;
-
-                        $('button#load_pilot_results').prop('disabled', false);
-                        if (race_list_loaded) {
-                                var prev_heat = $('#selected_heat').val();
-                        }
-
-                        $('#selected_heat').empty();
-                        for (var heat_i in race_list.heats) {
-                                var heat = race_list.heats[heat_i];
-
-                                if (heat.note) {
-                                        var heat_name = heat.note;
-                                } else {
-                                        var heat_name = __('Heat') + ' ' + heat_i;
-                                }
-
-                                $('#selected_heat').append('<option value="' + heat_i + '">' + heat_name + '</option>');
-                        }
-                        $('#selected_heat').val(heat_i);
-
-                        if (race_list_loaded) {
-                                $('#selected_heat').val(prev_heat);
-                        } else {
-                                race_list_loaded = true;
-                                $('#selected_heat').prop('disabled', false);
-                                $('#selected_round').prop('disabled', false);
-                                $('#selected_pilot').prop('disabled', false);
-                                $('#load_race').prop('disabled', false);
-                        }
-
-                        $('#selected_heat').trigger('change');
-                });
-
-
 		socket.on('round_data', function (msg) {
-			var page = $('.results_display')
+			var page = $('.page-rounds')
 			page.empty();
-                        $('button#load_all_results').prop('disabled', false);
 
 			if (!$.isEmptyObject(msg.heats)) {
-			    if (!$.isEmptyObject(msg.event_leaderboard)) {
 				var panel = $('<div id="event_leaderboard" class="panel collapsing">');
 
 				var panel_header = $('<div class="panel-header">');
@@ -106,7 +47,6 @@
 				panel.append(panel_content);
 
 				page.append(panel)
-                            }
 
 				// heats
 
@@ -264,265 +204,11 @@
 				page.append('<p>' + __('There is no saved race data available to view.') + '</p>');
 			}
 		});
+	});
+</script>
+<main class="page-rounds">
 
-		socket.on('class_round_data', function (msg) {
-			var page = $('.results_display')
-			page.empty();
+<p>Loading...</p>
 
-                        $('button#load_class_results').prop('disabled', false);
-
-			if (!$.isEmptyObject(msg.classes)) {
-
-				for (var class_id in msg.classes) {
-
-					var class_panel = $('<div id="class_' + class_id + '" class="panel collapsing">');
-					var class_panel_header = $('<div class="panel-header">');
-					var class_panel_content = $('<div class="panel-content" style="display: none">');
-
-					var current_class = msg.classes[class_id];
-					if (current_class) {
-						class_panel_header.append('<h2><button class="no-style">' + current_class.name + '</button></h2>');
-
-						var class_leaderboard = $('<div id="class_' + class_id + '_leaderboard" class="panel collapsing class-leaderboard">');
-
-						var class_leaderboard_header = $('<div class="panel-header">');
-						class_leaderboard_header.append('<h3><button class="no-style">' + __('Class Summary') + '</button></h3>');
-						class_leaderboard.append(class_leaderboard_header);
-
-						var class_leaderboard_content = $('<div class="panel-content" style="display: none">');
-
-						class_leaderboard_content.append('<h4>' + __('Race Totals') + '</h4>');
-						class_leaderboard_content.append(build_leaderboard(current_class.leaderboard.by_race_time, 'by_race_time', msg.meta));
-						class_leaderboard_content.append('<h4>' + __('Fastest Laps') + '</h4>');
-						class_leaderboard_content.append(build_leaderboard(current_class.leaderboard.by_fastest_lap, 'by_fastest_lap', msg.meta));
-						class_leaderboard_content.append('<h4>' + __('Fastest 3 Consecutive Laps') + '</h4>');
-						class_leaderboard_content.append(build_leaderboard(current_class.leaderboard.by_consecutives, 'by_consecutives', msg.meta));
-
-						class_leaderboard.append(class_leaderboard_content);
-						class_panel_content.append(class_leaderboard);
-					} else {
-						if ($.isEmptyObject(msg.classes)) {
-							class_panel_header.append('<h2><button class="no-style">' + __('Heats') + '</button></h2>')
-						} else {
-							class_panel_header.append('<h2><button class="no-style">' + __('Unclassified') + '</button></h2>')
-						}
-					}
-
-					class_panel.append(class_panel_header);
-
-					class_panel.append(class_panel_content);
-					page.append(class_panel);
-				}
-
-				for (var panel in rotorhazard.panelstates) {
-					var panel_obj = $('#' + panel);
-					var panelstate = rotorhazard.panelstates[panel];
-
-					if (panelstate) {
-						panel_obj.addClass('open');
-						panel_obj.children('.panel-content').stop().slideDown();
-					} else {
-						panel_obj.removeClass('open');
-						panel_obj.children('.panel-content').stop().slideUp();
-					}
-				}
-			} else {
-				page.append('<p>' + __('There is no saved race data available to view.') + '</p>');
-			}
-		});
-
-               $('button#load_class_results').click(function (event) {
-
-                        if(!$(this).prop('disabled')) {
-			        $('.results_display').empty()
-			        $('.results_display').html('<p> {{ __('Loading...') }} </p>')
-                                $(this).prop('disabled', true);
-                                socket.emit('load_data', {'load_types': [ 'class_round_data', ], 'specific_class' : $('#set_current_class').val() } );
-                        }
-                        return false;
-                });
-               $('button#load_all_results').click(function (event) {
-
-                        if(!$(this).prop('disabled')) {
-			        $('.results_display').empty()
-			        $('.results_display').html('<p> {{ __('Loading...') }} </p>')
-                                $(this).prop('disabled', true);
-                                socket.emit('load_data', {'load_types': [ 'round_data', ],  } );
-                        }
-                        return false;
-                });
-
-               $('button#load_pilot_results').click(function (event) {
-
-                        if(!$(this).prop('disabled')) {
-			        $('.race-view').html(' {{ __('Loading...') }}  <table id="laps"> </table>')
-                                $(this).prop('disabled', true);
-                                socket.emit('load_data', {'load_types': [ 'race_list', ],  } );
-                        }
-                        return false;
-                });
-
-		$('#selected_heat').change(function(){
-			var prev_round = $('#selected_round').val();
-
-			$('#selected_round').empty();
-
-			var heat = parseInt($(this).val());
-
-			for (var round_i in race_list.heats[heat].rounds) {
-				$('#selected_round').append('<option value="' + round_i + '">' + __('Round') + ' ' + round_i + '</option>');
-			}
-
-			$('#selected_round').val(round_i);
-			$('#selected_round option').each(function(){
-				if (this.value == prev_round) {
-					$('#selected_round').val(prev_round);
-					return false;
-				}
-			});
-
-
-			$('#selected_round').trigger('change');
-		});
-
-		$('#selected_round').change(function(){
-			var prev_pilot = $('#selected_pilot').data('pilot-id');
-
-			$('#selected_pilot').empty();
-
-			var heat = parseInt($('#selected_heat').val());
-			var round = parseInt($(this).val());
-
-			for (var pilot_i in race_list.heats[heat].rounds[round].pilotraces) {
-				var pilotrace = race_list.heats[heat].rounds[round].pilotraces[pilot_i];
-				$('#selected_pilot').append('<option value="' + pilot_i + '" data-pilot-id="' + pilotrace.pilot_id + '">' + pilotrace.callsign + '</option>');
-			}
-
-			$('#selected_pilot option').each(function(){
-				if ($(this).data('pilot-id') == prev_pilot) {
-					$('#selected_pilot').val($(this).val());
-					return false;
-				}
-			});
-
-
-			$('#selected_pilot').trigger('change');
-		});
-
-		$('#selected_pilot').change(function(){
-			var heat = parseInt($('#selected_heat').val());
-			var round = parseInt($('#selected_round').val());
-			var pilot = parseInt($(this).val());
-			var pilotrace = race_list.heats[heat].rounds[round].pilotraces[pilot];
-
-			$(this).data('pilot-id', pilotrace.pilot_id);
-
-			load_race();
-		});
-
-		function load_race() {
-                        table_html='<thead> <tr> <th>{{ __('Lap') }}</th> <th>{{ __('Timestamp') }}</th> <th>{{ __('Lap Time') }}</th> </tr> </thead> <tbody></tbody>'
-			$('.race-view').html(' <table id="laps"> ' + table_html + '</table>')
-
-			var lapList = $('#laps tbody');
-			lapList.empty();
-
-			race_loaded = true;
-
-			var heat = parseInt($('#selected_heat').val());
-			var round = parseInt($('#selected_round').val());
-			var pilot = parseInt($('#selected_pilot').val());
-
-
-			// load current race data
-			current_race_data = jQuery.extend(true, {}, race_list.heats[heat].rounds[round].pilotraces[pilot]);
-			// fill current data with race meta
-			current_race_data.round_id = round;
-			current_race_data.heat_id = heat;
-			current_race_data.race_id = race_list.heats[heat].rounds[round].race_id;
-			current_race_data.class_id = race_list.heats[heat].rounds[round].class_id;
-			current_race_data.format_id = race_list.heats[heat].rounds[round].format_id;
-			current_race_data.start_time = race_list.heats[heat].rounds[round].start_time;
-			current_race_data.start_time_formatted = race_list.heats[heat].rounds[round].start_time_formatted;
-
-			// populate laps
-			displayLaps(current_race_data.laps);
-
-			return false;
-		}
-
-
-			function displayLaps(laps_obj) {
-				var lapList = $('#laps tbody');
-				var lap_index = 0;
-				for (var lap_i in laps_obj) {
-					var lap = laps_obj[lap_i];
-					var lapData = $('<tr>');
-
-					if (lap.deleted) {
-						lapData.addClass('lap-deleted');
-					} else if (lap_index && lap.lap_time < min_lap) {
-						lapData.addClass('min-lap-warning');
-					}
-
-					if (!lap.deleted) {
-						lapData.append('<td>' + lap_index + '</td>');
-						lapData.append('<td>' + (lap.lap_time_stamp / 1000).toFixed(3) + '</td>');
-						lapData.append('<td>' + formatTimeMillis(lap.lap_time) + '</td>');
-						lap_index++;
-					} else {
-						lapData.append('<td>-</td>');
-						lapData.append('<td>' + (lap.lap_time_stamp / 1000).toFixed(3) + '</td>');
-						lapData.append('<td>' + __('Deleted') + '</td>');
-					}
-
-					lapList.append(lapData);
-				}
-			}
-
-		});
-	</script>
-	<main class="page-rounds">
-
-			<div class="control-set">
-				<label for="selected_heat" class="screen-reader-text">{{ __('Heat') }}</label>
-				<select id="selected_heat" disabled>
-					<option value="--">{{ __('Not Loaded') }}</option>
-				</select>
-
-				<label for="selected_round" class="screen-reader-text">{{ __('Round') }}</label>
-				<select id="selected_round" disabled>
-					<option value="--">{{ __('Not Loaded') }}</option>
-				</select>
-
-				<label for="selected_pilot" class="screen-reader-text">{{ __('Pilot') }}</label>
-				<select id="selected_pilot" disabled>
-					<option value="--">{{ __('Not Loaded') }}</option>
-				</select>
-				<button id="load_pilot_results"><span class="narrow">{{ __('Get') }}</span><span class="wide">{{ __('Load Race') }}</span></button>
-
-			</div>
-
-			<div id="race-display">
-
-				<div id="race-view" class="race-view">
-				</div>
-
-			</div>
-			<div class="control-set">
-				<label for="set_current_class" class="screen-reader-text">{{ __('Current Class') }}</label>
-				<select id="set_current_class">
-					<option value="">{{ __('Loading...') }}</option>
-				</select>
-				<button id="load_class_results"><span class="narrow">{{ __('Get') }}</span><span class="wide">{{ __('Class Summary') }}</span></button>
-				 <!-- change line below to <p class="admin-hide"> if you only want admins to see this button  -->
-				<p><button id="load_all_results"><span class="narrow">{{ __('GetSummary') }}</span><span class="wide">{{ __('All') }} {{ __('Results') }}</span></button> </p>
-			</div>
-
-			<div id="id=results_display" class="results_display">
-			   <p>Select class and press {{__('Class Summary')}} button</p>
-			</div>
-
-
-	</main>
+</main>
 {% endblock %}

--- a/src/server/templates/rounds.html
+++ b/src/server/templates/rounds.html
@@ -23,6 +23,55 @@
 			]});
 		});
 
+                socket.on('class_data', function (msg) {
+                        if (msg.classes.length > 0) {
+                            $('#set_current_class').empty();
+                            for (var i in msg.classes) {
+                                    var raceclass = msg.classes[i];
+                                    var opt = $('<option value="' + raceclass.id + '">' + raceclass.name + '</option>');
+
+                                    $('#set_current_class').append(opt);
+                            }
+                        }
+
+                });
+
+
+                socket.on('race_list', function (msg) {
+                        race_list = msg;
+
+                        $('button#load_pilot_results').prop('disabled', false);
+                        if (race_list_loaded) {
+                                var prev_heat = $('#selected_heat').val();
+                        }
+
+                        $('#selected_heat').empty();
+                        for (var heat_i in race_list.heats) {
+                                var heat = race_list.heats[heat_i];
+
+                                if (heat.note) {
+                                        var heat_name = heat.note;
+                                } else {
+                                        var heat_name = __('Heat') + ' ' + heat_i;
+                                }
+
+                                $('#selected_heat').append('<option value="' + heat_i + '">' + heat_name + '</option>');
+                        }
+                        $('#selected_heat').val(heat_i);
+
+                        if (race_list_loaded) {
+                                $('#selected_heat').val(prev_heat);
+                        } else {
+                                race_list_loaded = true;
+                                $('#selected_heat').prop('disabled', false);
+                                $('#selected_round').prop('disabled', false);
+                                $('#selected_pilot').prop('disabled', false);
+                                $('#load_race').prop('disabled', false);
+                        }
+
+                        $('#selected_heat').trigger('change');
+                });
+
 		socket.on('round_data', function (msg) {
 			var page = $('.page-rounds')
 			page.empty();

--- a/src/server/templates/rounds.html
+++ b/src/server/templates/rounds.html
@@ -1,10 +1,17 @@
 {% extends "layout.html" %} {% block title %}Rounds{% endblock %} {% block head %} {% endblock %} {% block content %}
 <script type="text/javascript" charset="utf-8">
+
+	var race_list = {};
+	var race_list_loaded = false;
+	var race_loaded = false;
+	var current_race_data = {};
+	var min_lap = {{ getOption('MinLapSec') }} * 1000;
+        
 	$(document).ready(function () {
 		socket.emit('load_data', {'load_types': [
 			'all_languages',
 			'language',
-			'round_data',
+			'class_data',
 		]});
 
 		socket.on('all_languages', function (msg) {
@@ -19,15 +26,67 @@
 
 		socket.on('round_data_notify', function () {
 			socket.emit('load_data', {'load_types': [
-				'round_data',
+				'class_round_data',
 			]});
 		});
 
+              socket.on('class_data', function (msg) {
+                        $('#set_current_class').empty();
+                        if (msg.classes.length) {
+                            for (var i in msg.classes) {
+                                    var raceclass = msg.classes[i];
+                                    var opt = $('<option value="' + raceclass.id + '">' + raceclass.name + '</option>');
+
+                                    $('#set_current_class').append(opt);
+                            }
+                        }
+
+                });
+
+
+                socket.on('race_list', function (msg) {
+                        race_list = msg;
+
+                        $('button#load_pilot_results').prop('disabled', false);
+                        if (race_list_loaded) {
+                                var prev_heat = $('#selected_heat').val();
+                        }
+
+                        $('#selected_heat').empty();
+                        for (var heat_i in race_list.heats) {
+                                var heat = race_list.heats[heat_i];
+
+                                if (heat.note) {
+                                        var heat_name = heat.note;
+                                } else {
+                                        var heat_name = __('Heat') + ' ' + heat_i;
+                                }
+
+                                $('#selected_heat').append('<option value="' + heat_i + '">' + heat_name + '</option>');
+                        }
+                        $('#selected_heat').val(heat_i);
+
+                        if (race_list_loaded) {
+                                $('#selected_heat').val(prev_heat);
+                        } else {
+                                race_list_loaded = true;
+                                $('#selected_heat').prop('disabled', false);
+                                $('#selected_round').prop('disabled', false);
+                                $('#selected_pilot').prop('disabled', false);
+                                $('#load_race').prop('disabled', false);
+                        }
+
+                        $('#selected_heat').trigger('change');
+                });
+
+
 		socket.on('round_data', function (msg) {
-			var page = $('.page-rounds')
+			var page = $('.results_display')
 			page.empty();
+                        $('button#load_all_results').prop('disabled', false);
 
 			if (!$.isEmptyObject(msg.heats)) {
+			    if (!$.isEmptyObject(msg.event_leaderboard)) {
 				var panel = $('<div id="event_leaderboard" class="panel collapsing">');
 
 				var panel_header = $('<div class="panel-header">');
@@ -47,6 +106,7 @@
 				panel.append(panel_content);
 
 				page.append(panel)
+                            }
 
 				// heats
 
@@ -204,11 +264,265 @@
 				page.append('<p>' + __('There is no saved race data available to view.') + '</p>');
 			}
 		});
-	});
-</script>
-<main class="page-rounds">
 
-<p>Loading...</p>
+		socket.on('class_round_data', function (msg) {
+			var page = $('.results_display')
+			page.empty();
 
-</main>
+                        $('button#load_class_results').prop('disabled', false);
+
+			if (!$.isEmptyObject(msg.classes)) {
+
+				for (var class_id in msg.classes) {
+
+					var class_panel = $('<div id="class_' + class_id + '" class="panel collapsing">');
+					var class_panel_header = $('<div class="panel-header">');
+					var class_panel_content = $('<div class="panel-content" style="display: none">');
+
+					var current_class = msg.classes[class_id];
+					if (current_class) {
+						class_panel_header.append('<h2><button class="no-style">' + current_class.name + '</button></h2>');
+
+						var class_leaderboard = $('<div id="class_' + class_id + '_leaderboard" class="panel collapsing class-leaderboard">');
+
+						var class_leaderboard_header = $('<div class="panel-header">');
+						class_leaderboard_header.append('<h3><button class="no-style">' + __('Class Summary') + '</button></h3>');
+						class_leaderboard.append(class_leaderboard_header);
+
+						var class_leaderboard_content = $('<div class="panel-content" style="display: none">');
+
+						class_leaderboard_content.append('<h4>' + __('Race Totals') + '</h4>');
+						class_leaderboard_content.append(build_leaderboard(current_class.leaderboard.by_race_time, 'by_race_time', msg.meta));
+						class_leaderboard_content.append('<h4>' + __('Fastest Laps') + '</h4>');
+						class_leaderboard_content.append(build_leaderboard(current_class.leaderboard.by_fastest_lap, 'by_fastest_lap', msg.meta));
+						class_leaderboard_content.append('<h4>' + __('Fastest 3 Consecutive Laps') + '</h4>');
+						class_leaderboard_content.append(build_leaderboard(current_class.leaderboard.by_consecutives, 'by_consecutives', msg.meta));
+
+						class_leaderboard.append(class_leaderboard_content);
+						class_panel_content.append(class_leaderboard);
+					} else {
+						if ($.isEmptyObject(msg.classes)) {
+							class_panel_header.append('<h2><button class="no-style">' + __('Heats') + '</button></h2>')
+						} else {
+							class_panel_header.append('<h2><button class="no-style">' + __('Unclassified') + '</button></h2>')
+						}
+					}
+
+					class_panel.append(class_panel_header);
+
+					class_panel.append(class_panel_content);
+					page.append(class_panel);
+				}
+
+				for (var panel in rotorhazard.panelstates) {
+					var panel_obj = $('#' + panel);
+					var panelstate = rotorhazard.panelstates[panel];
+
+					if (panelstate) {
+						panel_obj.addClass('open');
+						panel_obj.children('.panel-content').stop().slideDown();
+					} else {
+						panel_obj.removeClass('open');
+						panel_obj.children('.panel-content').stop().slideUp();
+					}
+				}
+			} else {
+				page.append('<p>' + __('There is no saved race data available to view.') + '</p>');
+			}
+		});
+
+               $('button#load_class_results').click(function (event) {
+
+                        if(!$(this).prop('disabled')) {
+			        $('.results_display').empty()
+			        $('.results_display').html('<p> {{ __('Loading...') }} </p>')
+                                $(this).prop('disabled', true);
+                                socket.emit('load_data', {'load_types': [ 'class_round_data', ], 'specific_class' : $('#set_current_class').val() } );
+                        }
+                        return false;
+                });
+               $('button#load_all_results').click(function (event) {
+
+                        if(!$(this).prop('disabled')) {
+			        $('.results_display').empty()
+			        $('.results_display').html('<p> {{ __('Loading...') }} </p>')
+                                $(this).prop('disabled', true);
+                                socket.emit('load_data', {'load_types': [ 'round_data', ],  } );
+                        }
+                        return false;
+                });
+
+               $('button#load_pilot_results').click(function (event) {
+
+                        if(!$(this).prop('disabled')) {
+			        $('.race-view').html(' {{ __('Loading...') }}  <table id="laps"> </table>')
+                                $(this).prop('disabled', true);
+                                socket.emit('load_data', {'load_types': [ 'race_list', ],  } );
+                        }
+                        return false;
+                });
+
+		$('#selected_heat').change(function(){
+			var prev_round = $('#selected_round').val();
+
+			$('#selected_round').empty();
+
+			var heat = parseInt($(this).val());
+
+			for (var round_i in race_list.heats[heat].rounds) {
+				$('#selected_round').append('<option value="' + round_i + '">' + __('Round') + ' ' + round_i + '</option>');
+			}
+
+			$('#selected_round').val(round_i);
+			$('#selected_round option').each(function(){
+				if (this.value == prev_round) {
+					$('#selected_round').val(prev_round);
+					return false;
+				}
+			});
+
+
+			$('#selected_round').trigger('change');
+		});
+
+		$('#selected_round').change(function(){
+			var prev_pilot = $('#selected_pilot').data('pilot-id');
+
+			$('#selected_pilot').empty();
+
+			var heat = parseInt($('#selected_heat').val());
+			var round = parseInt($(this).val());
+
+			for (var pilot_i in race_list.heats[heat].rounds[round].pilotraces) {
+				var pilotrace = race_list.heats[heat].rounds[round].pilotraces[pilot_i];
+				$('#selected_pilot').append('<option value="' + pilot_i + '" data-pilot-id="' + pilotrace.pilot_id + '">' + pilotrace.callsign + '</option>');
+			}
+
+			$('#selected_pilot option').each(function(){
+				if ($(this).data('pilot-id') == prev_pilot) {
+					$('#selected_pilot').val($(this).val());
+					return false;
+				}
+			});
+
+
+			$('#selected_pilot').trigger('change');
+		});
+
+		$('#selected_pilot').change(function(){
+			var heat = parseInt($('#selected_heat').val());
+			var round = parseInt($('#selected_round').val());
+			var pilot = parseInt($(this).val());
+			var pilotrace = race_list.heats[heat].rounds[round].pilotraces[pilot];
+
+			$(this).data('pilot-id', pilotrace.pilot_id);
+
+			load_race();
+		});
+
+		function load_race() {
+                        table_html='<thead> <tr> <th>{{ __('Lap') }}</th> <th>{{ __('Timestamp') }}</th> <th>{{ __('Lap Time') }}</th> </tr> </thead> <tbody></tbody>'
+			$('.race-view').html(' <table id="laps"> ' + table_html + '</table>')
+
+			var lapList = $('#laps tbody');
+			lapList.empty();
+
+			race_loaded = true;
+
+			var heat = parseInt($('#selected_heat').val());
+			var round = parseInt($('#selected_round').val());
+			var pilot = parseInt($('#selected_pilot').val());
+
+
+			// load current race data
+			current_race_data = jQuery.extend(true, {}, race_list.heats[heat].rounds[round].pilotraces[pilot]);
+			// fill current data with race meta
+			current_race_data.round_id = round;
+			current_race_data.heat_id = heat;
+			current_race_data.race_id = race_list.heats[heat].rounds[round].race_id;
+			current_race_data.class_id = race_list.heats[heat].rounds[round].class_id;
+			current_race_data.format_id = race_list.heats[heat].rounds[round].format_id;
+			current_race_data.start_time = race_list.heats[heat].rounds[round].start_time;
+			current_race_data.start_time_formatted = race_list.heats[heat].rounds[round].start_time_formatted;
+
+			// populate laps
+			displayLaps(current_race_data.laps);
+
+			return false;
+		}
+
+
+			function displayLaps(laps_obj) {
+				var lapList = $('#laps tbody');
+				var lap_index = 0;
+				for (var lap_i in laps_obj) {
+					var lap = laps_obj[lap_i];
+					var lapData = $('<tr>');
+
+					if (lap.deleted) {
+						lapData.addClass('lap-deleted');
+					} else if (lap_index && lap.lap_time < min_lap) {
+						lapData.addClass('min-lap-warning');
+					}
+
+					if (!lap.deleted) {
+						lapData.append('<td>' + lap_index + '</td>');
+						lapData.append('<td>' + (lap.lap_time_stamp / 1000).toFixed(3) + '</td>');
+						lapData.append('<td>' + formatTimeMillis(lap.lap_time) + '</td>');
+						lap_index++;
+					} else {
+						lapData.append('<td>-</td>');
+						lapData.append('<td>' + (lap.lap_time_stamp / 1000).toFixed(3) + '</td>');
+						lapData.append('<td>' + __('Deleted') + '</td>');
+					}
+
+					lapList.append(lapData);
+				}
+			}
+
+		});
+	</script>
+	<main class="page-rounds">
+
+			<div class="control-set">
+				<label for="selected_heat" class="screen-reader-text">{{ __('Heat') }}</label>
+				<select id="selected_heat" disabled>
+					<option value="--">{{ __('Not Loaded') }}</option>
+				</select>
+
+				<label for="selected_round" class="screen-reader-text">{{ __('Round') }}</label>
+				<select id="selected_round" disabled>
+					<option value="--">{{ __('Not Loaded') }}</option>
+				</select>
+
+				<label for="selected_pilot" class="screen-reader-text">{{ __('Pilot') }}</label>
+				<select id="selected_pilot" disabled>
+					<option value="--">{{ __('Not Loaded') }}</option>
+				</select>
+				<button id="load_pilot_results"><span class="narrow">{{ __('Get') }}</span><span class="wide">{{ __('Load Race') }}</span></button>
+
+			</div>
+
+			<div id="race-display">
+
+				<div id="race-view" class="race-view">
+				</div>
+
+			</div>
+			<div class="control-set">
+				<label for="set_current_class" class="screen-reader-text">{{ __('Current Class') }}</label>
+				<select id="set_current_class">
+					<option value="">{{ __('Loading...') }}</option>
+				</select>
+				<button id="load_class_results"><span class="narrow">{{ __('Get') }}</span><span class="wide">{{ __('Class Summary') }}</span></button>
+				 <!-- change line below to <p class="admin-hide"> if you only want admins to see this button  -->
+				<p><button id="load_all_results"><span class="narrow">{{ __('GetSummary') }}</span><span class="wide">{{ __('All') }} {{ __('Results') }}</span></button> </p>
+			</div>
+
+			<div id="id=results_display" class="results_display">
+			   <p>Select class and press {{__('Class Summary')}} button</p>
+			</div>
+
+
+	</main>
 {% endblock %}

--- a/src/server/templates/settings.html
+++ b/src/server/templates/settings.html
@@ -577,9 +577,9 @@
 
                 $('button#generate_heats').click(function (event) {
                         var data = {
-                                generator_input_class: parseInt($(this).data('generator_input_class')),
-                                pilots_per_heat: parseInt($(this).data('pilots_per_heat')),
-                                win_condition: parseInt($(this).data('win_condition'))
+                                generator_input_class: $('#generator_input_class').val(),
+                                pilots_per_heat: $('#pilots_per_heat').val(),
+                                win_condition: $('#win_condition').val(),
                         };
                         socket.emit('generate_heats', data);
                         return false;
@@ -1479,8 +1479,9 @@
 		<div class="control-set">
 				<button id="add_heat">+ {{ __('Add Heat') }}</button>
                                 <h2>Advanced heat generator</h2> 
+                                <p>For generating main event heats based on results from existing class</p>
 
-			        <label for="generator_input_class">{{ __('input class') }}</label>
+			        <label for="generator_input_class">{{ __('Input class') }}</label>
 			        <select id="generator_input_class">
 			     	    <option>{{ __('Loading...') }}</option>
 			        </select>
@@ -1492,7 +1493,7 @@
 				</select>
                                 <br>
 				<label> pilots per heat <input type="number" id="pilots_per_heat" value="4" min="1" max="8" >  </label>
-				<button class="generate_heats" >{{ __('Generate Heat') }}</button>
+				<button id="generate_heats">{{ __('Generate Heats') }}</button>
 				<button id="delete_last_heat">- {{ __('Delete Last Heat') }}</button>
 
 		</div>

--- a/src/server/templates/settings.html
+++ b/src/server/templates/settings.html
@@ -488,6 +488,8 @@
 					return 1;
 				return 0;
 			});
+                        $('button#delete_last_heat').prop('disabled', false);
+                        $('button#generate_heats').prop('disabled', false);
 
 			$(".heats").empty();
 			for (var i in msg.heats) {
@@ -572,6 +574,7 @@
 
 		$('button#delete_last_heat').click(function (event) {
 			socket.emit('delete_last_heat');
+                        $('button#delete_last_heat').prop('disabled', true);
 			return false;
 		});
 
@@ -581,6 +584,7 @@
                                 pilots_per_heat: $('#pilots_per_heat').val(),
                                 win_condition: $('#win_condition').val(),
                         };
+                        $('button#generate_heats').prop('disabled', true);
                         socket.emit('generate_heats', data);
                         return false;
                 });
@@ -588,11 +592,13 @@
 		socket.on('class_data', function (msg) {
 			$(".race_classes").empty();
 
+                        $('#generator_input_class').empty();
+			opt = '<option value="0">Unclassified</option>'
+                        $('#generator_input_class').append(opt);
 			if (msg.classes.length) {
 				$('.race_classes').append('<p class="form-note">' + __('Selections cannot be modified for classes with saved races. (Clear races to release.)') + '</p>');
 
 				var classlist = $('<ol>');
-                                $('#generator_input_class').empty();
 				for (var i in msg.classes) {
 					var race_class = msg.classes[i];
 					opt = '<option value="' + msg.classes[i].id + '">' + msg.classes[i].name + '</option>'
@@ -619,7 +625,6 @@
 					el.appendTo(classlist);
 				}
 				classlist.appendTo($('.race_classes'));
-
 			} else {
 				$('.race_classes').append('<p class="form-note">' + __('No classes are defined; this will be a single-class event.') + '</p>');
 			}
@@ -1499,126 +1504,126 @@
 		</div>
 	</div>
 
-	<!--Pilots list for editing-->
-	<div class="panel collapsing">
-		<div class="panel-header">
-			<h2>{{ __('Pilots') }}</h2>
-		</div>
-		<div class="panel-content">
-			<ul class="pilots">
-				<li>{{ __('Loading...') }}</li>
-			</ul>
+<!--Pilots list for editing-->
+<div class="panel collapsing">
+	<div class="panel-header">
+		<h2>{{ __('Pilots') }}</h2>
+	</div>
+	<div class="panel-content">
+		<ul class="pilots">
+			<li>{{ __('Loading...') }}</li>
+		</ul>
 
-			<div class="control-set">
-				<button id="add_pilot">+ {{ __('Add Pilot') }}</button>
-			</div>
+		<div class="control-set">
+			<button id="add_pilot">+ {{ __('Add Pilot') }}</button>
 		</div>
 	</div>
+</div>
 
-	<!--Voice Settings-->
-	<div class="panel collapsing">
-		<div class="panel-header">
-			<h2>{{ __('Audio Control') }}</h2>
-		</div>
-		<div class="panel-content">
-			<p class="form-note">{{ __('Voice settings apply to this device only.') }}</p>
-			<ol class="form">
-				<li>
-					<div class="label-block">
-						<label for="set_voice_language">{{ __('Voice Select') }}</label>
-					</div>
-					<div id="voice_select"></div>
-				</li>
-				<li>
-					<div class="label-block">
-						<label for="set_voice_string_language">{{ __('Voice Language') }}</label>
-					</div>
-					<select id="set_voice_string_language">
-						<option>{{ __('Loading...') }}</option>
-					</select>
-				</li>
-				<li>
-					<div class="label-block">
-						{{ __('Voice Test') }} &nbsp; &nbsp;
-					</div>
-					<input type="text" id="voice_test_text" value="{{ getOption('timerName') }}">
-					<button class="button" id="play_voice_test">&#9658;&#65038; <span class="screen-reader-text">{{ __('Play') }}</span></button>
-				</li>
-				<li>
-					<div class="label-block">
-						{{ __('Announcements') }}
-					</div>
-					<ul>
-						<li><label><input type="checkbox" id="voice_callsign"> {{ __('Callsign') }}</label></li>
-						<li><label><input type="checkbox" id="voice_lap_count"> {{ __('Lap Number') }}</label></li>
-						<li><label><input type="checkbox" id="voice_lap_time"> {{ __('Lap Time') }}</label></li>
-						<li><label><input type="checkbox" id="voice_race_timer"> {{ __('Race Timer') }}</label></li>
-						<li><label><input type="checkbox" id="voice_team_lap_count"> {{ __('Team Lap Total') }}</label></li>
-						<li><label><input type="checkbox" id="voice_race_winner"> {{ __('Race Winner') }}</label></li>
-					</ul>
-				</li>
-				<li>
-					<div class="label-block">
-						<label for="set_voice_volume">{{ __('Voice Volume') }}</label>
-						<p class="desc">{{ __('Volume') }}: <span id="voice_volume_value"></span></p>
-					</div>
-					<input type="range" id="set_voice_volume" min="1" max="100">
-				</li>
-				<li>
-					<div class="label-block">
-						<label for="set_voice_rate">{{ __('Voice Rate') }}</label>
-						<p class="desc">{{ __('Rate') }}: <span id="voice_rate_value"></span></p>
-					</div>
-					<input type="range" id="set_voice_rate" min="0" max="2.0" step="0.01">
-				</li>
-				<li>
-					<div class="label-block">
-						<label for="set_voice_pitch">{{ __('Voice Pitch') }}</label>
-						<p class="desc">{{ __('Pitch') }}: <span id="voice_pitch_value"></span></p>
-					</div>
-					<input type="range" id="set_voice_pitch" min="0" max="2.0" step="0.01">
-				</li>
-				<li>
-					<div class="label-block">
-						<label for="set_tone_volume">{{ __('Tone Volume') }}</label>
-						<p class="desc">{{ __('Volume') }}: <span id="tone_volume_value"></span></p>
-					</div>
-					<input type="range" id="set_tone_volume" min="1" max="100">
-				</li>
-				<li>
-					<div class="label-block">
-						{{ __('Indicator Beeps') }}
-					</div>
-					<ul>
-						<li><label><input type="checkbox" id="beep_on_first_pass_button"> {{ __('On First Pass') }}</label></li>
-						<li><label><input type="checkbox" id="beep_crossing_entered"> {{ __('Crossing Entered') }}</label></li>
-						<li><label><input type="checkbox" id="beep_crossing_exited"> {{ __('Crossing Exited') }}</label></li>
-						<li><label><input type="checkbox" id="beep_manual_lap_button"> {{ __('Manual Lap Button') }}</label></li>
-						<li><label><input type="checkbox" id="use_mp3_tones"> {{ __('Use MP3 Tones instead of synthetic tones') }}</label></li>
-					</ul>
-				</li>
-				<li>
-					<div class="label-block">
-						<label for="set_indicator_volume">{{ __('Indicator Beeps Volume') }}</label>
-						<p class="desc">{{ __('Volume') }}: <span id="indicator_volume_value"></span></p>
-					</div>
-					<input type="range" id="set_indicator_volume" min="1" max="100">
-				</li>
-			</ol>
-		</div>
+<!--Voice Settings-->
+<div class="panel collapsing">
+	<div class="panel-header">
+		<h2>{{ __('Audio Control') }}</h2>
 	</div>
+	<div class="panel-content">
+		<p class="form-note">{{ __('Voice settings apply to this device only.') }}</p>
+		<ol class="form">
+			<li>
+				<div class="label-block">
+					<label for="set_voice_language">{{ __('Voice Select') }}</label>
+				</div>
+				<div id="voice_select"></div>
+			</li>
+			<li>
+				<div class="label-block">
+					<label for="set_voice_string_language">{{ __('Voice Language') }}</label>
+				</div>
+				<select id="set_voice_string_language">
+					<option>{{ __('Loading...') }}</option>
+				</select>
+			</li>
+			<li>
+				<div class="label-block">
+					{{ __('Voice Test') }} &nbsp; &nbsp;
+				</div>
+				<input type="text" id="voice_test_text" value="{{ getOption('timerName') }}">
+				<button class="button" id="play_voice_test">&#9658;&#65038; <span class="screen-reader-text">{{ __('Play') }}</span></button>
+			</li>
+			<li>
+				<div class="label-block">
+					{{ __('Announcements') }}
+				</div>
+				<ul>
+					<li><label><input type="checkbox" id="voice_callsign"> {{ __('Callsign') }}</label></li>
+					<li><label><input type="checkbox" id="voice_lap_count"> {{ __('Lap Number') }}</label></li>
+					<li><label><input type="checkbox" id="voice_lap_time"> {{ __('Lap Time') }}</label></li>
+					<li><label><input type="checkbox" id="voice_race_timer"> {{ __('Race Timer') }}</label></li>
+					<li><label><input type="checkbox" id="voice_team_lap_count"> {{ __('Team Lap Total') }}</label></li>
+					<li><label><input type="checkbox" id="voice_race_winner"> {{ __('Race Winner') }}</label></li>
+				</ul>
+			</li>
+			<li>
+				<div class="label-block">
+					<label for="set_voice_volume">{{ __('Voice Volume') }}</label>
+					<p class="desc">{{ __('Volume') }}: <span id="voice_volume_value"></span></p>
+				</div>
+				<input type="range" id="set_voice_volume" min="1" max="100">
+			</li>
+			<li>
+				<div class="label-block">
+					<label for="set_voice_rate">{{ __('Voice Rate') }}</label>
+					<p class="desc">{{ __('Rate') }}: <span id="voice_rate_value"></span></p>
+				</div>
+				<input type="range" id="set_voice_rate" min="0" max="2.0" step="0.01">
+			</li>
+			<li>
+				<div class="label-block">
+					<label for="set_voice_pitch">{{ __('Voice Pitch') }}</label>
+					<p class="desc">{{ __('Pitch') }}: <span id="voice_pitch_value"></span></p>
+				</div>
+				<input type="range" id="set_voice_pitch" min="0" max="2.0" step="0.01">
+			</li>
+			<li>
+				<div class="label-block">
+					<label for="set_tone_volume">{{ __('Tone Volume') }}</label>
+					<p class="desc">{{ __('Volume') }}: <span id="tone_volume_value"></span></p>
+				</div>
+				<input type="range" id="set_tone_volume" min="1" max="100">
+			</li>
+			<li>
+				<div class="label-block">
+					{{ __('Indicator Beeps') }}
+				</div>
+				<ul>
+					<li><label><input type="checkbox" id="beep_on_first_pass_button"> {{ __('On First Pass') }}</label></li>
+					<li><label><input type="checkbox" id="beep_crossing_entered"> {{ __('Crossing Entered') }}</label></li>
+					<li><label><input type="checkbox" id="beep_crossing_exited"> {{ __('Crossing Exited') }}</label></li>
+					<li><label><input type="checkbox" id="beep_manual_lap_button"> {{ __('Manual Lap Button') }}</label></li>
+					<li><label><input type="checkbox" id="use_mp3_tones"> {{ __('Use MP3 Tones instead of synthetic tones') }}</label></li>
+				</ul>
+			</li>
+			<li>
+				<div class="label-block">
+					<label for="set_indicator_volume">{{ __('Indicator Beeps Volume') }}</label>
+					<p class="desc">{{ __('Volume') }}: <span id="indicator_volume_value"></span></p>
+				</div>
+				<input type="range" id="set_indicator_volume" min="1" max="100">
+			</li>
+		</ol>
+	</div>
+</div>
 
-	<!--Race Format-->
-	<div class="panel collapsing">
-		<div class="panel-header">
-			<h2>{{ __('Race Format') }}</h2>
-		</div>
-		<div class="panel-content">
-			<p class="form-note">{{ __('Formats used with saved races cannot be modified. (Clear races to release.)') }}</p>
-			<p class="form-note">{{ __('Format cannot be changed while a race is running.') }}</p>
+<!--Race Format-->
+<div class="panel collapsing">
+	<div class="panel-header">
+		<h2>{{ __('Race Format') }}</h2>
+	</div>
+	<div class="panel-content">
+		<p class="form-note">{{ __('Formats used with saved races cannot be modified. (Clear races to release.)') }}</p>
+		<p class="form-note">{{ __('Format cannot be changed while a race is running.') }}</p>
 
-			<div class="control-set">
-				<label for="set_race_format">{{ __('Format:') }}</label>
+		<div class="control-set">
+			<label for="set_race_format">{{ __('Format:') }}</label>
 			<select id="set_race_format">
 				<option>{{ __('Loading...') }}</option>
 			</select>

--- a/src/server/templates/settings.html
+++ b/src/server/templates/settings.html
@@ -575,15 +575,15 @@
 			return false;
 		});
 
-		$('button#generate_heats').click(function (event) {
-			var data = {
-				class: parseInt($(this).data('generator_input_class')),
-				num_pilots: parseInt($(this).data('pilots_per_heat')),
-				win_condition: parseInt($(this).data('win_condition'))
-			};
-			socket.emit('generate_heats', data);
-			return false;
-		});
+                $('button#generate_heats').click(function (event) {
+                        var data = {
+                                generator_input_class: parseInt($(this).data('generator_input_class')),
+                                pilots_per_heat: parseInt($(this).data('pilots_per_heat')),
+                                win_condition: parseInt($(this).data('win_condition'))
+                        };
+                        socket.emit('generate_heats', data);
+                        return false;
+                });
 
 		socket.on('class_data', function (msg) {
 			$(".race_classes").empty();
@@ -1478,8 +1478,7 @@
 		</ol>
 		<div class="control-set">
 				<button id="add_heat">+ {{ __('Add Heat') }}</button>
-				<button id="delete_last_heat">+ {{ __('Delete Last Heat') }}</button>
-                                <p>Advanced heat generator</p> 
+                                <h2>Advanced heat generator</h2> 
 
 			        <label for="generator_input_class">{{ __('input class') }}</label>
 			        <select id="generator_input_class">
@@ -1494,6 +1493,7 @@
                                 <br>
 				<label> pilots per heat <input type="number" id="pilots_per_heat" value="4" min="1" max="8" >  </label>
 				<button class="generate_heats" >{{ __('Generate Heat') }}</button>
+				<button id="delete_last_heat">- {{ __('Delete Last Heat') }}</button>
 
 		</div>
 	</div>

--- a/src/server/templates/settings.html
+++ b/src/server/templates/settings.html
@@ -570,6 +570,21 @@
 			return false;
 		});
 
+		$('button#delete_last_heat').click(function (event) {
+			socket.emit('delete_last_heat');
+			return false;
+		});
+
+		$('button#generate_heats').click(function (event) {
+			var data = {
+				class: parseInt($(this).data('generator_input_class')),
+				num_pilots: parseInt($(this).data('pilots_per_heat')),
+				win_condition: parseInt($(this).data('win_condition'))
+			};
+			socket.emit('generate_heats', data);
+			return false;
+		});
+
 		socket.on('class_data', function (msg) {
 			$(".race_classes").empty();
 
@@ -577,8 +592,11 @@
 				$('.race_classes').append('<p class="form-note">' + __('Selections cannot be modified for classes with saved races. (Clear races to release.)') + '</p>');
 
 				var classlist = $('<ol>');
+                                $('#generator_input_class').empty();
 				for (var i in msg.classes) {
 					var race_class = msg.classes[i];
+					opt = '<option value="' + msg.classes[i].id + '">' + msg.classes[i].name + '</option>'
+                                        $('#generator_input_class').append(opt);
 					var el = $('<li>');
 					el.append('<h3>' + __('Class') + ' ' + race_class.id + '</h3>');
 					var input = $('<input type="text" id="race_class_name-' + race_class.id + '" class="set_race_class_name" data-class_id="' + race_class.id + '" placeholder="' + __('Name') + ' (' + __('Class') + ' ' + race_class.id + ')" maxlength="80">');
@@ -601,6 +619,7 @@
 					el.appendTo(classlist);
 				}
 				classlist.appendTo($('.race_classes'));
+
 			} else {
 				$('.race_classes').append('<p class="form-note">' + __('No classes are defined; this will be a single-class event.') + '</p>');
 			}
@@ -1458,131 +1477,147 @@
 			<li>{{ __('Loading...') }}</li>
 		</ol>
 		<div class="control-set">
-			<button id="add_heat">+ {{ __('Add Heat') }}</button>
-		</div>
-	</div>
-</div>
+				<button id="add_heat">+ {{ __('Add Heat') }}</button>
+				<button id="delete_last_heat">+ {{ __('Delete Last Heat') }}</button>
+                                <p>Advanced heat generator</p> 
 
-<!--Pilots list for editing-->
-<div class="panel collapsing">
-	<div class="panel-header">
-		<h2>{{ __('Pilots') }}</h2>
-	</div>
-	<div class="panel-content">
-		<ul class="pilots">
-			<li>{{ __('Loading...') }}</li>
-		</ul>
-
-		<div class="control-set">
-			<button id="add_pilot">+ {{ __('Add Pilot') }}</button>
-		</div>
-	</div>
-</div>
-
-<!--Voice Settings-->
-<div class="panel collapsing">
-	<div class="panel-header">
-		<h2>{{ __('Audio Control') }}</h2>
-	</div>
-	<div class="panel-content">
-		<p class="form-note">{{ __('Voice settings apply to this device only.') }}</p>
-		<ol class="form">
-			<li>
-				<div class="label-block">
-					<label for="set_voice_language">{{ __('Voice Select') }}</label>
-				</div>
-				<div id="voice_select"></div>
-			</li>
-			<li>
-				<div class="label-block">
-					<label for="set_voice_string_language">{{ __('Voice Language') }}</label>
-				</div>
-				<select id="set_voice_string_language">
-					<option>{{ __('Loading...') }}</option>
+			        <label for="generator_input_class">{{ __('input class') }}</label>
+			        <select id="generator_input_class">
+			     	    <option>{{ __('Loading...') }}</option>
+			        </select>
+				<label for="win_condition">{{ __('Win Condition') }}</label>
+				<select id="win_condition">
+					<option value="1">{{ __('Most Laps') }}</option>
+					<option value="3">{{ __('Fastest Lap') }}</option>
+					<option value="4">{{ __('Fastest 3 Consecutive Laps') }}</option>
 				</select>
-			</li>
-			<li>
-				<div class="label-block">
-					{{ __('Voice Test') }} &nbsp; &nbsp;
-				</div>
-				<input type="text" id="voice_test_text" value="{{ getOption('timerName') }}">
-				<button class="button" id="play_voice_test">&#9658;&#65038; <span class="screen-reader-text">{{ __('Play') }}</span></button>
-			</li>
-			<li>
-				<div class="label-block">
-					{{ __('Announcements') }}
-				</div>
-				<ul>
-					<li><label><input type="checkbox" id="voice_callsign"> {{ __('Callsign') }}</label></li>
-					<li><label><input type="checkbox" id="voice_lap_count"> {{ __('Lap Number') }}</label></li>
-					<li><label><input type="checkbox" id="voice_lap_time"> {{ __('Lap Time') }}</label></li>
-					<li><label><input type="checkbox" id="voice_race_timer"> {{ __('Race Timer') }}</label></li>
-					<li><label><input type="checkbox" id="voice_team_lap_count"> {{ __('Team Lap Total') }}</label></li>
-					<li><label><input type="checkbox" id="voice_race_winner"> {{ __('Race Winner') }}</label></li>
-				</ul>
-			</li>
-			<li>
-				<div class="label-block">
-					<label for="set_voice_volume">{{ __('Voice Volume') }}</label>
-					<p class="desc">{{ __('Volume') }}: <span id="voice_volume_value"></span></p>
-				</div>
-				<input type="range" id="set_voice_volume" min="1" max="100">
-			</li>
-			<li>
-				<div class="label-block">
-					<label for="set_voice_rate">{{ __('Voice Rate') }}</label>
-					<p class="desc">{{ __('Rate') }}: <span id="voice_rate_value"></span></p>
-				</div>
-				<input type="range" id="set_voice_rate" min="0" max="2.0" step="0.01">
-			</li>
-			<li>
-				<div class="label-block">
-					<label for="set_voice_pitch">{{ __('Voice Pitch') }}</label>
-					<p class="desc">{{ __('Pitch') }}: <span id="voice_pitch_value"></span></p>
-				</div>
-				<input type="range" id="set_voice_pitch" min="0" max="2.0" step="0.01">
-			</li>
-			<li>
-				<div class="label-block">
-					<label for="set_tone_volume">{{ __('Tone Volume') }}</label>
-					<p class="desc">{{ __('Volume') }}: <span id="tone_volume_value"></span></p>
-				</div>
-				<input type="range" id="set_tone_volume" min="1" max="100">
-			</li>
-			<li>
-				<div class="label-block">
-					{{ __('Indicator Beeps') }}
-				</div>
-				<ul>
-					<li><label><input type="checkbox" id="beep_on_first_pass_button"> {{ __('On First Pass') }}</label></li>
-					<li><label><input type="checkbox" id="beep_crossing_entered"> {{ __('Crossing Entered') }}</label></li>
-					<li><label><input type="checkbox" id="beep_crossing_exited"> {{ __('Crossing Exited') }}</label></li>
-					<li><label><input type="checkbox" id="beep_manual_lap_button"> {{ __('Manual Lap Button') }}</label></li>
-					<li><label><input type="checkbox" id="use_mp3_tones"> {{ __('Use MP3 Tones instead of synthetic tones') }}</label></li>
-				</ul>
-			</li>
-			<li>
-				<div class="label-block">
-					<label for="set_indicator_volume">{{ __('Indicator Beeps Volume') }}</label>
-					<p class="desc">{{ __('Volume') }}: <span id="indicator_volume_value"></span></p>
-				</div>
-				<input type="range" id="set_indicator_volume" min="1" max="100">
-			</li>
-		</ol>
-	</div>
-</div>
+                                <br>
+				<label> pilots per heat <input type="number" id="pilots_per_heat" value="4" min="1" max="8" >  </label>
+				<button class="generate_heats" >{{ __('Generate Heat') }}</button>
 
-<!--Race Format-->
-<div class="panel collapsing">
-	<div class="panel-header">
-		<h2>{{ __('Race Format') }}</h2>
+		</div>
 	</div>
-	<div class="panel-content">
-		<p class="form-note">{{ __('Formats used with saved races cannot be modified. (Clear races to release.)') }}</p>
-		<p class="form-note">{{ __('Format cannot be changed while a race is running.') }}</p>
 
-		<div class="control-set">
-			<label for="set_race_format">{{ __('Format:') }}</label>
+	<!--Pilots list for editing-->
+	<div class="panel collapsing">
+		<div class="panel-header">
+			<h2>{{ __('Pilots') }}</h2>
+		</div>
+		<div class="panel-content">
+			<ul class="pilots">
+				<li>{{ __('Loading...') }}</li>
+			</ul>
+
+			<div class="control-set">
+				<button id="add_pilot">+ {{ __('Add Pilot') }}</button>
+			</div>
+		</div>
+	</div>
+
+	<!--Voice Settings-->
+	<div class="panel collapsing">
+		<div class="panel-header">
+			<h2>{{ __('Audio Control') }}</h2>
+		</div>
+		<div class="panel-content">
+			<p class="form-note">{{ __('Voice settings apply to this device only.') }}</p>
+			<ol class="form">
+				<li>
+					<div class="label-block">
+						<label for="set_voice_language">{{ __('Voice Select') }}</label>
+					</div>
+					<div id="voice_select"></div>
+				</li>
+				<li>
+					<div class="label-block">
+						<label for="set_voice_string_language">{{ __('Voice Language') }}</label>
+					</div>
+					<select id="set_voice_string_language">
+						<option>{{ __('Loading...') }}</option>
+					</select>
+				</li>
+				<li>
+					<div class="label-block">
+						{{ __('Voice Test') }} &nbsp; &nbsp;
+					</div>
+					<input type="text" id="voice_test_text" value="{{ getOption('timerName') }}">
+					<button class="button" id="play_voice_test">&#9658;&#65038; <span class="screen-reader-text">{{ __('Play') }}</span></button>
+				</li>
+				<li>
+					<div class="label-block">
+						{{ __('Announcements') }}
+					</div>
+					<ul>
+						<li><label><input type="checkbox" id="voice_callsign"> {{ __('Callsign') }}</label></li>
+						<li><label><input type="checkbox" id="voice_lap_count"> {{ __('Lap Number') }}</label></li>
+						<li><label><input type="checkbox" id="voice_lap_time"> {{ __('Lap Time') }}</label></li>
+						<li><label><input type="checkbox" id="voice_race_timer"> {{ __('Race Timer') }}</label></li>
+						<li><label><input type="checkbox" id="voice_team_lap_count"> {{ __('Team Lap Total') }}</label></li>
+						<li><label><input type="checkbox" id="voice_race_winner"> {{ __('Race Winner') }}</label></li>
+					</ul>
+				</li>
+				<li>
+					<div class="label-block">
+						<label for="set_voice_volume">{{ __('Voice Volume') }}</label>
+						<p class="desc">{{ __('Volume') }}: <span id="voice_volume_value"></span></p>
+					</div>
+					<input type="range" id="set_voice_volume" min="1" max="100">
+				</li>
+				<li>
+					<div class="label-block">
+						<label for="set_voice_rate">{{ __('Voice Rate') }}</label>
+						<p class="desc">{{ __('Rate') }}: <span id="voice_rate_value"></span></p>
+					</div>
+					<input type="range" id="set_voice_rate" min="0" max="2.0" step="0.01">
+				</li>
+				<li>
+					<div class="label-block">
+						<label for="set_voice_pitch">{{ __('Voice Pitch') }}</label>
+						<p class="desc">{{ __('Pitch') }}: <span id="voice_pitch_value"></span></p>
+					</div>
+					<input type="range" id="set_voice_pitch" min="0" max="2.0" step="0.01">
+				</li>
+				<li>
+					<div class="label-block">
+						<label for="set_tone_volume">{{ __('Tone Volume') }}</label>
+						<p class="desc">{{ __('Volume') }}: <span id="tone_volume_value"></span></p>
+					</div>
+					<input type="range" id="set_tone_volume" min="1" max="100">
+				</li>
+				<li>
+					<div class="label-block">
+						{{ __('Indicator Beeps') }}
+					</div>
+					<ul>
+						<li><label><input type="checkbox" id="beep_on_first_pass_button"> {{ __('On First Pass') }}</label></li>
+						<li><label><input type="checkbox" id="beep_crossing_entered"> {{ __('Crossing Entered') }}</label></li>
+						<li><label><input type="checkbox" id="beep_crossing_exited"> {{ __('Crossing Exited') }}</label></li>
+						<li><label><input type="checkbox" id="beep_manual_lap_button"> {{ __('Manual Lap Button') }}</label></li>
+						<li><label><input type="checkbox" id="use_mp3_tones"> {{ __('Use MP3 Tones instead of synthetic tones') }}</label></li>
+					</ul>
+				</li>
+				<li>
+					<div class="label-block">
+						<label for="set_indicator_volume">{{ __('Indicator Beeps Volume') }}</label>
+						<p class="desc">{{ __('Volume') }}: <span id="indicator_volume_value"></span></p>
+					</div>
+					<input type="range" id="set_indicator_volume" min="1" max="100">
+				</li>
+			</ol>
+		</div>
+	</div>
+
+	<!--Race Format-->
+	<div class="panel collapsing">
+		<div class="panel-header">
+			<h2>{{ __('Race Format') }}</h2>
+		</div>
+		<div class="panel-content">
+			<p class="form-note">{{ __('Formats used with saved races cannot be modified. (Clear races to release.)') }}</p>
+			<p class="form-note">{{ __('Format cannot be changed while a race is running.') }}</p>
+
+			<div class="control-set">
+				<label for="set_race_format">{{ __('Format:') }}</label>
 			<select id="set_race_format">
 				<option>{{ __('Loading...') }}</option>
 			</select>


### PR DESCRIPTION
This code generates heats based on results of an already existing class. It is intended for 'letter' type mains, and generates the new heats from fastest pilots to slowest.

The user specifies:
-Class to use as input, (select box)
-Number of pilots per heat to generate
-win condition (total laps, fastest lap, fastest 3 consecutive)

Then press the 'generate heat' button.

The results are the pilots are placed in heats, preserving the frequency they were previously on if possible. If the frequency was already taken by a higher placing pilot, then the first available node index is used.

Also a delete last heat button is available now. It will only delete the highest heat id, IFF that heat has no race data associated, otherwise the delete operation does nothing.

Finally, the generator did rely on the caching, and specific class results generating back end code, so that is also in this pull request. (although there are no front end changes in this pull for the specific heat results, that will be in a different pull request).