### PR TITLE
Staging tone options

### DIFF
--- a/src/server/server.py
+++ b/src/server/server.py
@@ -597,9 +597,14 @@ class RaceFormat(DB.Model):
     race_time_sec = DB.Column(DB.Integer, nullable=False)
     start_delay_min = DB.Column(DB.Integer, nullable=False)
     start_delay_max = DB.Column(DB.Integer, nullable=False)
+    staging_tones = DB.Column(DB.Integer, nullable=False)
     number_laps_win = DB.Column(DB.Integer, nullable=False)
     win_condition = DB.Column(DB.Integer, nullable=False)
     team_racing_mode = DB.Column(DB.Boolean, nullable=False)
+
+TONES_NONE = 0
+TONES_ONE = 1
+TONES_ALL = 2
 
 WIN_CONDITION_NONE = 0
 WIN_CONDITION_MOST_LAPS = 1
@@ -675,12 +680,13 @@ def setCurrentRaceFormat(race_format):
         RACE.format = race_format
 
 class RHRaceFormat():
-    def __init__(self, name, race_mode, race_time_sec, start_delay_min, start_delay_max, number_laps_win, win_condition, team_racing_mode):
+    def __init__(self, name, race_mode, race_time_sec, start_delay_min, start_delay_max, staging_tones, number_laps_win, win_condition, team_racing_mode):
         self.name = name
         self.race_mode = race_mode
         self.race_time_sec = race_time_sec
         self.start_delay_min = start_delay_min
         self.start_delay_max = start_delay_max
+        self.staging_tones = staging_tones
         self.number_laps_win = number_laps_win
         self.win_condition = win_condition
         self.team_racing_mode = team_racing_mode
@@ -692,6 +698,7 @@ class RHRaceFormat():
                             race_time_sec=race_format.race_time_sec,
                             start_delay_min=race_format.start_delay_min,
                             start_delay_max=race_format.start_delay_max,
+                            staging_tones=race_format.staging_tones,
                             number_laps_win=race_format.number_laps_win,
                             win_condition=race_format.win_condition,
                             team_racing_mode=race_format.team_racing_mode)
@@ -1717,6 +1724,7 @@ def on_add_race_format():
                              race_time_sec=source_format.race_time_sec ,
                              start_delay_min=source_format.start_delay_min,
                              start_delay_max=source_format.start_delay_max,
+                             staging_tones=source_format.staging_tones,
                              number_laps_win=source_format.number_laps_win,
                              win_condition=source_format.win_condition,
                              team_racing_mode=source_format.team_racing_mode)
@@ -1758,6 +1766,8 @@ def on_alter_race_format(data):
             race_format.start_delay_min = data['start_delay_min']
         if 'start_delay_max' in data:
             race_format.start_delay_max = data['start_delay_max']
+        if 'staging_tones' in data:
+            race_format.staging_tones = data['staging_tones']
         if 'number_laps_win' in data:
             race_format.number_laps_win = data['number_laps_win']
         if 'win_condition' in data:
@@ -1923,6 +1933,7 @@ def on_stage_race():
 
         SOCKET_IO.emit('stage_ready', {
             'hide_stage_timer': MIN != MAX,
+            'delay': DELAY,
             'race_mode': race_format.race_mode,
             'race_time_sec': race_format.race_time_sec,
             'pi_starts_at_s': RACE_START
@@ -2427,6 +2438,7 @@ def emit_race_status(**params):
             'race_status': RACE.race_status,
             'race_mode': race_format.race_mode,
             'race_time_sec': race_format.race_time_sec,
+            'race_staging_tones': race_format.staging_tones,
             'hide_stage_timer': race_format.start_delay_min != race_format.start_delay_max,
             'pi_starts_at_s': RACE_START
         }
@@ -2556,6 +2568,7 @@ def emit_race_format(**params):
         'race_time_sec': race_format.race_time_sec,
         'start_delay_min': race_format.start_delay_min,
         'start_delay_max': race_format.start_delay_max,
+        'staging_tones': race_format.staging_tones,
         'number_laps_win': race_format.number_laps_win,
         'win_condition': race_format.win_condition,
         'team_racing_mode': 1 if race_format.team_racing_mode else 0,
@@ -4164,6 +4177,7 @@ def db_reset_race_formats():
                              race_time_sec=120,
                              start_delay_min=2,
                              start_delay_max=5,
+                             staging_tones=2,
                              number_laps_win=0,
                              win_condition=WIN_CONDITION_MOST_LAPS,
                              team_racing_mode=False))
@@ -4172,6 +4186,7 @@ def db_reset_race_formats():
                              race_time_sec=90,
                              start_delay_min=2,
                              start_delay_max=5,
+                             staging_tones=2,
                              number_laps_win=0,
                              win_condition=WIN_CONDITION_MOST_LAPS,
                              team_racing_mode=False))
@@ -4180,6 +4195,7 @@ def db_reset_race_formats():
                              race_time_sec=210,
                              start_delay_min=2,
                              start_delay_max=5,
+                             staging_tones=2,
                              number_laps_win=0,
                              win_condition=WIN_CONDITION_MOST_LAPS,
                              team_racing_mode=False))
@@ -4188,14 +4204,16 @@ def db_reset_race_formats():
                              race_time_sec=0,
                              start_delay_min=2,
                              start_delay_max=5,
