### PR TITLE
Global event system

### DIFF
--- a/src/server/eventmanager.py
+++ b/src/server/eventmanager.py
@@ -55,19 +55,6 @@ class EventManager:
                 return True
         return False
 
-'''
-Events.trigger(Event.RACESTAGE, None)
-
-Events.on(Event.RACESTAGE, 'LED', ledEffect(), {})
-
-Events.on(Event.RACESTAGE, 'OSD', osdEffect)
-
-Events.trigger(Evt.CROSSINGENTER, {
-    'nodeIndex': node_index,
-    'color': hexToColor(getOption('colorNode_' + str(node_index), '#ffffff'))
-    })
-'''
-
 class Evt:
     MANUAL = 'maunaul'
     RACESCHEDULE = 'raceSchedule'

--- a/src/server/eventmanager.py
+++ b/src/server/eventmanager.py
@@ -1,0 +1,83 @@
+'''
+RotorHazard event manager
+'''
+
+import gevent
+
+class EventManager:
+    processEventObj = gevent.event.Event()
+
+    events = {}
+    eventThreads = {}
+
+    def __init__(self):
+        pass
+
+    def on(self, event, name, handlerFn, defaultArgs=None, direct=False):
+        if event not in self.events:
+            self.events[event] = {}
+
+        self.events[event][name] = {
+            "handlerFn": handlerFn,
+            "defaultArgs": defaultArgs,
+            "direct": direct
+        }
+        return True
+
+    def trigger(self, event, evtArgs=None):
+        if event in self.events:
+            for name in self.events[event]:
+                handler = self.events[event][name]
+
+                args = handler['defaultArgs']
+                if evtArgs:
+                    if args:
+                        args.update(evtArgs)
+                    else:
+                        args = evtArgs
+
+                if handler['direct']:
+                    # stop any threads with same name
+                    if name in self.eventThreads:
+                        if self.eventThreads[name] is not None:
+                            self.eventThreads[name].kill()
+                            self.eventThreads[name] = None
+
+                    handler['handlerFn'](args)
+                else:
+                    # restart thread with same name regardless of status
+                    if name in self.eventThreads:
+                        if self.eventThreads[name] is not None:
+                            self.eventThreads[name].kill()
+
+                    self.eventThreads[name] = gevent.spawn(handler['handlerFn'], args)
+
+                return True
+        return False
+
+'''
+Events.trigger(Event.RACESTAGE, None)
+
+Events.on(Event.RACESTAGE, 'LED', ledEffect(), {})
+
+Events.on(Event.RACESTAGE, 'OSD', osdEffect)
+
+Events.trigger(Evt.CROSSINGENTER, {
+    'nodeIndex': node_index,
+    'color': hexToColor(getOption('colorNode_' + str(node_index), '#ffffff'))
+    })
+'''
+
+class Evt:
+    MANUAL = 'maunaul'
+    RACESCHEDULE = 'raceSchedule'
+    RACESTAGE = 'raceStage'
+    RACESTART = 'raceStart'
+    RACEFINISH = 'raceFinish'
+    RACESTOP = 'raceStop'
+    LAPSCLEAR = 'lapsClear'
+    RACEWIN = 'raceWin'
+    CROSSINGENTER = 'crossingEnter'
+    CROSSINGEXIT = 'crossingExit'
+    STARTUP = 'startup'
+    SHUTDOWN = 'shutdown'

--- a/src/server/eventmanager.py
+++ b/src/server/eventmanager.py
@@ -8,51 +8,56 @@ class EventManager:
     processEventObj = gevent.event.Event()
 
     events = {}
+    eventOrder = {}
     eventThreads = {}
 
     def __init__(self):
         pass
 
-    def on(self, event, name, handlerFn, defaultArgs=None, direct=False):
+    def on(self, event, name, handlerFn, defaultArgs=None, priority=200):
         if event not in self.events:
             self.events[event] = {}
 
         self.events[event][name] = {
             "handlerFn": handlerFn,
             "defaultArgs": defaultArgs,
-            "direct": direct
+            "priority": priority
         }
+
+        self.eventOrder[event] = sorted(self.events[event].items(), key=lambda x: x[1]['priority'])
+
         return True
 
     def trigger(self, event, evtArgs=None):
         if event in self.events:
-            for name in self.events[event]:
-                handler = self.events[event][name]
+            for handlerlist in self.eventOrder[event]:
+                for name in handlerlist:
+                    handler = self.events[event][name]
 
-                args = handler['defaultArgs']
-                if evtArgs:
-                    if args:
-                        args.update(evtArgs)
+                    args = handler['defaultArgs']
+                    if evtArgs:
+                        if args:
+                            args.update(evtArgs)
+                        else:
+                            args = evtArgs
+
+                    if handler['priority'] < 100:
+                        # stop any threads with same name
+                        if name in self.eventThreads:
+                            if self.eventThreads[name] is not None:
+                                self.eventThreads[name].kill()
+                                self.eventThreads[name] = None
+
+                        handler['handlerFn'](args)
                     else:
-                        args = evtArgs
+                        # restart thread with same name regardless of status
+                        if name in self.eventThreads:
+                            if self.eventThreads[name] is not None:
+                                self.eventThreads[name].kill()
 
-                if handler['direct']:
-                    # stop any threads with same name
-                    if name in self.eventThreads:
-                        if self.eventThreads[name] is not None:
-                            self.eventThreads[name].kill()
-                            self.eventThreads[name] = None
+                        self.eventThreads[name] = gevent.spawn(handler['handlerFn'], args)
 
-                    handler['handlerFn'](args)
-                else:
-                    # restart thread with same name regardless of status
-                    if name in self.eventThreads:
-                        if self.eventThreads[name] is not None:
-                            self.eventThreads[name].kill()
-
-                    self.eventThreads[name] = gevent.spawn(handler['handlerFn'], args)
-
-                return True
+                    return True
         return False
 
 class Evt:

--- a/src/server/led_event_manager.py
+++ b/src/server/led_event_manager.py
@@ -20,10 +20,10 @@ class LEDEventManager:
 
         # hold
         self.registerEffect("hold", "Hold", lambda *args: None,
-            [LEDEvent.NOCONTROL, LEDEvent.RACESTAGE, LEDEvent.CROSSINGENTER, LEDEvent.CROSSINGEXIT, LEDEvent.RACESTART, LEDEvent.RACEFINISH, LEDEvent.RACESTOP, LEDEvent.LAPSCLEAR, LEDEvent.SHUTDOWN])
+            [LEDEvent.NOCONTROL, Evt.RACESTAGE, Evt.CROSSINGENTER, Evt.CROSSINGEXIT, Evt.RACESTART, Evt.RACEFINISH, Evt.RACESTOP, Evt.LAPSCLEAR, Evt.SHUTDOWN])
 
         # do nothing
