### PR TITLE
Add tracking/logging of comm-error counts

### DIFF
--- a/src/interface/MockInterface.py
+++ b/src/interface/MockInterface.py
@@ -132,7 +132,25 @@ class MockInterface(BaseHardwareInterface):
             node.exit_at_level = self.transmit_exit_at_level(node, level)
 
     def force_end_crossing(self, node_index):
-        node = self.nodes[node_index]
+        pass
+
+    def inc_intf_read_block_count(self):
+        pass
+
+    def inc_intf_read_error_count(self):
+        pass
+
+    def inc_intf_write_block_count(self):
+        pass
+
+    def inc_intf_write_error_count(self):
+        pass
+
+    def get_intf_total_error_count(self):
+        pass
+
+    def get_intf_error_report_str(self):
+        return ""
 
 def get_hardware_interface(*args, **kwargs):
     '''Returns the interface object.'''

--- a/src/interface/Node.py
+++ b/src/interface/Node.py
@@ -49,7 +49,9 @@ class Node:
 
         self.io_request = None # request time of last I/O read
         self.io_response = None # response time of last I/O read
-
+        
+        self.read_block_count = 0
+        self.read_error_count = 0
 
     def init(self):
         if self.api_level >= 10:
@@ -95,3 +97,17 @@ class Node:
 
     def is_valid_rssi(self, value):
         return value > 0 and value < self.max_rssi_value
+
+    def inc_read_block_count(self, interface):
+        if interface:
+            self.read_block_count += 1
+            interface.inc_intf_read_block_count()
+
+    def inc_read_error_count(self, interface):
+        if interface:
+            self.read_error_count += 1
+            interface.inc_intf_read_error_count()
+
+    def get_read_error_report_str(self):
+        return "Node{0}:{1}/{2}({3:.2%})".format(self.index+1, self.read_error_count, \
+                self.read_block_count, (float(self.read_error_count) / float(self.read_block_count)))

--- a/src/interface/serial_node.py
+++ b/src/interface/serial_node.py
@@ -5,7 +5,7 @@ import gevent
 from monotonic import monotonic
 
 from Node import Node
-from RHInterface import RETRY_COUNT, validate_checksum, calculate_checksum
+from RHInterface import MAX_RETRY_COUNT, validate_checksum, calculate_checksum
 
 BOOTLOADER_CHILL_TIME = 2 # Delay for USB to switch from bootloader to serial mode
 
@@ -15,6 +15,11 @@ class SerialNode(Node):
         self.index = index
         self.serial = serial.Serial(port=port, baudrate=115200, timeout=0.25)
 
+    def node_log(self, interface, message):
+        if interface:
+            interface.log(message)
+        else:
+            print(message)
 
     #
     # Serial Common Functions
@@ -24,10 +29,11 @@ class SerialNode(Node):
         '''
         Read serial data given command, and data size.
         '''
+        self.inc_read_block_count(interface)
         success = False
         retry_count = 0
         data = None
-        while success is False and retry_count < RETRY_COUNT:
+        while success is False and retry_count <= MAX_RETRY_COUNT:
             try:
                 self.io_request = monotonic()
                 self.serial.flushInput()
@@ -40,58 +46,64 @@ class SerialNode(Node):
                         data = data[:-1]
                     else:
                         retry_count = retry_count + 1
-                        if retry_count < RETRY_COUNT:
-                            interface.log('Retry (bad length) in read_block:  port={0} cmd={1} size={2} retry={3}'.format(self.serial.port, command, size, retry_count))
+                        if retry_count <= MAX_RETRY_COUNT:
+                            self.node_log(interface, 'Retry (bad length) in read_block:  port={0} cmd={1} size={2} retry={3}'.format(self.serial.port, command, size, retry_count))
                         else:
-                            interface.log('Retry (bad length) limit reached in read_block:  port={0} cmd={1} size={2} retry={3}'.format(self.serial.port, command, size, retry_count))
-                        gevent.sleep(0.25)
+                            self.node_log(interface, 'Retry (bad length) limit reached in read_block:  port={0} cmd={1} size={2} retry={3}'.format(self.serial.port, command, size, retry_count))
+                        self.inc_read_error_count(interface)
+                        gevent.sleep(0.1)
                 else:
                     # self.log('Invalid Checksum ({0}): {1}'.format(retry_count, data))
                     retry_count = retry_count + 1
                     if data and len(data) > 0:
-                        if retry_count < RETRY_COUNT:
+                        if retry_count <= MAX_RETRY_COUNT:
                             if retry_count > 1:  # don't log the occasional single retry