+                             staging_tones=2,
                              number_laps_win=3,
                              win_condition=WIN_CONDITION_FIRST_TO_LAP_X,
                              team_racing_mode=False))
     DB.session.add(RaceFormat(name=__("Open Practice"),
                              race_mode=1,
                              race_time_sec=0,
-                             start_delay_min=3,
-                             start_delay_max=3,
+                             start_delay_min=0,
+                             start_delay_max=0,
+                             staging_tones=0,
                              number_laps_win=0,
                              win_condition=WIN_CONDITION_NONE,
                              team_racing_mode=False))
@@ -4204,6 +4222,7 @@ def db_reset_race_formats():
                              race_time_sec=120,
                              start_delay_min=2,
                              start_delay_max=5,
+                             staging_tones=2,
                              number_laps_win=0,
                              win_condition=WIN_CONDITION_MOST_LAPS,
                              team_racing_mode=True))
@@ -4212,6 +4231,7 @@ def db_reset_race_formats():
                              race_time_sec=120,
                              start_delay_min=2,
                              start_delay_max=5,
+                             staging_tones=2,
                              number_laps_win=7,
                              win_condition=WIN_CONDITION_FIRST_TO_LAP_X,
                              team_racing_mode=True))
@@ -4498,6 +4518,7 @@ SLAVE_RACE_FORMAT = RHRaceFormat(name=__("Slave"),
                          race_time_sec=0,
                          start_delay_min=0,
                          start_delay_max=0,
+                         staging_tones=0,
                          number_laps_win=0,
                          win_condition=WIN_CONDITION_NONE,
                          team_racing_mode=False)

--- a/src/server/templates/race.html
+++ b/src/server/templates/race.html
@@ -20,6 +20,8 @@
 		rotorhazard.timer.race.count_up = Boolean(msg.race_mode);
 		rotorhazard.timer.race.duration = msg.race_time_sec;
 
+		rotorhazard.timer.race.max_delay = msg.delay;
+
 		rotorhazard.timer.race.start(rotorhazard.race_start_pi, rotorhazard.pi_time_diff);
 	}
 
@@ -192,6 +194,7 @@
 		socket.on('race_status', function (msg) {
 			rotorhazard.timer.race.count_up = Boolean(msg.race_mode);
 			rotorhazard.timer.race.duration = msg.race_time_sec;
+			rotorhazard.timer.race.staging_tones = msg.race_staging_tones;
 
 			switch (msg.race_status) {
 				case 1: // Race running

--- a/src/server/templates/settings.html
+++ b/src/server/templates/settings.html
@@ -123,6 +123,7 @@
 					$('#set_fix_race_time').prop('disabled', true);
 					$('#set_start_delay_min').prop('disabled', true);
 					$('#set_start_delay_max').prop('disabled', true);
+					$('#set_staging_tones').prop('disabled', true);
 					$('#set_number_laps_win').prop('disabled', true);
 					$('#set_win_condition').prop('disabled', true);
 					$('#set_team_racing_mode').prop('disabled', true);
@@ -136,6 +137,7 @@
 					$('#set_fix_race_time').prop('disabled', false);
 					$('#set_start_delay_min').prop('disabled', false);
 					$('#set_start_delay_max').prop('disabled', false);
+					$('#set_staging_tones').prop('disabled', false);
 					$('#set_number_laps_win').prop('disabled', false);
 					$('#set_win_condition').prop('disabled', false);
 					$('#set_team_racing_mode').prop('disabled', false);
@@ -919,6 +921,8 @@
 			$('#set_start_delay_min').prop('disabled', msg.locked);
 			$('#set_start_delay_max').val(msg.start_delay_max);
 			$('#set_start_delay_max').prop('disabled', msg.locked);
+			$('#set_staging_tones').val(msg.staging_tones);
+			$('#set_staging_tones').prop('disabled', msg.locked);
 			$('#set_number_laps_win').val(msg.number_laps_win);
 			$('#set_number_laps_win').prop('disabled', msg.locked);
 			$('#set_win_condition').val(msg.win_condition);
@@ -989,6 +993,13 @@
 		$('#set_number_laps_win').change(function (event) {
 			var data = {
 				number_laps_win: parseInt($(this).val())
+			};
+			socket.emit('alter_race_format', data);
+		})
+
+		$('#set_staging_tones').change(function (event) {
+			var data = {
+				staging_tones: parseInt($(this).val())
 			};
 			socket.emit('alter_race_format', data);
 		})
@@ -1676,6 +1687,16 @@
 						{{ __('Staging timer is hidden unless value matches Minimum Start Delay') }}</p>
 				</div>
 				<input type="number" id="set_start_delay_max" min="0" max="999">
+			</li>
+			<li>
+				<div class="label-block">
+					<label for="set_staging_tones">{{ __('Staging Tones') }}</label>
+				</div>
+				<select id="set_staging_tones">
+					<option value="2">{{ __('Each Second') }}</option>
+					<option value="1">{{ __('One') }}</option>
+					<option value="0">{{ __('None') }}</option>
+				</select>
 			</li>
 			<li>
 				<div class="label-block">


### PR DESCRIPTION
* Select from 'each second', 'one', or 'none'
* Preserves random or fixed staging times
* Suppress all when staging time is 0
* Store staging tone behavior in race format
* Suppress extra staging tones if browser sync is poor

Question: currently staging tones are limited to a maximum of 5. Should this be lifted with an additional option?

Based on work started by @RogerBFPV in #258 .
Resolves #93.