### PR TITLE
Use logging module

### DIFF
--- a/src/interface/BaseHardwareInterface.py
+++ b/src/interface/BaseHardwareInterface.py
@@ -1,10 +1,13 @@
 import gevent
+import logging
 import importlib
 import pkgutil
 from monotonic import monotonic
 
 ENTER_AT_PEAK_MARGIN = 5 # closest that captured enter-at level can be to node peak RSSI
 CAP_ENTER_EXIT_AT_MILLIS = 3000  # number of ms for capture of enter/exit-at levels
+
+logger = logging.getLogger(__name__)
 
 
 def discover_modules(type):
@@ -14,7 +17,7 @@ def discover_modules(type):
             try:
                 plugin_module = importlib.import_module(name)
                 plugin_modules.append(plugin_module)
-                print('Loaded module {0}'.format(name))
+                logger.info('Loaded module {0}'.format(name))
             except ImportError:
                 pass
     return plugin_modules
@@ -25,7 +28,7 @@ def discover_plugins(mod_type, *args, **kwargs):
         try:
             plugins.extend(plugin_module.discover(len(plugins), *args, **kwargs))
         except AttributeError as err:
-            print('Error loading plugin {0}: {1}'.format(plugin_module.__name__, err))
+            logger.info('Error loading plugin {0}: {1}'.format(plugin_module.__name__, err))
             pass
     return plugins
 
@@ -67,7 +70,7 @@ class BaseHardwareInterface(object):
             string = 'Interface: {0}'.format(message)
             gevent.spawn(self.hardware_log_callback, string)
         else:
-            print 'Interface: {0}'.format(message)
+            logger.info('Interface: {0}'.format(message))
 
     def process_lap_stats(self, node, readtime, lap_id, ms_val, cross_flag, pn_history, cross_list, upd_list):
         if node.scan_interval == 0:
@@ -75,18 +78,18 @@ class BaseHardwareInterface(object):
                 node.crossing_flag = cross_flag
                 if callable(self.node_crossing_callback):
                     cross_list.append(node)
-    
+
             # calc lap timestamp
             if ms_val < 0 or ms_val > 9999999:
                 ms_val = 0  # don't allow negative or too-large value
                 node.lap_timestamp = 0
             else:
                 node.lap_timestamp = readtime - (ms_val / 1000.0)
-    
+
             # if new lap detected for node then append item to updates list
             if lap_id != node.node_lap_id:
                 upd_list.append((node, lap_id, node.lap_timestamp))
-    
+
             # check if capturing enter-at level for node
             if node.cap_enter_at_flag:
                 node.cap_enter_at_total += node.current_rssi
@@ -99,7 +102,7 @@ class BaseHardwareInterface(object):
                         node.enter_at_level = node.node_peak_rssi - ENTER_AT_PEAK_MARGIN
                     if callable(self.new_enter_or_exit_at_callback):
                         gevent.spawn(self.new_enter_or_exit_at_callback, node, True)
-    
+
             # check if capturing exit-at level for node
             if node.cap_exit_at_flag:
                 node.cap_exit_at_total += node.current_rssi

--- a/src/interface/BaseHardwareInterface.py
+++ b/src/interface/BaseHardwareInterface.py
@@ -53,7 +53,6 @@ class BaseHardwareInterface(object):
         self.environmental_data_update_tracker = 0
         self.race_status = BaseHardwareInterface.RACE_STATUS_READY
         self.pass_record_callback = None # Function added in server.py
-        self.hardware_log_callback = None # Function added in server.py
         self.new_enter_or_exit_at_callback = None # Function added in server.py
         self.node_crossing_callback = None # Function added in server.py
 
@@ -65,12 +64,7 @@ class BaseHardwareInterface(object):
         return 1000*monotonic() - self.start_time
 
     def log(self, message):
-        '''Hardware log of messages.'''
-        if callable(self.hardware_log_callback):
-            string = 'Interface: {0}'.format(message)
-            gevent.spawn(self.hardware_log_callback, string)
-        else:
-            logger.info('Interface: {0}'.format(message))
+        logger.info('Interface: {0}'.format(message))
 
     def process_lap_stats(self, node, readtime, lap_id, ms_val, cross_flag, pn_history, cross_list, upd_list):
         if node.scan_interval == 0:

--- a/src/interface/MockInterface.py
+++ b/src/interface/MockInterface.py
@@ -1,6 +1,7 @@
 '''Mock hardware interface layer.'''
 
 import os
+import logging
 import gevent # For threads and timing
 import random
 from gevent.lock import BoundedSemaphore # To limit i2c calls
@@ -8,6 +9,8 @@ from monotonic import monotonic # to capture read timing
 
 from Node import Node
 from BaseHardwareInterface import BaseHardwareInterface, PeakNadirHistory
+
+logger = logging.getLogger(__name__)
 
 UPDATE_SLEEP = float(os.environ.get('RH_UPDATE_INTERVAL', '0.5')) # Main update loop delay
 
@@ -34,7 +37,7 @@ class MockInterface(BaseHardwareInterface):
             self.nodes.append(node) # Add new node to RHInterface
             try:
                 f = open("mock_data_{0}.csv".format(index+1))
-                print "Loaded mock_data_{0}.csv".format(index+1)
+                logger.info("Loaded mock_data_{0}.csv".format(index+1))
             except IOError:
                 f = None
             self.data.append(f)
@@ -55,7 +58,7 @@ class MockInterface(BaseHardwareInterface):
                 self.update()
                 gevent.sleep(UPDATE_SLEEP)
         except KeyboardInterrupt:
-            print "Update thread terminated by keyboard interrupt"
+            logger.info("Update thread terminated by keyboard interrupt")
 
     def update(self):
         upd_list = []  # list of nodes with new laps (node, new_lap_id, lap_timestamp)
@@ -154,5 +157,5 @@ class MockInterface(BaseHardwareInterface):
 
 def get_hardware_interface(*args, **kwargs):
     '''Returns the interface object.'''
-    print('Using mock hardware interface')
+    logger.info('Using mock hardware interface')
     return MockInterface(*args, **kwargs)

--- a/src/interface/bme280_sensor.py
+++ b/src/interface/bme280_sensor.py
@@ -1,7 +1,11 @@
 # coding=UTF-8
+import logging
 
 from sensor import I2CSensor, Reading
 import bme280
+
+logger = logging.getLogger(__name__)
+
 
 class BME280Sensor(I2CSensor):
     def __init__(self, name, addr, i2c_helper):
@@ -38,7 +42,7 @@ def discover(idxOffset, config, *args, **kwargs):
         name = sensor_config.get('name', url)
         try:
             sensors.append(BME280Sensor(name, addr, i2c_helper))
-            print "BME280 found at address {0}".format(addr)
+            logger.info("BME280 found at address {0}".format(addr))
         except IOError:
-            print "No BME280 at address {0}".format(addr)
+            logger.info("No BME280 at address {0}".format(addr))
     return sensors

--- a/src/interface/i2c_node.py
+++ b/src/interface/i2c_node.py
@@ -1,11 +1,14 @@
 '''RotorHazard I2C interface layer.'''
-
+import logging
 import gevent
 from gevent.lock import BoundedSemaphore # To limit i2c calls
 from monotonic import monotonic
 
 from Node import Node
 from RHInterface import READ_ADDRESS, MAX_RETRY_COUNT, validate_checksum, calculate_checksum
+
+logger = logging.getLogger(__name__)
+
 
 class I2CNode(Node):
     def __init__(self, index, addr, i2c_helper):
@@ -101,11 +104,11 @@ def discover(idxOffset, *args, **kwargs):
     for index, addr in enumerate(i2c_addrs):
         try:
             i2c_helper.i2c.read_i2c_block_data(addr, READ_ADDRESS, 1)
-            print("I2C node {0} found at address {1}".format(index+idxOffset+1, addr))
+            logger.info("I2C node {0} found at address {1}".format(index+idxOffset+1, addr))
             node = I2CNode(index+idxOffset, addr, i2c_helper) # New node instance
             nodes.append(node) # Add new node to RHInterface
         except IOError as err:
-            print("No I2C node at address {0}".format(addr))
+            logger.info("No I2C node at address {0}".format(addr))
         i2c_helper.i2c_end()
         i2c_helper.i2c_sleep()
     return nodes

--- a/src/interface/ina219_sensor.py
+++ b/src/interface/ina219_sensor.py
@@ -1,5 +1,9 @@
+import logging
 from sensor import I2CSensor, Reading
 import ina219
+
+logger = logging.getLogger(__name__)
+
 
 class INA219Sensor(I2CSensor):
     def __init__(self, name, addr, i2c_helper, config={}):
@@ -43,7 +47,7 @@ def discover(idxOffset, config, *args, **kwargs):
         name = sensor_config.get('name', url)
         try:
             sensors.append(INA219Sensor(name, addr, i2c_helper, sensor_config))
-            print "INA219 found at address {0}".format(addr)
+            logger.info("INA219 found at address {0}".format(addr))
         except IOError:
-            print "No INA219 at address {0}".format(addr)
+            logger.info("No INA219 at address {0}".format(addr))
     return sensors