-        self.registerEffect("none", "No Change", lambda *args: None, [LEDEvent.NOCONTROL, LEDEvent.RACESTAGE, LEDEvent.CROSSINGENTER, LEDEvent.CROSSINGEXIT, LEDEvent.RACESTART, LEDEvent.RACEFINISH, LEDEvent.RACESTOP, LEDEvent.LAPSCLEAR, LEDEvent.SHUTDOWN])
+        self.registerEffect("none", "No Change", lambda *args: None, [LEDEvent.NOCONTROL, Evt.RACESTAGE, Evt.CROSSINGENTER, Evt.CROSSINGEXIT, Evt.RACESTART, Evt.RACEFINISH, Evt.RACESTOP, Evt.LAPSCLEAR, Evt.SHUTDOWN])
 
 
     def isEnabled(self):
@@ -124,53 +124,42 @@ class ColorPattern:
 
 class LEDEvent:
     NOCONTROL = 'noControlDisplay'
-    MANUAL = 'manual'
-    RACESTAGE = 'raceStage'
-    RACESTART = 'raceStart'
-    RACEFINISH = 'raceFinish'
-    RACESTOP = 'raceStop'
-    LAPSCLEAR = 'lapsClear'
-    RACEWIN = 'raceWin'
-    CROSSINGENTER = 'crossingEnter'
-    CROSSINGEXIT = 'crossingExit'
-    STARTUP = 'startup'
-    SHUTDOWN = 'shutdown'
 
     configurable_events = [
         {
-            "event": RACESTAGE,
+            "event": Evt.RACESTAGE,
             "label": "Race Staging"
         },
         {
-            "event": RACESTART,
+            "event": Evt.RACESTART,
             "label": "Race Start"
         },
         {
-            "event": RACEFINISH,
+            "event": Evt.RACEFINISH,
             "label": "Race Finish"
         },
         {
-            "event": RACESTOP,
+            "event": Evt.RACESTOP,
             "label": "Race Stop"
         },
         {
-            "event": LAPSCLEAR,
+            "event": Evt.LAPSCLEAR,
             "label": "Save/Clear Laps"
         },
         {
-            "event": CROSSINGENTER,
+            "event": Evt.CROSSINGENTER,
             "label": "Gate Entrance"
         },
         {
-            "event": CROSSINGEXIT,
+            "event": Evt.CROSSINGEXIT,
             "label": "Gate Exit"
         },
         {
-            "event": STARTUP,
+            "event": Evt.STARTUP,
             "label": "Server Startup"
         },
         {
-            "event": SHUTDOWN,
+            "event": Evt.SHUTDOWN,
             "label": "Server Shutdown"
         }
     ]

--- a/src/server/led_event_manager.py
+++ b/src/server/led_event_manager.py
@@ -61,10 +61,10 @@ class LEDEventManager:
 
         if event in [Evt.SHUTDOWN]:
             # event is direct (blocking)
-            self.Events.on(event, 'LED', self.eventEffects[name]['handlerFn'], args, True)
+            self.Events.on(event, 'LED', self.eventEffects[name]['handlerFn'], args, 50)
         else:
             # event is normal (threaded/non-blocking)
-            self.Events.on(event, 'LED', self.eventEffects[name]['handlerFn'], args, False)
+            self.Events.on(event, 'LED', self.eventEffects[name]['handlerFn'], args, 100)
         return True
 
     def clear(self):

--- a/src/server/led_event_manager.py
+++ b/src/server/led_event_manager.py
@@ -64,7 +64,7 @@ class LEDEventManager:
             self.Events.on(event, 'LED', self.eventEffects[name]['handlerFn'], args, 50)
         else:
             # event is normal (threaded/non-blocking)
-            self.Events.on(event, 'LED', self.eventEffects[name]['handlerFn'], args, 100)
+            self.Events.on(event, 'LED', self.eventEffects[name]['handlerFn'], args, 150)
         return True
 
     def clear(self):

--- a/src/server/led_handler_bitmap.py
+++ b/src/server/led_handler_bitmap.py
@@ -4,6 +4,7 @@
 #    sudo apt-get install libjpeg-dev
 #    sudo pip install pillow
 
+from eventmanager import Evt
 from led_event_manager import LEDEvent, Color
 import gevent
 from PIL import Image
@@ -50,18 +51,18 @@ def showBitmap(args):
 
 def registerEffects(manager):
     # register state bitmaps
