### PR TITLE
Automatic calibration adjustment from saved race values

### DIFF
--- a/src/server/templates/settings.html
+++ b/src/server/templates/settings.html
@@ -1380,6 +1380,15 @@
 		<ol class="form">
 			<li>
 				<div class="label-block">
+					<label for="set_calibrationMode">{{ __('Calibration Mode') }}</label>
+				</div>
+				<select id="set_calibrationMode" class="set-option" data-option="calibrationMode">
+					<option value="0">{{ __('Manual') }}</option>
+					<option value="1">{{ __('Adaptive') }}</option>
+				</select>
+			</li>
+			<li>
+				<div class="label-block">
 					<label for="set_recovery_max_offset">{{ __('Missed Lap Offset') }}</label>
 					<p class="desc">{{ __('Adjusts EnterAt value after "Catch Missed Lap"') }}</p>
 				</div>


### PR DESCRIPTION
During race staging, timer looks at saved race history and copies the most likely useful calibration values to the nodes. In theory, this will prevent nodes from needing recalibrated when quads with very different power output are used on the same node.

* Uses saved enter/exit points from most recent saved race that matches same heat+node, same pilot+node+class, same pilot+node (any class), same node; or none (descending priority).
* Operates only when 'calibrationMode' option is enabled. UI is available from Sensor Tuning panel on Settings page.
* Changes made by marshaling are saved to race data, so are factored in

Settings page currently defaults to "manual" every time, this would need fixed before merging.

Current algorithm locks values to those used on the same node. (Done this way as node values are not useful from one to the next.) This will do nothing to prevent recalibration being necessary if the poorly-performing VTx changes to another node. Algorithm will also not account for temperature drift.

Comments and discussion are requested.

To consider:
* Robust and useful enough to merge in?
* Are the algorithm priorities correct? Any other conditions which would make a better guess?
* Should storing tuning values to Arduino EEPROM be disabled?