--- a/src/interface/serial_node.py
+++ b/src/interface/serial_node.py
@@ -1,5 +1,5 @@
 '''RotorHazard hardware interface layer.'''
-
+import logging
 import serial # For serial comms
 import gevent
 from monotonic import monotonic
@@ -8,6 +8,9 @@ from Node import Node
 from RHInterface import MAX_RETRY_COUNT, validate_checksum, calculate_checksum
 
 BOOTLOADER_CHILL_TIME = 2 # Delay for USB to switch from bootloader to serial mode
+
+logger = logging.getLogger(__name__)
+
 
 class SerialNode(Node):
     def __init__(self, index, port):
@@ -19,7 +22,7 @@ class SerialNode(Node):
         if interface:
             interface.log(message)
         else:
-            print(message)
+            logger.info(message)
 
     #
     # Serial Common Functions
@@ -112,7 +115,7 @@ def discover(idxOffset, *args, **kwargs):
     config = kwargs['config']
     for index, comm in enumerate(getattr(config, 'SERIAL_PORTS', [])):
         node = SerialNode(index+idxOffset, comm)
-        print("Serial node {0} found at port {1}".format(index+idxOffset+1, node.serial.name))
+        logger.info("Serial node {0} found at port {1}".format(index+idxOffset+1, node.serial.name))
         nodes.append(node)
 
     gevent.sleep(BOOTLOADER_CHILL_TIME)

--- a/src/server/Config.py
+++ b/src/server/Config.py
@@ -1,9 +1,11 @@
 '''
 Global configurations
 '''
-
+import logging
 import random
 import json
+
+logger = logging.getLogger(__name__)
 
 CONFIG_FILE_NAME = 'config.json'
 
@@ -11,6 +13,7 @@ GENERAL = {}
 SENSORS = {}
 LED = {}
 SERIAL_PORTS = []
+LOGGING = {}
 
 # LED strip configuration:
 LED['LED_COUNT']      = 0       # Number of LED pixels.
@@ -34,13 +37,16 @@ GENERAL['SLAVE_TIMEOUT'] = 300 # seconds
 GENERAL['DEBUG'] = False
 GENERAL['CORS_ALLOWED_HOSTS'] = '*'
 
+
 InitResultStr = None
 
 # override defaults above with config from file
 try:
     with open(CONFIG_FILE_NAME, 'r') as f:
         ExternalConfig = json.load(f)
+
     GENERAL.update(ExternalConfig['GENERAL'])
+    LOGGING.update(ExternalConfig['LOGGING'])
 
     if 'LED' in ExternalConfig:
         LED.update(ExternalConfig['LED'])
@@ -70,7 +76,4 @@ except IOError:
     InitResultStr = "No configuration file found, using defaults"
 except ValueError as ex:
     GENERAL['configFile'] = -1
-    InitResultStr = "Configuration file invalid, using defaults; error is: " + str(ex)
-
-def getInitResultStr():
-    return InitResultStr
+    logger.exception("Configuration file invalid, using defaults; error is: ")

--- a/src/server/Language.py
+++ b/src/server/Language.py
@@ -1,26 +1,26 @@
 #
 # Translation functions
 #
-
-import Options
+import logging
 import json
+import Options
+
+logger = logging.getLogger(__name__)
+
 
 LANGUAGE_FILE_NAME = 'language.json'
 
 Languages = {}
-InitResultStr = None
 # Load language file
 try:
     with open(LANGUAGE_FILE_NAME, 'r') as f:
         Languages = json.load(f)
-    InitResultStr = 'Language file imported'
+    logger.info('Language file imported')
 except IOError:
-    InitResultStr = 'No language file found, using defaults'
+    logger.warn('No language file found, using defaults')
 except ValueError:
-    InitResultStr = 'Language file invalid, using defaults'
+    logger.error('Language file invalid, using defaults')
 
-def getInitResultStr():
-    return InitResultStr
 
 def __(text, domain=''):
     # return translated string

--- a/src/server/log.py
+++ b/src/server/log.py
@@ -1,7 +1,18 @@
 import sys
 import logging.handlers
+import gevent
 
 ROTORHAZARD_FORMAT = "<-RotorHazard-> %(message)s"
+
+
+class GEventDeferredHandler(logging.Handler):
+
+    def __init__(self, handler):
+        super(GEventDeferredHandler, self).__init__()
+        self._handler = handler
+
+    def emit(self, record):
+        gevent.spawn(self._handler.emit(record))
 
 
 class SocketForwardHandler(logging.Handler):
@@ -60,4 +71,4 @@ def later_stage_setup(config, socket):
 
     for handler in handlers:
         handler.setFormatter(logging.Formatter(ROTORHAZARD_FORMAT))
-        root.addHandler(handler)
+        root.addHandler(GEventDeferredHandler(handler))

--- a/src/server/log.py
+++ b/src/server/log.py
@@ -13,3 +13,36 @@ def early_stage_setup():
     # some 3rd party packages use logging. Good for them. Now be quiet.
     logging.getLogger("socketio.server").setLevel(logging.WARN)
     logging.getLogger("engineio.server").setLevel(logging.WARN)
+
+
+def handler_for_config(destination):
+    choices = {
+        "STDERR": logging.StreamHandler(stream=sys.stderr),
+        "STDOUT": logging.StreamHandler(stream=sys.stdout),
+        "SYSLOG": logging.handlers.SysLogHandler("/dev/log")
+    }
+    if destination in choices:
+        return choices[destination]
+    # we assume if the entry is not amongst them
+    # pre-defined choices, it's a filename
+    return logging.FileHandler(destination)
+
+
+def later_stage_setup(config):
+    logging_config = dict(
+        LEVEL="INFO",
+        DESTINATION="STDERR",
+    )
+    logging_config.update(config)
+
+    root = logging.getLogger()
+    # empty out the already configured handler
+    # from basicConfig
+    root.handlers[:] = []
+    handler = handler_for_config(
+        logging_config["DESTINATION"]
+    )
+    handler.setFormatter(logging.Formatter(ROTORHAZARD_FORMAT))
+    level = getattr(logging, logging_config["LEVEL"])
+    root.setLevel(level)
+    root.addHandler(handler)