-    manager.registerEffect("bitmapRHLogo", "Image: RotorHazard", showBitmap, [LEDEvent.STARTUP, LEDEvent.RACESTAGE, LEDEvent.RACESTART, LEDEvent.RACEFINISH, LEDEvent.RACESTOP, LEDEvent.SHUTDOWN], {'bitmaps': [
+    manager.registerEffect("bitmapRHLogo", "Image: RotorHazard", showBitmap, [Evt.STARTUP, Evt.RACESTAGE, Evt.RACESTART, Evt.RACEFINISH, Evt.RACESTOP, Evt.SHUTDOWN], {'bitmaps': [
         {"image": "static/image/LEDpanel-16x16-RotorHazard.png", "delay": 0}
         ]})
-    manager.registerEffect("bitmapOrangeSquare", "Image: Orange Pause Icon", showBitmap, [LEDEvent.RACESTAGE], {'bitmaps': [
+    manager.registerEffect("bitmapOrangeSquare", "Image: Orange Pause Icon", showBitmap, [Evt.RACESTAGE], {'bitmaps': [
         {"image": "static/image/LEDpanel-16x16-pause.png", "delay": 0}
         ]})
-    manager.registerEffect("bitmapGreenArrow", "Image: Green Upward Arrow", showBitmap, [LEDEvent.RACESTART], {'bitmaps': [
+    manager.registerEffect("bitmapGreenArrow", "Image: Green Upward Arrow", showBitmap, [Evt.RACESTART], {'bitmaps': [
         {"image": "static/image/LEDpanel-16x16-arrow.png", "delay": 0}
         ]})
-    manager.registerEffect("bitmapRedX", "Image: Red X", showBitmap, [LEDEvent.RACESTOP], {'bitmaps': [
+    manager.registerEffect("bitmapRedX", "Image: Red X", showBitmap, [Evt.RACESTOP], {'bitmaps': [
         {"image": "static/image/LEDpanel-16x16-X.png", "delay": 0}
         ]})
-    manager.registerEffect("bitmapCheckerboard", "Image: Checkerboard", showBitmap, [LEDEvent.RACEFINISH, LEDEvent.RACESTOP], {'bitmaps': [
+    manager.registerEffect("bitmapCheckerboard", "Image: Checkerboard", showBitmap, [Evt.RACEFINISH, Evt.RACESTOP], {'bitmaps': [
         {"image": "static/image/LEDpanel-16x16-checkerboard.png", "delay": 0}
         ]})

--- a/src/server/led_handler_bitmap.py
+++ b/src/server/led_handler_bitmap.py
@@ -8,7 +8,17 @@ from led_event_manager import LEDEvent, Color
 import gevent
 from PIL import Image
 
-def showBitmap(strip, config, args):
+def showBitmap(args):
+    if 'strip' in args:
+        strip = args['strip']
+    else:
+        return False
+
+    if 'config' in args:
+        config = args['config']
+    else:
+        return False
+
     def setPixels(img):
         pos = 0
         for row in range(0, img.height):

--- a/src/server/led_handler_strip.py
+++ b/src/server/led_handler_strip.py
@@ -27,24 +27,29 @@ def led_on(strip, color=ColorVal.WHITE, pattern=ColorPattern.SOLID, offset=0):
 def led_off(strip):
     led_on(strip, ColorVal.NONE)
 
-def chase(strip, config, a={}):
+def chase(args):
     """Movie theater light style chaser animation."""
-    args = {
+    if 'strip' in args:
+        strip = args['strip']
+    else:
+        return False
+
+    a = {
         'color': ColorVal.WHITE,
         'pattern': ColorPattern.ONE_OF_THREE,
         'speedDelay': 50,
         'iterations': 5,
         'offWhenDone': True
     }
-    args.update(a)
+    a.update(args)
 
     led_off(strip)
 
-    for i in range(args['iterations'] * sum(args['pattern'])):
-        led_on(strip, args['color'], args['pattern'], i)
-        gevent.sleep(args['speedDelay']/1000.0)
+    for i in range(a['iterations'] * sum(a['pattern'])):
+        led_on(strip, a['color'], a['pattern'], i)
+        gevent.sleep(a['speedDelay']/1000.0)
 
-    if args['offWhenDone']:
+    if a['offWhenDone']:
         led_off(strip)
 
 def color_wheel(pos):
@@ -58,14 +63,24 @@ def color_wheel(pos):
         pos -= 170
         return Color(0, pos * 3, 255 - pos * 3)
 
-def rainbow(strip, config, args=None):
+def rainbow(args):
     """Draw rainbow that fades across all pixels at once."""
+    if 'strip' in args:
+        strip = args['strip']
+    else:
+        return False
+
     for i in range(strip.numPixels()):
         strip.setPixelColor(i, color_wheel(int(i * 256 / strip.numPixels()) & 255))
     strip.show()
 
-def rainbowCycle(strip, config, args=None):
+def rainbowCycle(args):
     """Draw rainbow that uniformly distributes itself across all pixels."""
+    if 'strip' in args:
+        strip = args['strip']
+    else:
+        return False
+
     if args and 'wait_ms' in args:
         wait_ms = args['wait_ms']
     else:
@@ -85,6 +100,7 @@ def rainbowCycle(strip, config, args=None):
     if 'offWhenDone' in args and args['offWhenDone']:
         led_off(strip)
 
+'''
 def theaterChaseRainbow(strip, wait_ms=25):
     """Rainbow movie theater light style chaser animation."""
     led_on(strip, ColorVal.NONE)
@@ -96,14 +112,20 @@ def theaterChaseRainbow(strip, wait_ms=25):
             gevent.sleep(wait_ms/1000.0)
             for i in range(0, strip.numPixels()-q, 3):
                 strip.setPixelColor(i+q, 0)
+'''
 
-def showColor(strip, config, args=None):
-    if args and 'color' in args:
+def showColor(args):
+    if 'strip' in args:
+        strip = args['strip']
+    else:
+        return False
+
+    if 'color' in args:
         color = args['color']
     else:
         color = ColorVal.WHITE
 
-    if args and 'pattern' in args:
+    if 'pattern' in args:
         pattern = args['pattern']
     else:
         pattern = ColorPattern.SOLID
@@ -114,29 +136,44 @@ def showColor(strip, config, args=None):
         gevent.sleep(float(args['time']))
         led_off(strip)
 
-def clear(strip, config, args=None):
+def clear(args):
+    if 'strip' in args:
+        strip = args['strip']
+    else:
+        return False
+
     led_off(strip)
 
 # Effects adapted from work by Hans Luijten https://www.tweaking4all.com/hardware/arduino/adruino-led-strip-effects/
 
-def colorWipe(strip, config, a={}):
+def colorWipe(args):
     gevent.idle() # never time-critical
 
-    args = {
+    if 'strip' in args:
+        strip = args['strip']
+    else:
+        return False
+
+    a = {
         'color': ColorVal.WHITE,
         'speedDelay': 256,
     }
-    args.update(a)
+    a.update(args)
 
-    args['speedDelay'] = args['speedDelay']/float(strip.numPixels()) # scale effect by strip length
+    a['speedDelay'] = a['speedDelay']/float(strip.numPixels()) # scale effect by strip length
 
     for i in range(strip.numPixels()):
-        strip.setPixelColor(i, args['color'])
+        strip.setPixelColor(i, a['color'])
         strip.show()
-        gevent.sleep(args['speedDelay']/1000.0)
+        gevent.sleep(a['speedDelay']/1000.0)
 
-def fade(strip, config, a={}):
-    args = {
+def fade(args):
+    if 'strip' in args:
+        strip = args['strip']
+    else:
+        return False
+
+    a = {
         'color': ColorVal.WHITE,
         'pattern': ColorPattern.SOLID,
         'steps': 25,
@@ -145,93 +182,103 @@ def fade(strip, config, a={}):
         'offTime': 250,
         'iterations': 1
     }
-    args.update(a)
+    a.update(args)
 
     led_off(strip)
 
-    if 'outSteps' not in args:
-        args['outSteps'] = args['steps']
+    if 'outSteps' not in a:
+        a['outSteps'] = a['steps']
 
     # effect should never exceed 3Hz (prevent seizures)
-    args['offTime'] = min(333-((args['steps']*args['speedDelay'])+(args['outSteps']*args['speedDelay'])+args['onTime']), args['offTime'])
+    a['offTime'] = min(333-((a['steps']*a['speedDelay'])+(a['outSteps']*a['speedDelay'])+a['onTime']), a['offTime'])
 
-    for i in range(args['iterations']):
+    for i in range(a['iterations']):
         # fade in
-        if args['steps']:
+        if a['steps']:
             led_off(strip)
             gevent.idle() # never time-critical
-            for j in range(0, args['steps'], 1):
-                c = dim(args['color'], j/float(args['steps']))
-                led_on(strip, c, args['pattern'])
+            for j in range(0, a['steps'], 1):
+                c = dim(a['color'], j/float(a['steps']))
+                led_on(strip, c, a['pattern'])
                 strip.show()
-                gevent.sleep(args['speedDelay']/1000.0);
+                gevent.sleep(a['speedDelay']/1000.0);
             else:
-                led_on(strip, args['color'], args['pattern'])
+                led_on(strip, a['color'], a['pattern'])
 
-            led_on(strip, args['color'], args['pattern'])
-            gevent.sleep(args['onTime']/1000.0);
+            led_on(strip, a['color'], a['pattern'])
+            gevent.sleep(a['onTime']/1000.0);
 
         # fade out
-        if args['outSteps']:
-            led_on(strip, args['color'], args['pattern'])
-            for j in range(args['outSteps'], 0, -1):
-                c = dim(args['color'], j/float(args['outSteps']))
-                led_on(strip, c, args['pattern'])
+        if a['outSteps']:
+            led_on(strip, a['color'], a['pattern'])
+            for j in range(a['outSteps'], 0, -1):
+                c = dim(a['color'], j/float(a['outSteps']))
+                led_on(strip, c, a['pattern'])
                 strip.show()
-                gevent.sleep(args['speedDelay']/1000.0);
+                gevent.sleep(a['speedDelay']/1000.0);
 
             else:
                 led_off(strip)
 
             led_off(strip)
 
-        gevent.sleep(args['offTime']/1000.0);
+        gevent.sleep(a['offTime']/1000.0);
 
-def sparkle(strip, config, a={}):
-    args = {
+def sparkle(args):
+    if 'strip' in args:
+        strip = args['strip']
+    else:
+        return False
+
+    a = {
         'color': ColorVal.WHITE,
         'chance': 1.0,
         'decay': 0.95,
         'speedDelay': 100,
         'iterations': 100
     }
-    args.update(a)
+    a.update(args)
 
     gevent.idle() # never time-critical
 
     # decay time = log(decay cutoff=10 / max brightness=256) / log(decay rate)
-    if args['decay']:
-        decaySteps = int(math.ceil(math.log(0.00390625) / math.log(args['decay'])))
+    if a['decay']:
+        decaySteps = int(math.ceil(math.log(0.00390625) / math.log(a['decay'])))
     else:
         decaySteps = 0
 
     led_off(strip)
 
-    for i in range(args['iterations'] + decaySteps):
+    for i in range(a['iterations'] + decaySteps):
         # fade brightness all LEDs one step
         for j in range(strip.numPixels()):
             c = strip.getPixelColor(j)
-            strip.setPixelColor(j, dim(c, args['decay']))
+            strip.setPixelColor(j, dim(c, a['decay']))
 
         # pick new pixels to light up
-        if i < args['iterations']:
+        if i < a['iterations']:
             for px in range(strip.numPixels()):
-                if random.random() < float(args['chance']) / strip.numPixels():
+                if random.random() < float(a['chance']) / strip.numPixels():
                     # scale effect by strip length
-                    strip.setPixelColor(px, args['color'])
+                    strip.setPixelColor(px, a['color'])
 
         strip.show()
-        gevent.sleep(args['speedDelay']/1000.0);
+        gevent.sleep(a['speedDelay']/1000.0);
 
-def meteor(strip, config, a={}):
-    args = {
+def meteor(args):
+    if 'strip' in args:
+        strip = args['strip']
+    else:
+        return False
+
+    a = {
         'color': ColorVal.WHITE,
         'meteorSize': 10,
         'decay': 0.75,
         'randomDecay': True,
         'speedDelay': 1
     }
-    args.update(a)
+    a.update(args)
 
     gevent.idle() # never time-critical
 
@@ -241,59 +288,64 @@ def meteor(strip, config, a={}):
 
         # fade brightness all LEDs one step
         for j in range(strip.numPixels()):
-            if not args['randomDecay'] or random.random() > 0.5:
+            if not a['randomDecay'] or random.random() > 0.5:
                 c = strip.getPixelColor(j)
-                strip.setPixelColor(j, dim(c, args['decay']))
+                strip.setPixelColor(j, dim(c, a['decay']))
 
         # draw meteor
-        for j in range(args['meteorSize']):
+        for j in range(a['meteorSize']):
             if i - j < strip.numPixels() and i - j >= 0:
-                strip.setPixelColor(i-j, args['color'])
+                strip.setPixelColor(i-j, a['color'])
 
         strip.show()
-        gevent.sleep(args['speedDelay']/1000.0)
+        gevent.sleep(a['speedDelay']/1000.0)
 
-def larsonScanner(strip, config, a={}):
-    args = {
+def larsonScanner(args):
+    if 'strip' in args:
+        strip = args['strip']
+    else:
+        return False
+
+    a = {
         'color': ColorVal.WHITE,
         'eyeSize': 4,
         'speedDelay': 256,
         'returnDelay': 50,
         'iterations': 3
     }
-    args.update(a)
+    a.update(args)
 
-    args['speedDelay'] = args['speedDelay']/float(strip.numPixels()) # scale effect by strip length
+    a['speedDelay'] = a['speedDelay']/float(strip.numPixels()) # scale effect by strip length
 
     gevent.idle() # never time-critical
 
     led_off(strip)
 
-    for k in range(args['iterations']):
-        for i in range(strip.numPixels()-args['eyeSize']-1):
+    for k in range(a['iterations']):
+        for i in range(strip.numPixels()-a['eyeSize']-1):
             strip.setPixelColor(i-1, ColorVal.NONE)
 
-            strip.setPixelColor(i, dim(args['color'], 0.25))
-            for j in range(args['eyeSize']):
-                strip.setPixelColor(i+j+1, args['color'])
-            strip.setPixelColor(i+args['eyeSize']+1, dim(args['color'], 0.25))
+            strip.setPixelColor(i, dim(a['color'], 0.25))
+            for j in range(a['eyeSize']):
+                strip.setPixelColor(i+j+1, a['color'])
+            strip.setPixelColor(i+a['eyeSize']+1, dim(a['color'], 0.25))
             strip.show()
-            gevent.sleep(args['speedDelay']/1000.0)
+            gevent.sleep(a['speedDelay']/1000.0)
 
-        gevent.sleep(args['returnDelay']/1000.0)
+        gevent.sleep(a['returnDelay']/1000.0)
 
-        for i in range(strip.numPixels()-args['eyeSize']-2, -1, -1):
-            if i < strip.numPixels()-args['eyeSize']-2:
-                strip.setPixelColor(i+args['eyeSize']+2, ColorVal.NONE)
+        for i in range(strip.numPixels()-a['eyeSize']-2, -1, -1):
+            if i < strip.numPixels()-a['eyeSize']-2:
+                strip.setPixelColor(i+a['eyeSize']+2, ColorVal.NONE)
 
-            strip.setPixelColor(i, dim(args['color'], 0.25))
-            for j in range(args['eyeSize']):
-                strip.setPixelColor(i+j+1, args['color'])
-            strip.setPixelColor(i+args['eyeSize']+1, dim(args['color'], 0.25))
+            strip.setPixelColor(i, dim(a['color'], 0.25))
+            for j in range(a['eyeSize']):
+                strip.setPixelColor(i+j+1, a['color'])
+            strip.setPixelColor(i+a['eyeSize']+1, dim(a['color'], 0.25))
             strip.show()
-            gevent.sleep(args['speedDelay']/1000.0)
+            gevent.sleep(a['speedDelay']/1000.0)
 
-        gevent.sleep(args['returnDelay']/1000.0)
+        gevent.sleep(a['returnDelay']/1000.0)
 
 def dim(color, decay):
     r = (color & 0x00ff0000) >> 16;

--- a/src/server/led_handler_strip.py
+++ b/src/server/led_handler_strip.py
@@ -1,5 +1,6 @@
 '''LED visual effects'''
 
+from eventmanager import Evt
 from led_event_manager import LEDEvent, Color, ColorVal, ColorPattern
 import gevent
 import random
@@ -362,44 +363,44 @@ def registerEffects(manager):
 
     # color
     manager.registerEffect("stripColor", "Color/Pattern (Args)", showColor, [LEDEvent.NOCONTROL])
-    manager.registerEffect("stripColorSolid", "Solid", showColor, [LEDEvent.STARTUP, LEDEvent.RACESTAGE, LEDEvent.CROSSINGENTER, LEDEvent.CROSSINGEXIT, LEDEvent.RACESTART, LEDEvent.RACEFINISH, LEDEvent.RACESTOP, LEDEvent.LAPSCLEAR], {
+    manager.registerEffect("stripColorSolid", "Solid", showColor, [Evt.STARTUP, Evt.RACESTAGE, Evt.CROSSINGENTER, Evt.CROSSINGEXIT, Evt.RACESTART, Evt.RACEFINISH, Evt.RACESTOP, Evt.LAPSCLEAR], {
         'pattern': ColorPattern.SOLID
         })
-    manager.registerEffect("stripColor1_1", "Pattern 1-1", showColor, [LEDEvent.STARTUP, LEDEvent.RACESTAGE, LEDEvent.CROSSINGENTER, LEDEvent.CROSSINGEXIT, LEDEvent.RACESTART, LEDEvent.RACEFINISH, LEDEvent.RACESTOP, LEDEvent.LAPSCLEAR], {
+    manager.registerEffect("stripColor1_1", "Pattern 1-1", showColor, [Evt.STARTUP, Evt.RACESTAGE, Evt.CROSSINGENTER, Evt.CROSSINGEXIT, Evt.RACESTART, Evt.RACEFINISH, Evt.RACESTOP, Evt.LAPSCLEAR], {
         'pattern': ColorPattern.ALTERNATING
         })
 
-    manager.registerEffect("stripColorSolid_4s", "Solid (4s expire)", showColor, [LEDEvent.STARTUP, LEDEvent.RACESTAGE, LEDEvent.CROSSINGENTER, LEDEvent.CROSSINGEXIT, LEDEvent.RACESTART, LEDEvent.RACEFINISH, LEDEvent.RACESTOP, LEDEvent.LAPSCLEAR], {
+    manager.registerEffect("stripColorSolid_4s", "Solid (4s expire)", showColor, [Evt.STARTUP, Evt.RACESTAGE, Evt.CROSSINGENTER, Evt.CROSSINGEXIT, Evt.RACESTART, Evt.RACEFINISH, Evt.RACESTOP, Evt.LAPSCLEAR], {
         'pattern': ColorPattern.SOLID,
         'time': Timing.VTX_EXPIRE
         })
-    manager.registerEffect("stripColor1_1_4s", "Pattern 1-1 (4s expire)", showColor, [LEDEvent.STARTUP, LEDEvent.RACESTAGE, LEDEvent.CROSSINGENTER, LEDEvent.CROSSINGEXIT, LEDEvent.RACESTART, LEDEvent.RACEFINISH, LEDEvent.RACESTOP, LEDEvent.LAPSCLEAR], {
+    manager.registerEffect("stripColor1_1_4s", "Pattern 1-1 (4s expire)", showColor, [Evt.STARTUP, Evt.RACESTAGE, Evt.CROSSINGENTER, Evt.CROSSINGEXIT, Evt.RACESTART, Evt.RACEFINISH, Evt.RACESTOP, Evt.LAPSCLEAR], {
         'pattern': ColorPattern.ALTERNATING,
         'time': Timing.VTX_EXPIRE
         })
 
 
     # register specific items needed for typical events
-    manager.registerEffect("stripColorOrange2_1", "Pattern 2-1 / Orange", showColor, [LEDEvent.STARTUP, LEDEvent.RACESTAGE, LEDEvent.RACESTART, LEDEvent.RACEFINISH, LEDEvent.RACESTOP, LEDEvent.LAPSCLEAR, LEDEvent.SHUTDOWN], {
+    manager.registerEffect("stripColorOrange2_1", "Pattern 2-1 / Orange", showColor, [Evt.STARTUP, Evt.RACESTAGE, Evt.RACESTART, Evt.RACEFINISH, Evt.RACESTOP, Evt.LAPSCLEAR, Evt.SHUTDOWN], {
         'color': ColorVal.ORANGE,
         'pattern': ColorPattern.TWO_OUT_OF_THREE
         })
-    manager.registerEffect("stripColorGreenSolid", "Solid / Green", showColor, [LEDEvent.STARTUP, LEDEvent.RACESTAGE, LEDEvent.RACESTART, LEDEvent.RACEFINISH, LEDEvent.RACESTOP, LEDEvent.LAPSCLEAR, LEDEvent.SHUTDOWN], {
+    manager.registerEffect("stripColorGreenSolid", "Solid / Green", showColor, [Evt.STARTUP, Evt.RACESTAGE, Evt.RACESTART, Evt.RACEFINISH, Evt.RACESTOP, Evt.LAPSCLEAR, Evt.SHUTDOWN], {
         'color': ColorVal.GREEN,
         'pattern': ColorPattern.SOLID,
         'time': Timing.START_EXPIRE
         })
-    manager.registerEffect("stripColorWhite4_4", "Pattern 4-4", showColor, [LEDEvent.STARTUP, LEDEvent.RACESTAGE, LEDEvent.RACESTART, LEDEvent.RACEFINISH, LEDEvent.RACESTOP, LEDEvent.LAPSCLEAR, LEDEvent.SHUTDOWN], {
+    manager.registerEffect("stripColorWhite4_4", "Pattern 4-4", showColor, [Evt.STARTUP, Evt.RACESTAGE, Evt.RACESTART, Evt.RACEFINISH, Evt.RACESTOP, Evt.LAPSCLEAR, Evt.SHUTDOWN], {
         'color': ColorVal.WHITE,
         'pattern': ColorPattern.FOUR_ON_FOUR_OFF
         })
-    manager.registerEffect("stripColorRedSolid", "Solid / Red", showColor, [LEDEvent.STARTUP, LEDEvent.RACESTAGE, LEDEvent.RACESTART, LEDEvent.RACEFINISH, LEDEvent.RACESTOP, LEDEvent.LAPSCLEAR, LEDEvent.SHUTDOWN], {
+    manager.registerEffect("stripColorRedSolid", "Solid / Red", showColor, [Evt.STARTUP, Evt.RACESTAGE, Evt.RACESTART, Evt.RACEFINISH, Evt.RACESTOP, Evt.LAPSCLEAR, Evt.SHUTDOWN], {
         'color': ColorVal.RED,
         'pattern': ColorPattern.SOLID
         })
 
     # chase
-    manager.registerEffect("stripChase", "Chase Pattern 1-2", chase, [LEDEvent.STARTUP, LEDEvent.RACESTAGE, LEDEvent.CROSSINGENTER, LEDEvent.CROSSINGEXIT, LEDEvent.RACESTART, LEDEvent.RACEFINISH, LEDEvent.RACESTOP, LEDEvent.LAPSCLEAR], {
+    manager.registerEffect("stripChase", "Chase Pattern 1-2", chase, [Evt.STARTUP, Evt.RACESTAGE, Evt.CROSSINGENTER, Evt.CROSSINGEXIT, Evt.RACESTART, Evt.RACEFINISH, Evt.RACESTOP, Evt.LAPSCLEAR], {
         'color': ColorVal.WHITE,
         'pattern': ColorPattern.ONE_OF_THREE,
         'speedDelay': 50,
@@ -408,19 +409,19 @@ def registerEffects(manager):
         })
 
     # rainbow
-    manager.registerEffect("rainbow", "Rainbow", rainbow, [LEDEvent.STARTUP, LEDEvent.RACESTAGE, LEDEvent.CROSSINGENTER, LEDEvent.CROSSINGEXIT, LEDEvent.RACESTART, LEDEvent.RACEFINISH, LEDEvent.RACESTOP, LEDEvent.LAPSCLEAR])
-    manager.registerEffect("rainbowCycle", "Rainbow Cycle", rainbowCycle, [LEDEvent.STARTUP, LEDEvent.RACESTAGE, LEDEvent.CROSSINGENTER, LEDEvent.CROSSINGEXIT, LEDEvent.RACESTART, LEDEvent.RACEFINISH, LEDEvent.RACESTOP, LEDEvent.LAPSCLEAR], {
+    manager.registerEffect("rainbow", "Rainbow", rainbow, [Evt.STARTUP, Evt.RACESTAGE, Evt.CROSSINGENTER, Evt.CROSSINGEXIT, Evt.RACESTART, Evt.RACEFINISH, Evt.RACESTOP, Evt.LAPSCLEAR])
+    manager.registerEffect("rainbowCycle", "Rainbow Cycle", rainbowCycle, [Evt.STARTUP, Evt.RACESTAGE, Evt.CROSSINGENTER, Evt.CROSSINGEXIT, Evt.RACESTART, Evt.RACEFINISH, Evt.RACESTOP, Evt.LAPSCLEAR], {
         'offWhenDone': True
         })
 
     # wipe
-    manager.registerEffect("stripWipe", "Wipe", colorWipe, [LEDEvent.STARTUP, LEDEvent.RACESTAGE, LEDEvent.CROSSINGENTER, LEDEvent.CROSSINGEXIT, LEDEvent.RACESTART, LEDEvent.RACEFINISH, LEDEvent.RACESTOP, LEDEvent.LAPSCLEAR], {
+    manager.registerEffect("stripWipe", "Wipe", colorWipe, [Evt.STARTUP, Evt.RACESTAGE, Evt.CROSSINGENTER, Evt.CROSSINGEXIT, Evt.RACESTART, Evt.RACEFINISH, Evt.RACESTOP, Evt.LAPSCLEAR], {
         'color': ColorVal.WHITE,
         'speedDelay': 3,
         })
 
     # fade
-    manager.registerEffect("stripFadeIn", "Fade In", fade, [LEDEvent.STARTUP, LEDEvent.RACESTAGE, LEDEvent.CROSSINGENTER, LEDEvent.CROSSINGEXIT, LEDEvent.RACESTART, LEDEvent.RACEFINISH, LEDEvent.RACESTOP, LEDEvent.LAPSCLEAR], {
+    manager.registerEffect("stripFadeIn", "Fade In", fade, [Evt.STARTUP, Evt.RACESTAGE, Evt.CROSSINGENTER, Evt.CROSSINGEXIT, Evt.RACESTART, Evt.RACEFINISH, Evt.RACESTOP, Evt.LAPSCLEAR], {
         'color': ColorVal.WHITE,
         'pattern': ColorPattern.SOLID,
         'steps': 50,
@@ -430,7 +431,7 @@ def registerEffects(manager):
         'offTime': 0,
         'iterations': 1
         })
-    manager.registerEffect("stripPulse", "Pulse 3x", fade, [LEDEvent.STARTUP, LEDEvent.RACESTAGE, LEDEvent.CROSSINGENTER, LEDEvent.CROSSINGEXIT, LEDEvent.RACESTART, LEDEvent.RACEFINISH, LEDEvent.RACESTOP, LEDEvent.LAPSCLEAR], {
+    manager.registerEffect("stripPulse", "Pulse 3x", fade, [Evt.STARTUP, Evt.RACESTAGE, Evt.CROSSINGENTER, Evt.CROSSINGEXIT, Evt.RACESTART, Evt.RACEFINISH, Evt.RACESTOP, Evt.LAPSCLEAR], {
         'color': ColorVal.WHITE,
         'pattern': ColorPattern.SOLID,
         'steps': 10,
@@ -440,7 +441,7 @@ def registerEffects(manager):
         'offTime': 10,
         'iterations': 3
         })
-    manager.registerEffect("stripFadeOut", "Fade Out", fade, [LEDEvent.STARTUP, LEDEvent.RACESTAGE, LEDEvent.CROSSINGENTER, LEDEvent.CROSSINGEXIT, LEDEvent.RACESTART, LEDEvent.RACEFINISH, LEDEvent.RACESTOP, LEDEvent.LAPSCLEAR], {
+    manager.registerEffect("stripFadeOut", "Fade Out", fade, [Evt.STARTUP, Evt.RACESTAGE, Evt.CROSSINGENTER, Evt.CROSSINGEXIT, Evt.RACESTART, Evt.RACEFINISH, Evt.RACESTOP, Evt.LAPSCLEAR], {
         'color': ColorVal.WHITE,
         'pattern': ColorPattern.SOLID,
         'steps': 10,
@@ -452,7 +453,7 @@ def registerEffects(manager):
         })
 
     # blink
-    manager.registerEffect("stripBlink", "Blink 3x", fade, [LEDEvent.STARTUP, LEDEvent.RACESTAGE, LEDEvent.CROSSINGENTER, LEDEvent.CROSSINGEXIT, LEDEvent.RACESTART, LEDEvent.RACEFINISH, LEDEvent.RACESTOP, LEDEvent.LAPSCLEAR], {
+    manager.registerEffect("stripBlink", "Blink 3x", fade, [Evt.STARTUP, Evt.RACESTAGE, Evt.CROSSINGENTER, Evt.CROSSINGEXIT, Evt.RACESTART, Evt.RACEFINISH, Evt.RACESTOP, Evt.LAPSCLEAR], {
         'color': ColorVal.WHITE,
         'pattern': ColorPattern.SOLID,
         'steps': 1,
@@ -463,7 +464,7 @@ def registerEffects(manager):
         })
 
     # sparkle
-    manager.registerEffect("stripSparkle", "Sparkle", sparkle, [LEDEvent.STARTUP, LEDEvent.RACESTAGE, LEDEvent.CROSSINGENTER, LEDEvent.CROSSINGEXIT, LEDEvent.RACESTART, LEDEvent.RACEFINISH, LEDEvent.RACESTOP, LEDEvent.LAPSCLEAR], {
+    manager.registerEffect("stripSparkle", "Sparkle", sparkle, [Evt.STARTUP, Evt.RACESTAGE, Evt.CROSSINGENTER, Evt.CROSSINGEXIT, Evt.RACESTART, Evt.RACEFINISH, Evt.RACESTOP, Evt.LAPSCLEAR], {
         'color': ColorVal.WHITE,
         'chance': 1.0,
         'decay': 0.95,
@@ -472,7 +473,7 @@ def registerEffects(manager):
         })
 
     # meteor
-    manager.registerEffect("stripMeteor", "Meteor Fall", meteor, [LEDEvent.STARTUP, LEDEvent.RACESTAGE, LEDEvent.CROSSINGENTER, LEDEvent.CROSSINGEXIT, LEDEvent.RACESTART, LEDEvent.RACEFINISH, LEDEvent.RACESTOP, LEDEvent.LAPSCLEAR], {
+    manager.registerEffect("stripMeteor", "Meteor Fall", meteor, [Evt.STARTUP, Evt.RACESTAGE, Evt.CROSSINGENTER, Evt.CROSSINGEXIT, Evt.RACESTART, Evt.RACEFINISH, Evt.RACESTOP, Evt.LAPSCLEAR], {
         'color': ColorVal.WHITE,
         'meteorSize': 10,
         'decay': 0.75,
@@ -481,7 +482,7 @@ def registerEffects(manager):
         })
 
     # larson scanner
-    manager.registerEffect("stripScanner", "Scanner", larsonScanner, [LEDEvent.STARTUP, LEDEvent.RACESTAGE, LEDEvent.CROSSINGENTER, LEDEvent.CROSSINGEXIT, LEDEvent.RACESTART, LEDEvent.RACEFINISH, LEDEvent.RACESTOP, LEDEvent.LAPSCLEAR], {
+    manager.registerEffect("stripScanner", "Scanner", larsonScanner, [Evt.STARTUP, Evt.RACESTAGE, Evt.CROSSINGENTER, Evt.CROSSINGEXIT, Evt.RACESTART, Evt.RACEFINISH, Evt.RACESTOP, Evt.LAPSCLEAR], {
         'color': ColorVal.WHITE,
         'eyeSize': 4,
         'speedDelay': 256,
@@ -490,4 +491,4 @@ def registerEffects(manager):
         })
 
     # clear - permanently assigned to LEDEventManager.clear()
-    manager.registerEffect("clear", "Turn Off", clear, [LEDEvent.NOCONTROL, LEDEvent.STARTUP, LEDEvent.RACESTAGE, LEDEvent.CROSSINGENTER, LEDEvent.CROSSINGEXIT, LEDEvent.RACESTART, LEDEvent.RACEFINISH, LEDEvent.RACESTOP, LEDEvent.LAPSCLEAR, LEDEvent.SHUTDOWN])
+    manager.registerEffect("clear", "Turn Off", clear, [LEDEvent.NOCONTROL, Evt.STARTUP, Evt.RACESTAGE, Evt.CROSSINGENTER, Evt.CROSSINGEXIT, Evt.RACESTART, Evt.RACEFINISH, Evt.RACESTOP, Evt.LAPSCLEAR, Evt.SHUTDOWN])

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -4419,15 +4419,15 @@ def expand_heats():
 def init_LED_effects():
     # start with defaults
     effects = {
-        LEDEvent.RACESTAGE: "stripColorOrange2_1",
-        LEDEvent.RACESTART: "stripColorGreenSolid",
-        LEDEvent.RACEFINISH: "stripColorWhite4_4",
-        LEDEvent.RACESTOP: "stripColorRedSolid",
-        LEDEvent.LAPSCLEAR: "clear",
-        LEDEvent.CROSSINGENTER: "stripColorSolid",
-        LEDEvent.CROSSINGEXIT: "stripColor1_1_4s",
-        LEDEvent.STARTUP: "rainbowCycle",
-        LEDEvent.SHUTDOWN: "clear"
+        Evt.RACESTAGE: "stripColorOrange2_1",
+        Evt.RACESTART: "stripColorGreenSolid",
+        Evt.RACEFINISH: "stripColorWhite4_4",
+        Evt.RACESTOP: "stripColorRedSolid",
+        Evt.LAPSCLEAR: "clear",
+        Evt.CROSSINGENTER: "stripColorSolid",
+        Evt.CROSSINGEXIT: "stripColor1_1_4s",
+        Evt.STARTUP: "rainbowCycle",
+        Evt.SHUTDOWN: "clear"
     }
     # update with DB values (if any)
     effect_opt = getOption('ledEffects')

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -31,6 +31,10 @@ from flask_sqlalchemy import SQLAlchemy
 import random
 import json
 
+# Events manager
+from eventmanager import Evt, EventManager
+Events = EventManager()
+
 # LED imports
 from led_event_manager import LEDEventManager, NoLEDManager, LEDEvent, Color, ColorVal, ColorPattern, hexToColor
 
@@ -1659,7 +1663,7 @@ def on_reset_database(data):
 @SOCKET_IO.on('shutdown_pi')
 def on_shutdown_pi():
     '''Shutdown the raspberry pi.'''
-    led_manager.eventDirect(LEDEvent.SHUTDOWN)  # server is shutting down, so shut off LEDs
+    Events.trigger(Evt.SHUTDOWN)  # server is shutting down, so shut off LEDs
     CLUSTER.emit('shutdown_pi')
     emit_priority_message(__('Server has shut down.'), True)
     server_log('Shutdown pi')
@@ -1669,7 +1673,7 @@ def on_shutdown_pi():
 @SOCKET_IO.on('reboot_pi')
 def on_reboot_pi():
     '''Shutdown the raspberry pi.'''
-    led_manager.eventDirect(LEDEvent.SHUTDOWN)  # server is shutting down, so shut off LEDs
+    Events.trigger(Evt.SHUTDOWN)  # server is shutting down, so shut off LEDs
     CLUSTER.emit('reboot_pi')
     emit_priority_message(__('Server is rebooting.'), True)
     server_log('Rebooting pi')
@@ -1844,13 +1848,13 @@ def on_set_led_effect(data):
 def on_use_led_effect(data):
     '''Activate arbitrary LED Effect.'''
     if led_manager.isEnabled() and 'effect' in data:
-        led_manager.setEventEffect(LEDEvent.MANUAL, data['effect'])
+        led_manager.setEventEffect(Evt.MANUAL, data['effect'])
 
         args = None
         if 'args' in data:
             args = data['args']
 
-        led_manager.event(LEDEvent.MANUAL, args)
+        Events.trigger(Evt.MANUAL, args)
 
 # Race management socket io events
 
@@ -1899,7 +1903,7 @@ def on_stage_race():
         global LAST_RACE_CACHE_VALID
         INTERFACE.enable_calibration_mode() # Nodes reset triggers on next pass
 
-        led_manager.event(LEDEvent.RACESTAGE)
+        Events.trigger(Evt.RACESTAGE)
         clear_laps() # Clear laps before race start
         init_node_cross_fields()  # set 'cur_pilot_id' and 'cross' fields on nodes
         LAST_RACE_CACHE_VALID = False # invalidate last race results cache
@@ -2035,7 +2039,7 @@ def race_start_thread(start_token):
             pass
 
         # do time-critical tasks
-        led_manager.event(LEDEvent.RACESTART)
+        Events.trigger(Evt.RACESTART)
 
         # do secondary start tasks (small delay is acceptable)
         RACE.start_time = datetime.now()
@@ -2092,7 +2096,7 @@ def on_stop_race():
 
     SOCKET_IO.emit('stop_timer') # Loop back to race page to start the timer counting up
     emit_race_status() # Race page, to set race button states
-    led_manager.event(LEDEvent.RACESTOP)
+    Events.trigger(Evt.RACESTOP)
 
 @SOCKET_IO.on('save_laps')
 def on_save_laps():
@@ -2221,7 +2225,7 @@ def on_discard_laps():
         check_emit_team_racing_status()  # Show team-racing status info
     else:
         emit_team_racing_status('')  # clear any displayed "Winner is" text
-    led_manager.event(LEDEvent.LAPSCLEAR)
+    Events.trigger(Evt.LAPSCLEAR)
 
 def clear_laps():
     '''Clear the current laps table.'''
@@ -2309,7 +2313,7 @@ def on_simulate_lap(data):
     '''Simulates a lap (for debug testing).'''
     node_index = data['node']
     server_log('Simulated lap: Node {0}'.format(node_index+1))
-    led_manager.event(LEDEvent.CROSSINGEXIT, {
+    Events.trigger(Evt.CROSSINGEXIT, {
         'nodeIndex': node_index,
         'color': hexToColor(getOption('colorNode_' + str(node_index), '#ffffff'))
         })
@@ -3848,7 +3852,7 @@ def check_race_time_expired():
     if race_format and race_format.race_mode == 0: # count down
         if monotonic() >= RACE_START + race_format.race_time_sec:
             RACE.timer_running = 0 # indicate race timer no longer running
-            led_manager.event(LEDEvent.RACEFINISH)
+            Events.trigger(Evt.RACEFINISH)
             if race_format.win_condition == WIN_CONDITION_MOST_LAPS:  # Most Laps Wins Enabled
                 check_most_laps_win()  # check if pilot or team has most laps for win
 
@@ -4032,14 +4036,14 @@ def node_crossing_callback(node):
             # first crossing has happened; if 'enter' then show indicator,
             #  if first event is 'exit' then ignore (because will be end of first crossing)
             if node.crossing_flag:
-                led_manager.event(LEDEvent.CROSSINGENTER, {
+                Events.trigger(Evt.CROSSINGENTER, {
                     'nodeIndex': node.index,
                     'color': hexToColor(getOption('colorNode_' + str(node.index), '#ffffff'))
                     })
                 node.show_crossing_flag = True
             else:
                 if node.show_crossing_flag:
-                    led_manager.event(LEDEvent.CROSSINGEXIT, {
+                    Events.trigger(Evt.CROSSINGEXIT, {
                         'nodeIndex': node.index,
                         'color': hexToColor(getOption('colorNode_' + str(node.index), '#ffffff'))
                         })
@@ -4565,7 +4569,7 @@ else:
 if strip:
     # Initialize the library (must be called once before other functions).
     strip.begin()
-    led_manager = LEDEventManager(strip, Config['LED'])
+    led_manager = LEDEventManager(Events, strip, Config['LED'])
     LEDHandlerFiles = [item.replace('.py', '') for item in glob.glob("led_handler_*.py")]
     for handlerFile in LEDHandlerFiles:
         try:
@@ -4585,7 +4589,8 @@ def start(port_val = Config['GENERAL']['HTTP_PORT']):
 
     print "Running http server at port " + str(port_val)
 
-    led_manager.event(LEDEvent.STARTUP) # show startup indicator on LEDs
+    Events.trigger(Evt.STARTUP)
+
     try:
         # the following fn does not return until the server is shutting down
         SOCKET_IO.run(APP, host='0.0.0.0', port=port_val, debug=True, use_reloader=False)
@@ -4593,7 +4598,8 @@ def start(port_val = Config['GENERAL']['HTTP_PORT']):
         print "Server terminated by keyboard interrupt"
     except Exception as ex:
         print "Server exception:  " + str(ex)
-    led_manager.eventDirect(LEDEvent.SHUTDOWN)  # server is shutting down, so shut off LEDs
+
+    Events.trigger(Evt.SHUTDOWN)
 
 # Start HTTP server
 if __name__ == '__main__':


### PR DESCRIPTION
Register events with Events.on(event, name, handlerFn, defaultArgs=None, priority=200)
"event" is one of any triggered events (list maintained in Evt)
"name" is an event category, such as "LED". Event handlers with the same name will be overridden by any other handlers with the same name.
"handlerFn" is the function to call when the event is triggered
"defaultArgs" sets up event arguments for the handler
"priority" sets order in which events are processed. Lower numbers first. Priority less than 100 causes handler to play as blocking code; 100 or more is threaded/non-blocking

Trigger events with Events.trigger(event, eventArgs)
"event" is the triggered event name
"eventArgs" overrides defaultArgs (with update(); subtrees are replaced)

LED effects have been migrated to global events, but LED manager remains useful for effect selection. This use case also provides examples for how events can be called

To consider before merging: handler priority?