-                                interface.log('Retry (checksum) in read_block:  port={0} cmd={1} size={2} retry={3}'.format(self.serial.port, command, size, retry_count))
+                                self.node_log(interface, 'Retry (checksum) in read_block:  port={0} cmd={1} size={2} retry={3}'.format(self.serial.port, command, size, retry_count))
                         else:
-                            interface.log('Retry (checksum) limit reached in read_block:  port={0} cmd={1} size={2} retry={3}'.format(self.serial.port, command, size, retry_count))
+                            self.node_log(interface, 'Retry (checksum) limit reached in read_block:  port={0} cmd={1} size={2} retry={3}'.format(self.serial.port, command, size, retry_count))
                     else:
-                        if retry_count < RETRY_COUNT:
-                                interface.log('Retry (no data) in read_block:  port={0} cmd={1} size={2} retry={3}'.format(self.serial.port, command, size, retry_count))
+                        if retry_count <= MAX_RETRY_COUNT:
+                                self.node_log(interface, 'Retry (no data) in read_block:  port={0} cmd={1} size={2} retry={3}'.format(self.serial.port, command, size, retry_count))
                         else:
-                            interface.log('Retry (no data) limit reached in read_block:  port={0} cmd={1} size={2} retry={3}'.format(self.serial.port, command, size, retry_count))
-                    gevent.sleep(0.25)
+                            self.node_log(interface, 'Retry (no data) limit reached in read_block:  port={0} cmd={1} size={2} retry={3}'.format(self.serial.port, command, size, retry_count))
+                    self.inc_read_error_count(interface)
+                    gevent.sleep(0.1)
             except IOError as err:
-                interface.log('Read Error: ' + str(err))
+                self.node_log(interface, 'Read Error: ' + str(err))
                 retry_count = retry_count + 1
-                if retry_count < RETRY_COUNT:
+                if retry_count <= MAX_RETRY_COUNT:
                     if retry_count > 1:  # don't log the occasional single retry
-                        interface.log('Retry (IOError) in read_block:  port={0} cmd={1} size={2} retry={3}'.format(self.serial.port, command, size, retry_count))
+                        self.node_log(interface, 'Retry (IOError) in read_block:  port={0} cmd={1} size={2} retry={3}'.format(self.serial.port, command, size, retry_count))
                 else:
-                    interface.log('Retry (IOError) limit reached in read_block:  port={0} cmd={1} size={2} retry={3}'.format(self.serial.port, command, size, retry_count))
-                gevent.sleep(0.25)
+                    self.node_log(interface, 'Retry (IOError) limit reached in read_block:  port={0} cmd={1} size={2} retry={3}'.format(self.serial.port, command, size, retry_count))
+                self.inc_read_error_count(interface)
+                gevent.sleep(0.1)
         return data if success else None
 
     def write_block(self, interface, command, data):
         '''
         Write serial data given command, and data.
         '''
+        interface.inc_intf_write_block_count()
         success = False
         retry_count = 0
         data_with_checksum = bytearray()
         data_with_checksum.append(command)
         data_with_checksum.extend(data)
         data_with_checksum.append(calculate_checksum(data_with_checksum[1:]))
-        while success is False and retry_count < RETRY_COUNT:
+        while success is False and retry_count <= MAX_RETRY_COUNT:
             try:
                 self.serial.write(data_with_checksum)
                 success = True
             except IOError as err:
-                interface.log('Write Error: ' + str(err))
+                self.node_log(interface, 'Write Error: ' + str(err))
                 retry_count = retry_count + 1
-                if retry_count < RETRY_COUNT:
-                    interface.log('Retry (IOError) in write_block:  port={0} cmd={1} data={2} retry={3}'.format(self.serial.port, command, data, retry_count))
+                if retry_count <= MAX_RETRY_COUNT:
+                    self.node_log(interface, 'Retry (IOError) in write_block:  port={0} cmd={1} data={2} retry={3}'.format(self.serial.port, command, data, retry_count))
                 else:
-                    interface.log('Retry (IOError) limit reached in write_block:  port={0} cmd={1} data={2} retry={3}'.format(self.serial.port, command, data, retry_count))
+                    self.node_log(interface, 'Retry (IOError) limit reached in write_block:  port={0} cmd={1} data={2} retry={3}'.format(self.serial.port, command, data, retry_count))
+                interface.inc_intf_write_error_count()
+                gevent.sleep(0.1)
         return success
 
 


### PR DESCRIPTION
Comm-error stats are tracked, and logged at timed intervals (if any errors to report).
  (Also logged at server shutdown)

Added 'node_log()' to 'serial_node.py' with fallback to 'print' if interface not setup.

Made (max) retry_count mean number of retries, not number of total attempts.