--- a/src/server/log.py
+++ b/src/server/log.py
@@ -1,0 +1,15 @@
+import sys
+import logging.handlers
+
+ROTORHAZARD_FORMAT = "<-RotorHazard-> %(message)s"
+
+
+def early_stage_setup():
+    logging.basicConfig(
+        stream=sys.stderr,
+        level=logging.INFO,
+        format=ROTORHAZARD_FORMAT,
+    )
+    # some 3rd party packages use logging. Good for them. Now be quiet.
+    logging.getLogger("socketio.server").setLevel(logging.WARN)
+    logging.getLogger("engineio.server").setLevel(logging.WARN)

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -22,6 +22,7 @@ PROGRAM_START_TIMESTAMP = int((datetime.now() - EPOCH_START).total_seconds() / 1
 logger.info('RotorHazard v{0}'.format(RELEASE_VERSION))
 logger.info('Program started at {0:13f}'.format(PROGRAM_START_TIMESTAMP))
 
+# Normal importing resumes here
 import gevent
 import gevent.monkey
 gevent.monkey.patch_all()
@@ -105,6 +106,10 @@ DB.app = APP
 
 # start SocketIO service
 SOCKET_IO = SocketIO(APP, async_mode='gevent', cors_allowed_origins=Config.GENERAL['CORS_ALLOWED_HOSTS'])
+
+# this is the moment where we can forward log-messages to the frontend, and
+# thus set up logging for good.
+log.later_stage_setup(Config.LOGGING)
 
 INTERFACE = None  # initialized later
 CLUSTER = None    # initialized later

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -109,7 +109,7 @@ SOCKET_IO = SocketIO(APP, async_mode='gevent', cors_allowed_origins=Config.GENER
 
 # this is the moment where we can forward log-messages to the frontend, and
 # thus set up logging for good.
-log.later_stage_setup(Config.LOGGING)
+log.later_stage_setup(Config.LOGGING, SOCKET_IO)
 
 INTERFACE = None  # initialized later
 CLUSTER = None    # initialized later
@@ -195,21 +195,21 @@ class Slave:
             last_split_id = DB.session.query(DB.func.max(Database.LapSplit.split_id)).filter_by(node_index=node_index, lap_id=lap_count).scalar()
             if last_split_id is None: # first split for this lap
                 if split_id > 0:
-                    server_log('Ignoring missing splits before {0} for node {1}'.format(split_id+1, node_index+1))
+                    logger.info('Ignoring missing splits before {0} for node {1}'.format(split_id+1, node_index+1))
                 last_split_ts = last_lap_ts
             else:
                 if split_id > last_split_id:
                     if split_id > last_split_id + 1:
-                        server_log('Ignoring missing splits between {0} and {1} for node {2}'.format(last_split_id+1, split_id+1, node_index+1))
+                        logger.info('Ignoring missing splits between {0} and {1} for node {2}'.format(last_split_id+1, split_id+1, node_index+1))
                     last_split_ts = Database.LapSplit.query.filter_by(node_index=node_index, lap_id=lap_count, split_id=last_split_id).one().split_time_stamp
                 else:
-                    server_log('Ignoring out-of-order split {0} for node {1}'.format(split_id+1, node_index+1))
+                    logger.info('Ignoring out-of-order split {0} for node {1}'.format(split_id+1, node_index+1))
                     last_split_ts = None
 
             if last_split_ts is not None:
                 split_time = split_ts - last_split_ts
                 split_speed = float(self.info['distance'])*1000.0/float(split_time) if 'distance' in self.info else None
-                server_log('Split pass record: Node: {0}, Lap: {1}, Split time: {2}, Split speed: {3}' \
+                logger.info('Split pass record: Node: {0}, Lap: {1}, Split time: {2}, Split speed: {3}' \
                     .format(node_index+1, lap_count+1, time_format(split_time), \
                     ('{0:.2f}'.format(split_speed) if split_speed <> None else 'None')))
 
@@ -219,7 +219,7 @@ class Slave:
                 DB.session.commit()
                 emit_current_laps() # update all laps on the race page
         else:
-            server_log('Split pass record dismissed: Node: {0}, Frequency not defined' \
+            logger.info('Split pass record dismissed: Node: {0}, Frequency not defined' \
                 .format(node_index+1))
 
 class Cluster:
@@ -337,8 +337,8 @@ def idAndLogSystemInfo():
             pass
         if modelStr and "raspberry pi" in modelStr.lower():
             IS_SYS_RASPBERRY_PI = True
-            server_log("Host machine: " + modelStr)
-        server_log("Host OS: {0} {1}".format(platform.system(), platform.release()))
+            logger.info("Host machine: " + modelStr)
+        logger.info("Host OS: {0} {1}".format(platform.system(), platform.release()))
     except Exception as ex:
         logger.exception("Error in idAndLogSystemInfo():  ")
 
@@ -352,9 +352,9 @@ def checkSetFileOwnerPi(fileNameStr):
                 subprocess.check_call(["sudo", "chown", "pi:pi", fileNameStr])
                 if os.stat(fileNameStr).st_uid != 0:
                     return True
-                server_log("Unable to change owner in 'checkSetFileOwnerPi()', file: " + fileNameStr)
+                logger.info("Unable to change owner in 'checkSetFileOwnerPi()', file: " + fileNameStr)
     except Exception as ex:
-        server_log("Error in 'checkSetFileOwnerPi()':  " + str(ex))
+        logger.info("Error in 'checkSetFileOwnerPi()':  " + str(ex))
     return False
 
 #
@@ -836,18 +836,18 @@ def api_options():
 @SOCKET_IO.on('connect')
 def connect_handler():
     '''Starts the interface and a heartbeat thread for rssi.'''
-    server_log('Client connected')
+    logger.info('Client connected')
     INTERFACE.start()
     global HEARTBEAT_THREAD
     if HEARTBEAT_THREAD is None:
         HEARTBEAT_THREAD = gevent.spawn(heartbeat_thread_function)
-        server_log('Heartbeat thread started')
+        logger.info('Heartbeat thread started')
     emit_heat_data(nobroadcast=True)
 
 @SOCKET_IO.on('disconnect')
 def disconnect_handler():
     '''Emit disconnect event.'''
-    server_log('Client disconnected')
+    logger.info('Client disconnected')
 
 # LiveTime compatible events
 
@@ -891,7 +891,7 @@ def on_join_cluster():
     emit_race_format()
     Options.set("MinLapSec", "0")
     Options.set("MinLapBehavior", "0")
-    server_log('Joined cluster')
+    logger.info('Joined cluster')
 
 # RotorHazard events
 
@@ -972,7 +972,7 @@ def on_set_frequency(data):
     DB.session.commit()
 
     '''Set node frequency.'''
-    server_log('Frequency set: Node {0} Frequency {1}'.format(node_index+1, frequency))
+    logger.info('Frequency set: Node {0} Frequency {1}'.format(node_index+1, frequency))
     INTERFACE.set_frequency(node_index, frequency)
     if session.get('LiveTime', False):
         emit('frequency_set', data)
@@ -1012,7 +1012,7 @@ def set_all_frequencies(freqs):
 
     for idx in range(RACE.num_nodes):
         profile_freqs["f"][idx] = freqs[idx]
-        server_log('Frequency set: Node {0} Frequency {1}'.format(idx+1, freqs[idx]))
+        logger.info('Frequency set: Node {0} Frequency {1}'.format(idx+1, freqs[idx]))
 
     profile.frequencies = json.dumps(profile_freqs)
     DB.session.commit()
@@ -1029,7 +1029,7 @@ def restore_node_frequency(node_index):
     profile_freqs = json.loads(profile.frequencies)
     freq = profile_freqs["f"][node_index]
     INTERFACE.set_frequency(node_index, freq)
-    server_log('Frequency restored: Node {0} Frequency {1}'.format(node_index+1, freq))
+    logger.info('Frequency restored: Node {0} Frequency {1}'.format(node_index+1, freq))
 
 @SOCKET_IO.on('set_enter_at_level')
 def on_set_enter_at_level(data):
@@ -1038,7 +1038,7 @@ def on_set_enter_at_level(data):
     enter_at_level = data['enter_at_level']
 
     if not enter_at_level:
-        server_log('Node enter-at set null; getting from node: Node {0}'.format(node_index+1))
+        logger.info('Node enter-at set null; getting from node: Node {0}'.format(node_index+1))
         enter_at_level = INTERFACE.nodes[node_index].enter_at_level
 
     profile = getCurrentProfile()
@@ -1048,7 +1048,7 @@ def on_set_enter_at_level(data):
     DB.session.commit()
 
     INTERFACE.set_enter_at_level(node_index, enter_at_level)
-    server_log('Node enter-at set: Node {0} Level {1}'.format(node_index+1, enter_at_level))
+    logger.info('Node enter-at set: Node {0} Level {1}'.format(node_index+1, enter_at_level))
 
 @SOCKET_IO.on('set_exit_at_level')
 def on_set_exit_at_level(data):
@@ -1057,7 +1057,7 @@ def on_set_exit_at_level(data):
     exit_at_level = data['exit_at_level']
 
     if not exit_at_level:
-        server_log('Node exit-at set null; getting from node: Node {0}'.format(node_index+1))
+        logger.info('Node exit-at set null; getting from node: Node {0}'.format(node_index+1))
         exit_at_level = INTERFACE.nodes[node_index].exit_at_level
 
     profile = getCurrentProfile()
@@ -1067,7 +1067,7 @@ def on_set_exit_at_level(data):
     DB.session.commit()
 
     INTERFACE.set_exit_at_level(node_index, exit_at_level)
-    server_log('Node exit-at set: Node {0} Level {1}'.format(node_index+1, exit_at_level))
+    logger.info('Node exit-at set: Node {0} Level {1}'.format(node_index+1, exit_at_level))
 
 def hardware_set_all_enter_ats(enter_at_levels):
     '''send update to nodes'''
@@ -1103,14 +1103,14 @@ def on_cap_enter_at_btn(data):
     '''Capture enter-at level.'''
     node_index = data['node_index']
     if INTERFACE.start_capture_enter_at_level(node_index):
-        server_log('Starting capture of enter-at level for node {0}'.format(node_index+1))
+        logger.info('Starting capture of enter-at level for node {0}'.format(node_index+1))
 
 @SOCKET_IO.on('cap_exit_at_btn')
 def on_cap_exit_at_btn(data):
     '''Capture exit-at level.'''
     node_index = data['node_index']
     if INTERFACE.start_capture_exit_at_level(node_index):
-        server_log('Starting capture of exit-at level for node {0}'.format(node_index+1))
+        logger.info('Starting capture of exit-at level for node {0}'.format(node_index+1))
 
 @SOCKET_IO.on('set_scan')
 def on_set_scan(data):
@@ -1141,7 +1141,7 @@ def on_add_heat():
         DB.session.add(Database.HeatNode(heat_id=new_heat.id, node_index=node, pilot_id=PILOT_ID_NONE))
 
     DB.session.commit()
-    server_log('Heat added: Heat {0}'.format(new_heat.id))
+    logger.info('Heat added: Heat {0}'.format(new_heat.id))
     emit_heat_data()
 
 @SOCKET_IO.on('alter_heat')
@@ -1174,7 +1174,7 @@ def on_alter_heat(data):
             else:
                 RACE.node_teams[heatNode.node_index] = None
 
-    server_log('Heat {0} altered with {1}'.format(heat_id, data))
+    logger.info('Heat {0} altered with {1}'.format(heat_id, data))
     emit_heat_data(noself=True)
     if 'note' in data:
         emit_round_data_notify() # live update rounds page
@@ -1194,10 +1194,10 @@ def on_delete_heat(data):
         if RACE.current_heat == heat:
             RACE.current_heat = Database.Heat.query.first()
 
-        server_log('Heat {0} deleted'.format(heat))
+        logger.info('Heat {0} deleted'.format(heat))
         emit_heat_data(noself=True)
     else:
-        server_log('Refusing to delete only heat')
+        logger.info('Refusing to delete only heat')
 
 @SOCKET_IO.on('add_race_class')
 def on_add_race_class():
@@ -1209,7 +1209,7 @@ def on_add_race_class():
     new_race_class.name = ''
     new_race_class.description = ''
     DB.session.commit()
-    server_log('Class added: Class {0}'.format(new_race_class))
+    logger.info('Class added: Class {0}'.format(new_race_class))
     emit_class_data()
     emit_heat_data() # Update class selections in heat displays
 
@@ -1227,7 +1227,7 @@ def on_alter_race_class(data):
     if 'class_description' in data:
         db_update.description = data['class_description']
     DB.session.commit()
-    server_log('Altered race class {0} to {1}'.format(race_class, data))
+    logger.info('Altered race class {0} to {1}'.format(race_class, data))
     emit_class_data(noself=True)
     if 'class_name' in data:
         emit_heat_data() # Update class names in heat displays
@@ -1251,7 +1251,7 @@ def on_add_pilot():
     new_pilot.team = DEF_TEAM_NAME
     new_pilot.phonetic = ''
     DB.session.commit()
-    server_log('Pilot added: Pilot {0}'.format(new_pilot.id))
+    logger.info('Pilot added: Pilot {0}'.format(new_pilot.id))
     emit_pilot_data()
 
 @SOCKET_IO.on('alter_pilot')
@@ -1270,7 +1270,7 @@ def on_alter_pilot(data):
         db_update.name = data['name']
 
     DB.session.commit()
-    server_log('Altered pilot {0} to {1}'.format(pilot_id, data))
+    logger.info('Altered pilot {0} to {1}'.format(pilot_id, data))
     emit_pilot_data(noself=True) # Settings page, new pilot settings
     if 'callsign' in data:
         invalidate_all_caches() # wipe caches (all have stored pilot names)
@@ -1310,7 +1310,7 @@ def on_delete_profile():
         Options.set("currentProfile", first_profile_id)
         on_set_profile(data={ 'profile': first_profile_id })
     else:
-        server_log('Refusing to delete only profile')
+        logger.info('Refusing to delete only profile')
 
 @SOCKET_IO.on('alter_profile')
 def on_alter_profile(data):
@@ -1321,7 +1321,7 @@ def on_alter_profile(data):
     if 'profile_description' in data:
         profile.description = data['profile_description']
     DB.session.commit()
-    server_log('Altered current profile to %s' % (data))
+    logger.info('Altered current profile to %s' % (data))
     emit_node_tuning(noself=True)
 
 @SOCKET_IO.on("set_profile")
@@ -1332,7 +1332,7 @@ def on_set_profile(data, emit_vals=True):
     profile = Database.Profiles.query.get(profile_val)
     if profile:
         Options.set("currentProfile", data['profile'])
-        server_log("Set Profile to '%s'" % profile_val)
+        logger.info("Set Profile to '%s'" % profile_val)
         # set freqs, enter_ats, and exit_ats
         freqs_loaded = json.loads(profile.frequencies)
         freqs = freqs_loaded["f"]
@@ -1368,7 +1368,7 @@ def on_set_profile(data, emit_vals=True):
         hardware_set_all_exit_ats(exit_ats)
 
     else:
-        server_log('Invalid set_profile value: ' + str(profile_val))
+        logger.info('Invalid set_profile value: ' + str(profile_val))
 
 @SOCKET_IO.on('backup_database')
 def on_backup_database():
@@ -1427,7 +1427,7 @@ def on_shutdown_pi():
     Events.trigger(Evt.SHUTDOWN)  # server is shutting down, so shut off LEDs
     CLUSTER.emit('shutdown_pi')
     emit_priority_message(__('Server has shut down.'), True)
-    server_log('Shutdown pi')
+    logger.info('Shutdown pi')
     gevent.sleep(1);
     os.system("sudo shutdown now")
 
@@ -1437,7 +1437,7 @@ def on_reboot_pi():
     Events.trigger(Evt.SHUTDOWN)  # server is shutting down, so shut off LEDs
     CLUSTER.emit('reboot_pi')
     emit_priority_message(__('Server is rebooting.'), True)
-    server_log('Rebooting pi')
+    logger.info('Rebooting pi')
     gevent.sleep(1);
     os.system("sudo reboot now")
 
@@ -1445,14 +1445,14 @@ def on_reboot_pi():
 def on_set_min_lap(data):
     min_lap = data['min_lap']
     Options.set("MinLapSec", data['min_lap'])
-    server_log("set min lap time to %s seconds" % min_lap)
+    logger.info("set min lap time to %s seconds" % min_lap)
     emit_min_lap(noself=True)
 
 @SOCKET_IO.on("set_min_lap_behavior")
 def on_set_min_lap_behavior(data):
     min_lap_behavior = data['min_lap_behavior']
     Options.set("MinLapBehavior", data['min_lap_behavior'])
-    server_log("set min lap behavior to %s" % min_lap_behavior)
+    logger.info("set min lap behavior to %s" % min_lap_behavior)
     emit_min_lap(noself=True)
 
 @SOCKET_IO.on("set_race_format")
@@ -1465,11 +1465,11 @@ def on_set_race_format(data):
         setCurrentRaceFormat(race_format)
         DB.session.commit()
         emit_race_format()
-        server_log("set race format to '%s' (%s)" % (race_format.name, race_format.id))
+        logger.info("set race format to '%s' (%s)" % (race_format.name, race_format.id))
         CLUSTER.emitToMirrors('set_race_format', data)
     else:
         emit_priority_message(__('Format change prevented by active race: Stop and save/discard laps'), False, nobroadcast=True)
-        server_log("Format change prevented by active race")
+        logger.info("Format change prevented by active race")
         emit_race_format()
 
 @SOCKET_IO.on('add_race_format')
@@ -1504,10 +1504,10 @@ def on_delete_race_format():
             setCurrentRaceFormat(first_raceFormat)
             emit_race_format()
         else:
-            server_log('Refusing to delete only format')
+            logger.info('Refusing to delete only format')
     else:
         emit_priority_message(__('Format change prevented by active race: Stop and save/discard laps'), False, nobroadcast=True)
-        server_log("Format change prevented by active race")
+        logger.info("Format change prevented by active race")
 
 @SOCKET_IO.on('alter_race_format')
 def on_alter_race_format(data):
@@ -1536,7 +1536,7 @@ def on_alter_race_format(data):
             race_format.team_racing_mode = (True if data['team_racing_mode'] else False)
         DB.session.commit()
         setCurrentRaceFormat(race_format)
-        server_log('Altered race format to %s' % (data))
+        logger.info('Altered race format to %s' % (data))
         if emit:
             emit_race_format()
             emit_class_data()
@@ -1608,7 +1608,7 @@ def on_set_led_effect(data):
         effects[data['event']] = data['effect']
         Options.set('ledEffects', json.dumps(effects))
 
-        server_log('Set LED event {0} to effect {1}'.format(data['event'], data['effect']))
+        logger.info('Set LED event {0} to effect {1}'.format(data['event'], data['effect']))
 
 @SOCKET_IO.on('use_led_effect')
 def on_use_led_effect(data):
@@ -1737,7 +1737,7 @@ def findBestValues(node, node_index):
 
     # test for disabled node
     if pilot is PILOT_ID_NONE or node.frequency is FREQUENCY_ID_NONE:
-        server_log('Node {0} calibration: skipping disabled node'.format(node.index+1))
+        logger.info('Node {0} calibration: skipping disabled node'.format(node.index+1))
         return {
             'enter_at_level': node.enter_at_level,
             'exit_at_level': node.exit_at_level
@@ -1749,7 +1749,7 @@ def findBestValues(node, node_index):
     if race_query:
         pilotrace_query = Database.SavedPilotRace.query.filter_by(race_id=race_query.id, pilot_id=pilot).order_by(-Database.SavedPilotRace.id).first()
         if pilotrace_query:
-            server_log('Node {0} calibration: found same pilot+node in same heat'.format(node.index+1))
+            logger.info('Node {0} calibration: found same pilot+node in same heat'.format(node.index+1))
             return {
                 'enter_at_level': pilotrace_query.enter_at,
                 'exit_at_level': pilotrace_query.exit_at
@@ -1760,7 +1760,7 @@ def findBestValues(node, node_index):
     if race_query:
         pilotrace_query = Database.SavedPilotRace.query.filter_by(race_id=race_query.id, node_index=node_index, pilot_id=pilot).order_by(-Database.SavedPilotRace.id).first()
         if pilotrace_query:
-            server_log('Node {0} calibration: found same pilot+node in other heat with same class'.format(node.index+1))
+            logger.info('Node {0} calibration: found same pilot+node in other heat with same class'.format(node.index+1))
             return {
                 'enter_at_level': pilotrace_query.enter_at,
                 'exit_at_level': pilotrace_query.exit_at
@@ -1769,7 +1769,7 @@ def findBestValues(node, node_index):
     # test for same pilot, same node
     pilotrace_query = Database.SavedPilotRace.query.filter_by(node_index=node_index, pilot_id=pilot).order_by(-Database.SavedPilotRace.id).first()
     if pilotrace_query:
-        server_log('Node {0} calibration: found same pilot+node in other heat with other class'.format(node.index+1))
+        logger.info('Node {0} calibration: found same pilot+node in other heat with other class'.format(node.index+1))
         return {
             'enter_at_level': pilotrace_query.enter_at,
             'exit_at_level': pilotrace_query.exit_at
@@ -1778,14 +1778,14 @@ def findBestValues(node, node_index):
     # test for same node
     pilotrace_query = Database.SavedPilotRace.query.filter_by(node_index=node_index).order_by(-Database.SavedPilotRace.id).first()
     if pilotrace_query:
-        server_log('Node {0} calibration: found same node in other heat'.format(node.index+1))
+        logger.info('Node {0} calibration: found same node in other heat'.format(node.index+1))
         return {
             'enter_at_level': pilotrace_query.enter_at,
             'exit_at_level': pilotrace_query.exit_at
         }
 
     # fallback
-    server_log('Node {0} calibration: no calibration hints found, no change.format(node.index+1)')
+    logger.info('Node {0} calibration: no calibration hints found, no change.format(node.index+1)')
     return {
         'enter_at_level': node.enter_at_level,
         'exit_at_level': node.exit_at_level
@@ -1798,7 +1798,7 @@ def race_start_thread(start_token):
     for node in INTERFACE.nodes:
         if node.crossing_flag and node.frequency > 0 and node.current_pilot_id != PILOT_ID_NONE and \
                     node.current_rssi < node.enter_at_level:
-            server_log("Forcing end crossing for node {0} at staging (rssi={1}, enterAt={2}, exitAt={3})".\
+            logger.info("Forcing end crossing for node {0} at staging (rssi={1}, enterAt={2}, exitAt={3})".\
                        format(node.index+1, node.current_rssi, node.enter_at_level, node.exit_at_level))
             INTERFACE.force_end_crossing(node.index)
 
@@ -1827,7 +1827,7 @@ def race_start_thread(start_token):
             node.under_min_lap_count = 0
             # clear any lingering crossing (if rssi>enterAt then first crossing starts now)
             if node.crossing_flag and node.frequency > 0 and node.current_pilot_id != PILOT_ID_NONE:
-                server_log("Forcing end crossing for node {0} at start (rssi={1}, enterAt={2}, exitAt={3})".\
+                logger.info("Forcing end crossing for node {0} at start (rssi={1}, enterAt={2}, exitAt={3})".\
                            format(node.index+1, node.current_rssi, node.enter_at_level, node.exit_at_level))
                 INTERFACE.force_end_crossing(node.index)
 
@@ -1836,7 +1836,7 @@ def race_start_thread(start_token):
         RACE.timer_running = 1 # indicate race timer is running
         RACE.laps_winner_name = None  # name of winner in first-to-X-laps race
         emit_race_status() # Race page, to set race button states
-        server_log('Race started at {0} ({1:13f})'.format(RACE.start_time_monotonic, monotonic_to_milliseconds(RACE.start_time_monotonic)))
+        logger.info('Race started at {0} ({1:13f})'.format(RACE.start_time_monotonic, monotonic_to_milliseconds(RACE.start_time_monotonic)))
 
 @SOCKET_IO.on('stop_race')
 def on_stop_race():
@@ -1850,19 +1850,19 @@ def on_stop_race():
         milli_sec = delta_time * 1000.0
         RACE.duration_ms = milli_sec
 
-        server_log('Race stopped at {0} ({1:13f}), duration {2}ms'.format(RACE.end_time, monotonic_to_milliseconds(RACE.end_time), RACE.duration_ms))
+        logger.info('Race stopped at {0} ({1:13f}), duration {2}ms'.format(RACE.end_time, monotonic_to_milliseconds(RACE.end_time), RACE.duration_ms))
 
         min_laps_list = []  # show nodes with laps under minimum (if any)
         for node in INTERFACE.nodes:
             if node.under_min_lap_count > 0:
                 min_laps_list.append('Node {0} Count={1}'.format(node.index+1, node.under_min_lap_count))
         if len(min_laps_list) > 0:
-            server_log('Nodes with laps under minimum:  ' + ', '.join(min_laps_list))
+            logger.info('Nodes with laps under minimum:  ' + ', '.join(min_laps_list))
 
         RACE.race_status = RaceStatus.DONE # To stop registering passed laps, waiting for laps to be cleared
         INTERFACE.set_race_status(RaceStatus.DONE)
     else:
-        server_log('No active race to stop')
+        logger.info('No active race to stop')
         RACE.race_status = RaceStatus.READY # Go back to ready state
         INTERFACE.set_race_status(RaceStatus.READY)
         led_manager.clear()
@@ -1946,7 +1946,7 @@ def on_save_laps():
     }
     gevent.spawn(build_race_results_caches, params)
 
-    server_log('Current laps saved: Heat {0} Round {1}'.format(RACE.current_heat, max_round+1))
+    logger.info('Current laps saved: Heat {0} Round {1}'.format(RACE.current_heat, max_round+1))
     on_discard_laps() # Also clear the current laps
     emit_round_data_notify() # live update rounds page
 
@@ -1992,7 +1992,7 @@ def on_resave_laps(data):
     DB.session.commit()
     message = __('Race times adjusted for: Heat {0} Round {1} / {2}').format(heat_id, round_id, callsign)
     emit_priority_message(message, False)
-    server_log(message)
+    logger.info(message)
 
     # spawn thread for updating results caches
     params = {
@@ -2034,7 +2034,7 @@ def clear_laps():
     db_reset_current_laps() # Clear out the current laps table
     DB.session.query(Database.LapSplit).delete()
     DB.session.commit()
-    server_log('Current laps cleared')
+    logger.info('Current laps cleared')
 
 def init_node_cross_fields():
     '''Sets the 'current_pilot_id' and 'cross' values on each node.'''
@@ -2086,7 +2086,7 @@ def on_set_current_heat(data):
         else:
             RACE.node_teams[heatNode.node_index] = None
 
-    server_log('Current heat set: Heat {0}'.format(new_heat_id))
+    logger.info('Current heat set: Heat {0}'.format(new_heat_id))
 
     if int(Options.get('calibrationMode')):
         autoUpdateCalibration()
@@ -2133,7 +2133,7 @@ def on_delete_lap(data):
         db_next['lap_time'] = db_next['lap_time_stamp']
         db_next['lap_time_formatted'] = time_format(db_next['lap_time'])
 
-    server_log('Lap deleted: Node {0} Lap {1}'.format(node_index+1, lap_index))
+    logger.info('Lap deleted: Node {0} Lap {1}'.format(node_index+1, lap_index))
     emit_current_laps() # Race page, update web client
     emit_leaderboard() # Race page, update web client
     race_format = getCurrentRaceFormat()
@@ -2155,7 +2155,7 @@ def on_delete_lap(data):
 def on_simulate_lap(data):
     '''Simulates a lap (for debug testing).'''
     node_index = data['node']
-    server_log('Simulated lap: Node {0}'.format(node_index+1))
+    logger.info('Simulated lap: Node {0}'.format(node_index+1))
     Events.trigger(Evt.CROSSINGEXIT, {
         'nodeIndex': node_index,
         'color': hexToColor(Options.get('colorNode_' + str(node_index), '#ffffff'))
@@ -2756,7 +2756,7 @@ def invalidate_all_caches():
     global FULL_RESULTS_CACHE_VALID
     FULL_RESULTS_CACHE_VALID = False
 
-    server_log('All Result caches invalidated')
+    logger.info('All Result caches invalidated')
 
 def normalize_cache_status():
     ''' Check all caches and invalidate any paused builds '''
@@ -2780,7 +2780,7 @@ def normalize_cache_status():
     global FULL_RESULTS_CACHE_VALID
     FULL_RESULTS_CACHE_VALID = False
 
-    server_log('All Result caches normalized')
+    logger.info('All Result caches normalized')
 
 def build_race_results_caches(params):
     global FULL_RESULTS_CACHE
@@ -2826,7 +2826,7 @@ def build_race_results_caches(params):
     Options.set("eventResults", json.dumps(calc_leaderboard()))
     Options.set("eventResults_cacheStatus", CacheStatus.VALID)
 
-    server_log('Built result caches: Race {0}, Heat {1}, Class {2}, Event'.format(params['race_id'], params['heat_id'], heat.class_id))
+    logger.info('Built result caches: Race {0}, Heat {1}, Class {2}, Event'.format(params['race_id'], params['heat_id'], heat.class_id))
 
 def calc_leaderboard(**params):
     ''' Generates leaderboards '''
@@ -3334,7 +3334,7 @@ def get_team_laps_info(cur_pilot_id=-1, num_laps_win=0):
             pilot_id = node_pilot_dict.get(node.index)
             if pilot_id:
                 pilot_team_dict[pilot_id] = Database.Pilot.query.filter_by(id=pilot_id).one().team
-    #server_log('DEBUG get_team_laps_info pilot_team_dict: {0}'.format(pilot_team_dict))
+    #logger.info('DEBUG get_team_laps_info pilot_team_dict: {0}'.format(pilot_team_dict))
 
     t_laps_dict = {}  # create dictionary (key=team_name, value=[lapCount,timestamp]) with initial zero laps
     for team_name in pilot_team_dict.values():
@@ -3356,8 +3356,8 @@ def get_team_laps_info(cur_pilot_id=-1, num_laps_win=0):
                 t_laps_dict[team_name][0] += 1       # increment lap count for team
                 if num_laps_win == 0 or t_laps_dict[team_name][0] <= num_laps_win:
                     t_laps_dict[team_name][1] = item['lap_time_stamp']  # update lap_time_stamp (if not past winning lap)
-                #server_log('DEBUG get_team_laps_info team[{0}]={1} item: {2}'.format(team_name, t_laps_dict[team_name], item))
-    #server_log('DEBUG get_team_laps_info t_laps_dict: {0}'.format(t_laps_dict))
+                #logger.info('DEBUG get_team_laps_info team[{0}]={1} item: {2}'.format(team_name, t_laps_dict[team_name], item))
+    #logger.info('DEBUG get_team_laps_info t_laps_dict: {0}'.format(t_laps_dict))
 
     if cur_pilot_id >= 0:  # determine name for 'cur_pilot_id' if given
         cur_team_name = pilot_team_dict[cur_pilot_id]
@@ -3380,7 +3380,7 @@ def check_emit_team_racing_status(t_laps_dict=None, **params):
             disp_str += '<span class="team-winner">Winner is Team ' + RACE.laps_winner_name + '</span>'
         else:
             disp_str += '<span class="team-winner">' + RACE.laps_winner_name + '</span>'
-    #server_log('Team racing status: ' + disp_str)
+    #logger.info('Team racing status: ' + disp_str)
     emit_team_racing_status(disp_str)
 
 def emit_team_racing_stat_if_enb(**params):
@@ -3417,16 +3417,16 @@ def check_pilot_laps_win(pass_node_index, num_laps_win):
                             # if (other) pilot crossing for possible winning lap then wait
                             #  in case lap time turns out to be earliest:
                 if node.crossing_flag and node.index != pass_node_index and lap_count == num_laps_win - 1:
-                    server_log('check_pilot_laps_win waiting for crossing, Node {0}'.format(node.index+1))
+                    logger.info('check_pilot_laps_win waiting for crossing, Node {0}'.format(node.index+1))
                     return -1
                 if lap_count >= num_laps_win:
                     lap_data = filter(lambda lap : lap['lap_number']==num_laps_win, RACE.get_active_laps()[node.index])
-                    #server_log('DEBUG check_pilot_laps_win Node {0} pilot_id={1} tstamp={2}'.format(node.index+1, pilot_id, lap_data.lap_time_stamp))
+                    #logger.info('DEBUG check_pilot_laps_win Node {0} pilot_id={1} tstamp={2}'.format(node.index+1, pilot_id, lap_data.lap_time_stamp))
                              # save pilot_id for earliest lap time:
                     if win_pilot_id < 0 or lap_data[0]['lap_time_stamp'] < win_lap_tstamp:
                         win_pilot_id = pilot_id
                         win_lap_tstamp = lap_data[0]['lap_time_stamp']
-    #server_log('DEBUG check_pilot_laps_win returned win_pilot_id={0}'.format(win_pilot_id))
+    #logger.info('DEBUG check_pilot_laps_win returned win_pilot_id={0}'.format(win_pilot_id))
     return win_pilot_id
 
 def check_team_laps_win(t_laps_dict, num_laps_win, pilot_team_dict, pass_node_index=-1):
@@ -3452,7 +3452,7 @@ def check_team_laps_win(t_laps_dict, num_laps_win, pilot_team_dict, pass_node_in
                                         # if pilot crossing for possible winning lap then wait
                                         #  in case lap time turns out to be earliest:
                             if ent and ent[0] == num_laps_win - 1:
-                                server_log('check_team_laps_win waiting for crossing, Node {0}'.format(node.index+1))
+                                logger.info('check_team_laps_win waiting for crossing, Node {0}'.format(node.index+1))
                                 return
     win_name = None
     win_tstamp = -1
@@ -3463,7 +3463,7 @@ def check_team_laps_win(t_laps_dict, num_laps_win, pilot_team_dict, pass_node_in
         if ent[0] >= num_laps_win and (win_tstamp < 0 or ent[1] < win_tstamp):
             win_name = team_name
             win_tstamp = ent[1]
-    #server_log('DEBUG check_team_laps_win win_name={0} tstamp={1}'.format(win_name,win_tstamp))
+    #logger.info('DEBUG check_team_laps_win win_name={0} tstamp={1}'.format(win_name,win_tstamp))
     RACE.laps_winner_name = win_name
 
 def check_most_laps_win(pass_node_index=-1, t_laps_dict=None, pilot_team_dict=None):
@@ -3502,7 +3502,7 @@ def check_most_laps_win(pass_node_index=-1, t_laps_dict=None, pilot_team_dict=No
                             win_tstamp = ent[1]
                     else:  # waiting for crossing
                         tied_flag = True
-        #server_log('DEBUG check_most_laps_win tied={0} win_name={1} tstamp={2}'.format(tied_flag,win_name,win_tstamp))
+        #logger.info('DEBUG check_most_laps_win tied={0} win_name={1} tstamp={2}'.format(tied_flag,win_name,win_tstamp))
 
         if tied_flag or max_lap_count <= 0:
             RACE.laps_winner_name = RACE.status_tied_str  # indicate status tied
@@ -3540,7 +3540,7 @@ def check_most_laps_win(pass_node_index=-1, t_laps_dict=None, pilot_team_dict=No
                                                 RACE.laps_winner_name = RACE.status_crossing
                                             else:  # if called from 'pass_record_callback()' then no more ties
                                                 RACE.laps_winner_name = RACE.status_tied_str
-                                            server_log('check_most_laps_win waiting for crossing, Node {0}'.\
+                                            logger.info('check_most_laps_win waiting for crossing, Node {0}'.\
                                                                                   format(node.index+1))
                                             return
 
@@ -3579,7 +3579,7 @@ def check_most_laps_win(pass_node_index=-1, t_laps_dict=None, pilot_team_dict=No
                                 num_max_lap = 1
                             elif lap_count == max_lap_id:
                                 num_max_lap += 1  # count number of nodes at max lap
-        #server_log('DEBUG check_most_laps_win pass_node_index={0} max_lap={1}'.format(pass_node_index, max_lap_id))
+        #logger.info('DEBUG check_most_laps_win pass_node_index={0} max_lap={1}'.format(pass_node_index, max_lap_id))
 
         if max_lap_id <= 0:  # if no laps then bail out
             RACE.laps_winner_name = RACE.status_tied_str  # indicate status tied
@@ -3599,7 +3599,7 @@ def check_most_laps_win(pass_node_index=-1, t_laps_dict=None, pilot_team_dict=No
                         RACE.laps_winner_name = RACE.status_crossing
                     else:  # if called from 'pass_record_callback()' then no more ties
                         RACE.laps_winner_name = RACE.status_tied_str
-                    server_log('check_most_laps_win waiting for crossing, Node {0}'.format(item[3].index+1))
+                    logger.info('check_most_laps_win waiting for crossing, Node {0}'.format(item[3].index+1))
                     return
             else:
                 pass_node_lap_id = item[0]  # save 'lap_id' for node/pilot that caused current lap pass
@@ -3633,7 +3633,7 @@ def check_most_laps_win(pass_node_index=-1, t_laps_dict=None, pilot_team_dict=No
                             emit_team_racing_status(RACE.laps_winner_name)
                             emit_phonetic_text('Race tied', 'race_winner')
                         return  # wait for next 'pass_record_callback()' event
-        #server_log('DEBUG check_most_laps_win win_pilot_id={0}'.format(win_pilot_id))
+        #logger.info('DEBUG check_most_laps_win win_pilot_id={0}'.format(win_pilot_id))
 
         if win_pilot_id >= 0:
             win_callsign = Database.Pilot.query.filter_by(id=win_pilot_id).one().callsign
@@ -3736,7 +3736,7 @@ def emit_imdtabler_page(**params):
                     fs_list.append(str(val))
             emit_imdtabler_data(fs_list, imdtabler_ver)
         except Exception as ex:
-            server_log('emit_imdtabler_page exception:  ' + str(ex))
+            logger.info('emit_imdtabler_page exception:  ' + str(ex))
 
 def emit_imdtabler_data(fs_list, imdtabler_ver=None, **params):
     '''Emits IMDTabler data for given frequencies.'''
@@ -3747,7 +3747,7 @@ def emit_imdtabler_data(fs_list, imdtabler_ver=None, **params):
                         'java -jar ' + IMDTABLER_JAR_NAME + ' -t ' + ' '.join(fs_list), shell=True)
     except Exception as ex:
         imdtabler_data = None
-        server_log('emit_imdtabler_data exception:  ' + str(ex))
+        logger.info('emit_imdtabler_data exception:  ' + str(ex))
     emit_payload = {
         'freq_list': ' '.join(fs_list),
         'table_data': imdtabler_data,
@@ -3773,7 +3773,7 @@ def emit_imdtabler_rating():
                         'java -jar ' + IMDTABLER_JAR_NAME + ' -r ' + ' '.join(fs_list), shell=True).rstrip()
     except Exception as ex:
         imd_val = None
-        server_log('emit_imdtabler_rating exception:  ' + str(ex))
+        logger.info('emit_imdtabler_rating exception:  ' + str(ex))
     emit_payload = {
             'imd_rating': imd_val
         }
@@ -3834,7 +3834,7 @@ def heartbeat_thread_function():
                         else ERROR_REPORT_INTERVAL_SECS/10):
                 heartbeat_thread_function.last_error_rep_time = time_now
                 if INTERFACE.get_intf_total_error_count() > 0:
-                    server_log(INTERFACE.get_intf_error_report_str())
+                    logger.info(INTERFACE.get_intf_error_report_str())
 
             gevent.sleep(0.500/HEARTBEAT_DATA_RATE_FACTOR)
 
@@ -3842,8 +3842,8 @@ def heartbeat_thread_function():
             print("Heartbeat thread terminated by keyboard interrupt")
             return
         except Exception as ex:
-            server_log('Exception in Heartbeat thread loop:  ' + str(ex))
-            server_log(traceback.format_exc())
+            logger.info('Exception in Heartbeat thread loop:  ' + str(ex))
+            logger.info(traceback.format_exc())
             gevent.sleep(0.500)
 
 # declare/initialize variables for heartbeat functions
@@ -3923,7 +3923,7 @@ def check_race_time_expired():
 def pass_record_callback(node, lap_timestamp_absolute, source):
     '''Handles pass records from the nodes.'''
 
-    server_log('Raw pass record: Node: {0}, MS Since Lap: {1}'.format(node.index+1, lap_timestamp_absolute))
+    logger.info('Raw pass record: Node: {0}, MS Since Lap: {1}'.format(node.index+1, lap_timestamp_absolute))
     node.debug_pass_count += 1
     emit_node_data() # For updated triggers and peaks
 
@@ -3968,7 +3968,7 @@ def pass_record_callback(node, lap_timestamp_absolute, source):
                     if lap_number != 0:  # if initial lap then always accept and don't check lap time; else:
                         if lap_time < (min_lap * 1000):  # if lap time less than minimum
                             node.under_min_lap_count += 1
-                            server_log('Pass record under lap minimum ({3}): Node={0}, Lap={1}, LapTime={2}, Count={4}' \
+                            logger.info('Pass record under lap minimum ({3}): Node={0}, Lap={1}, LapTime={2}, Count={4}' \
                                        .format(node.index+1, lap_number, time_format(lap_time), min_lap, node.under_min_lap_count))
                             if min_lap_behavior != 0:  # if behavior is 'Discard New Short Laps'
                                 lap_ok_flag = False
@@ -3989,7 +3989,7 @@ def pass_record_callback(node, lap_timestamp_absolute, source):
                             'deleted': False
                         })
 
-                        #server_log('Pass record: Node: {0}, Lap: {1}, Lap time: {2}' \
+                        #logger.info('Pass record: Node: {0}, Lap: {1}, Lap time: {2}' \
                         #    .format(node.index+1, lap_number, time_format(lap_time)))
                         emit_current_laps() # update all laps on the race page
                         emit_leaderboard() # update leaderboard
@@ -4069,25 +4069,25 @@ def pass_record_callback(node, lap_timestamp_absolute, source):
                             'deleted': True
                         })
                 else:
-                    server_log('Pass record dismissed: Node: {0}, Race not started' \
+                    logger.info('Pass record dismissed: Node: {0}, Race not started' \
                         .format(node.index+1))
             else:
-                server_log('Pass record dismissed: Node: {0}, Pilot not defined' \
+                logger.info('Pass record dismissed: Node: {0}, Pilot not defined' \
                     .format(node.index+1))
     else:
-        server_log('Pass record dismissed: Node: {0}, Frequency not defined' \
+        logger.info('Pass record dismissed: Node: {0}, Frequency not defined' \
             .format(node.index+1))
 
 def new_enter_or_exit_at_callback(node, is_enter_at_flag):
     if is_enter_at_flag:
-        server_log('Finished capture of enter-at level for node {0}, level={1}, count={2}'.format(node.index+1, node.enter_at_level, node.cap_enter_at_count))
+        logger.info('Finished capture of enter-at level for node {0}, level={1}, count={2}'.format(node.index+1, node.enter_at_level, node.cap_enter_at_count))
         on_set_enter_at_level({
             'node': node.index,
             'enter_at_level': node.enter_at_level
         })
         emit_enter_at_level(node)
     else:
-        server_log('Finished capture of exit-at level for node {0}, level={1}, count={2}'.format(node.index+1, node.exit_at_level, node.cap_exit_at_count))
+        logger.info('Finished capture of exit-at level for node {0}, level={1}, count={2}'.format(node.index+1, node.exit_at_level, node.cap_exit_at_count))
         on_set_exit_at_level({
             'node': node.index,
             'exit_at_level': node.exit_at_level
@@ -4118,11 +4118,6 @@ def node_crossing_callback(node):
                 else:
                     node.show_crossing_flag = True
 
-def server_log(message):
-    '''Messages emitted from the server script.'''
-    logger.info(message)
-    SOCKET_IO.emit('hardware_log', message)
-
 def hardware_log_callback(message):
     '''Message emitted from the interface class.'''
     logger.info(message)
@@ -4143,7 +4138,7 @@ def assign_frequencies():
 
     for idx in range(RACE.num_nodes):
         INTERFACE.set_frequency(idx, freqs["f"][idx])
-        server_log('Frequency set: Node {0} Frequency {1}'.format(idx+1, freqs["f"][idx]))
+        logger.info('Frequency set: Node {0} Frequency {1}'.format(idx+1, freqs["f"][idx]))
     DB.session.commit()
 
 def db_init():
@@ -4157,7 +4152,7 @@ def db_init():
     db_reset_race_formats()
     db_reset_options_defaults()
     assign_frequencies()
-    server_log('Database initialized')
+    logger.info('Database initialized')
 
 def db_reset():
     '''Resets database.'''
@@ -4168,7 +4163,7 @@ def db_reset():
     db_reset_profile()
     db_reset_race_formats()
     assign_frequencies()
-    server_log('Database reset')
+    logger.info('Database reset')
 
 def db_reset_pilots():
     '''Resets database pilots to default.'''
@@ -4177,7 +4172,7 @@ def db_reset_pilots():
         DB.session.add(Database.Pilot(callsign='Callsign {0}'.format(node+1), \
             name='Pilot {0} Name'.format(node+1), team=DEF_TEAM_NAME, phonetic=''))
     DB.session.commit()
-    server_log('Database pilots reset')
+    logger.info('Database pilots reset')
 
 def db_reset_heats():
     '''Resets database heats to default.'''
@@ -4186,13 +4181,13 @@ def db_reset_heats():
     on_add_heat()
     DB.session.commit()
     RACE.current_heat = 1
-    server_log('Database heats reset')
+    logger.info('Database heats reset')
 
 def db_reset_classes():
     '''Resets database race classes to default.'''
     DB.session.query(Database.RaceClass).delete()
     DB.session.commit()
-    server_log('Database race classes reset')
+    logger.info('Database race classes reset')
 
 def db_reset_current_laps():
     '''Resets database current laps to default.'''
@@ -4200,7 +4195,7 @@ def db_reset_current_laps():
     for idx in range(RACE.num_nodes):
         RACE.node_laps[idx] = []
 
-    server_log('Database current laps reset')
+    logger.info('Database current laps reset')
 
 def db_reset_saved_races():
     '''Resets database saved races to default.'''
@@ -4208,7 +4203,7 @@ def db_reset_saved_races():
     DB.session.query(Database.SavedPilotRace).delete()
     DB.session.query(Database.SavedRaceLap).delete()
     DB.session.commit()
-    server_log('Database saved races reset')
+    logger.info('Database saved races reset')
 
 def db_reset_profile():
     '''Set default profile'''
@@ -4226,7 +4221,7 @@ def db_reset_profile():
                              exit_ats = json.dumps(template)))
     DB.session.commit()
     Options.set("currentProfile", 1)
-    server_log("Database set default profiles")
+    logger.info("Database set default profiles")
 
 def db_reset_race_formats():
     DB.session.query(Database.RaceFormat).delete()
@@ -4295,7 +4290,7 @@ def db_reset_race_formats():
                              team_racing_mode=True))
     DB.session.commit()
     setCurrentRaceFormat(Database.RaceFormat.query.first())
-    server_log("Database reset race formats")
+    logger.info("Database reset race formats")
 
 def db_reset_options_defaults():
     DB.session.query(Database.GlobalSettings).delete()
@@ -4342,7 +4337,7 @@ def db_reset_options_defaults():
     # Event results cache
     Options.set("eventResults_cacheStatus", CacheStatus.INVALID)
 
-    server_log("Reset global settings")
+    logger.info("Reset global settings")
 
 def backup_db_file(copy_flag):
     DB.session.close()
@@ -4360,12 +4355,12 @@ def backup_db_file(copy_flag):
             bkp_name = DB_BKP_DIR_NAME + '/' + dbname + '_' + time_str + dbext
         if copy_flag:
             shutil.copy2(DB_FILE_NAME, bkp_name);
-            server_log('Copied database file to:  ' + bkp_name)
+            logger.info('Copied database file to:  ' + bkp_name)
         else:
             os.renames(DB_FILE_NAME, bkp_name);
-            server_log('Moved old database file to:  ' + bkp_name)
+            logger.info('Moved old database file to:  ' + bkp_name)
     except Exception as ex:
-        server_log('Error backing up database file:  ' + str(ex))
+        logger.info('Error backing up database file:  ' + str(ex))
     return bkp_name
 
 def query_table_data(class_type, filter_crit=None, filter_value=0):
@@ -4374,7 +4369,7 @@ def query_table_data(class_type, filter_crit=None, filter_value=0):
             return class_type.query.all()
         return class_type.query.filter(filter_crit==filter_value).all()
     except Exception as ex:
-        server_log('Unable to read "{0}" table from previous database: {1}'.format(class_type.__name__, ex))
+        logger.info('Unable to read "{0}" table from previous database: {1}'.format(class_type.__name__, ex))
 
 def restore_table(class_type, table_query_data, match_name='name'):
     if table_query_data:
@@ -4388,21 +4383,21 @@ def restore_table(class_type, table_query_data, match_name='name'):
                         for col in class_type.__table__.columns.keys():
                             if col != 'id':
                                 setattr(new_data, col, getattr(row_data, col))
-                        #server_log('DEBUG row_data add:  ' + str(getattr(new_data, match_name)))
+                        #logger.info('DEBUG row_data add:  ' + str(getattr(new_data, match_name)))
                         DB.session.add(new_data)
                     else:
-                        #server_log('DEBUG row_data update:  ' + str(getattr(row_data, match_name)))
+                        #logger.info('DEBUG row_data update:  ' + str(getattr(row_data, match_name)))
                         for col in class_type.__table__.columns.keys():
                             if col != 'id':
                                 setattr(db_update, col, getattr(row_data, col))
                     DB.session.flush()
-            server_log('Database table "{0}" restored'.format(class_type.__name__))
+            logger.info('Database table "{0}" restored'.format(class_type.__name__))
         except Exception as ex:
-            server_log('Error restoring "{0}" table from previous database:  {1}'.format(class_type.__name__, ex))
+            logger.info('Error restoring "{0}" table from previous database:  {1}'.format(class_type.__name__, ex))
 
 def recover_database():
     try:
-        server_log('Recovering data from previous database')
+        logger.info('Recovering data from previous database')
         pilot_query_data = query_table_data(Database.Pilot)
         raceFormat_query_data = query_table_data(Database.RaceFormat)
         profiles_query_data = query_table_data(Database.Profiles)
@@ -4458,7 +4453,7 @@ def recover_database():
                     profile.exit_ats = json.dumps(exit_ats)
 
     except Exception as ex:
-        server_log('Error reading data from previous database:  ' + str(ex))
+        logger.info('Error reading data from previous database:  ' + str(ex))
 
     backup_db_file(False)  # rename and move DB file
     db_init()
@@ -4472,10 +4467,10 @@ def recover_database():
 
         for opt in carryOver:
             Options.set(opt, carryOver[opt])
-        server_log('UI Options restored')
+        logger.info('UI Options restored')
 
     except Exception as ex:
-        server_log('Error while writing data from previous database:  ' + str(ex))
+        logger.info('Error while writing data from previous database:  ' + str(ex))
 
     DB.session.commit()
 
@@ -4567,46 +4562,46 @@ gevent.sleep(0.500)
 # if no DB file then create it now (before "__()" fn used in 'buildServerInfo()')
 db_inited_flag = False
 if not os.path.exists(DB_FILE_NAME):
-    server_log('No database.db file found; creating initial database')
+    logger.info('No database.db file found; creating initial database')
     db_init()
     db_inited_flag = True
 
 # check if DB file owned by 'root' and change owner to 'pi' user if so
 if checkSetFileOwnerPi(DB_FILE_NAME):
-    server_log("Changed DB-file owner from 'root' to 'pi' (file: '{0}')".format(DB_FILE_NAME))
+    logger.info("Changed DB-file owner from 'root' to 'pi' (file: '{0}')".format(DB_FILE_NAME))
 
 Options.primeGlobalsCache()
 
 # collect server info for About panel
 serverInfo = buildServerInfo()
-server_log('Release: {0} / Server API: {1} / Latest Node API: {2}'.format(RELEASE_VERSION, SERVER_API, NODE_API_BEST))
+logger.info('Release: {0} / Server API: {1} / Latest Node API: {2}'.format(RELEASE_VERSION, SERVER_API, NODE_API_BEST))
 if serverInfo['node_api_match'] is False:
-    server_log('** WARNING: Node API mismatch. **')
+    logger.info('** WARNING: Node API mismatch. **')
 
 if RACE.num_nodes > 0:
     if serverInfo['node_api_lowest'] < NODE_API_SUPPORTED:
-        server_log('** WARNING: Node firmware is out of date and may not function properly **')
+        logger.info('** WARNING: Node firmware is out of date and may not function properly **')
     elif serverInfo['node_api_lowest'] < NODE_API_BEST:
-        server_log('** NOTICE: Node firmware update is available **')
+        logger.info('** NOTICE: Node firmware update is available **')
     elif serverInfo['node_api_lowest'] > NODE_API_BEST:
-        server_log('** WARNING: Node firmware is newer than this server version supports **')
+        logger.info('** WARNING: Node firmware is newer than this server version supports **')
 
 if not db_inited_flag:
     try:
         if int(Options.get('server_api')) < SERVER_API:
-            server_log('Old server API version; resetting database')
+            logger.info('Old server API version; resetting database')
             recover_database()
         elif not Database.Heat.query.count():
-            server_log('Heats are empty; resetting database')
+            logger.info('Heats are empty; resetting database')
             recover_database()
         elif not Database.Profiles.query.count():
-            server_log('Profiles are empty; resetting database')
+            logger.info('Profiles are empty; resetting database')
             recover_database()
         elif not Database.RaceFormat.query.count():
-            server_log('Formats are empty; resetting database')
+            logger.info('Formats are empty; resetting database')
             recover_database()
     except Exception as ex:
-        server_log('Resetting data after DB-check exception:  ' + str(ex))
+        logger.info('Resetting data after DB-check exception:  ' + str(ex))
         recover_database()
 
 # Expand heats (if number of nodes increases)
@@ -4628,22 +4623,22 @@ SLAVE_RACE_FORMAT = RHRaceFormat(name=__("Slave"),
 if os.path.exists(IMDTABLER_JAR_NAME):  # if 'IMDTabler.jar' is available
     try:
         java_ver = subprocess.check_output('java -version', stderr=subprocess.STDOUT, shell=True)
-        server_log('Found installed:  ' + java_ver.split('\n')[0])
+        logger.info('Found installed:  ' + java_ver.split('\n')[0])
     except:
         java_ver = None
-        server_log('Unable to find java; for IMDTabler functionality try:')
-        server_log('sudo apt-get install openjdk-8-jdk')
+        logger.info('Unable to find java; for IMDTabler functionality try:')
+        logger.info('sudo apt-get install openjdk-8-jdk')
     if java_ver:
         try:
             imdtabler_ver = subprocess.check_output( \
                         'java -jar ' + IMDTABLER_JAR_NAME + ' -v', \
                         stderr=subprocess.STDOUT, shell=True).rstrip()
             Use_imdtabler_jar_flag = True  # indicate IMDTabler.jar available
-            server_log('Found installed:  ' + imdtabler_ver)
+            logger.info('Found installed:  ' + imdtabler_ver)
         except Exception as ex:
-            server_log('Error checking IMDTabler:  ' + str(ex))
+            logger.exception('Error checking IMDTabler:  ')
 else:
-    server_log('IMDTabler lib not found at: ' + IMDTABLER_JAR_NAME)
+    logger.info('IMDTabler lib not found at: ' + IMDTABLER_JAR_NAME)
 
 
 # Clear any current laps from the database on each program start

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -4118,11 +4118,6 @@ def node_crossing_callback(node):
                 else:
                     node.show_crossing_flag = True
 
-def hardware_log_callback(message):
-    '''Message emitted from the interface class.'''
-    logger.info(message)
-    SOCKET_IO.emit('hardware_log', message)
-
 def default_frequencies():
     '''Set node frequencies, R1367 for 4, IMD6C+ for 5+.'''
     if RACE.num_nodes < 5:
@@ -4547,7 +4542,6 @@ for index, slave_info in enumerate(Config.GENERAL['SLAVES']):
 INTERFACE.pass_record_callback = pass_record_callback
 INTERFACE.new_enter_or_exit_at_callback = new_enter_or_exit_at_callback
 INTERFACE.node_crossing_callback = node_crossing_callback
-INTERFACE.hardware_log_callback = hardware_log_callback
 
 # Save number of nodes found
 RACE.num_nodes = len(INTERFACE.nodes)


### PR DESCRIPTION
This is a no-nonsense conversion to the python logging module. It doesn't really make use of the finer points of the logging setup, but those might be overkill anyway. 

The configuration now allows to specify stderr (default), stdout, syslog or a file. I'm personally excited about the syslog, as I plan on running a service that shows me all of the syslog (tailon for now) on a website. It might even mean one could omit the additional SOCKET_IO if so inclined, to reduce load.