### PR TITLE
Add geventsocket.handler to the list of 3rd-party loggers to silence

### DIFF
--- a/src/server/log.py
+++ b/src/server/log.py
@@ -34,8 +34,12 @@ def early_stage_setup():
         format=ROTORHAZARD_FORMAT,
     )
     # some 3rd party packages use logging. Good for them. Now be quiet.
-    logging.getLogger("socketio.server").setLevel(logging.WARN)
-    logging.getLogger("engineio.server").setLevel(logging.WARN)
+    for name in [
+            "geventwebsocket.handler",
+            "socketio.server",
+            "engineio.server"
+            ]:
+        logging.getLogger(name).setLevel(logging.WARN)
 
 
 def handler_for_config(destination):


### PR DESCRIPTION
There was an entry missing in the 3rd party logging handlers. This PR fixes the overabundance of HTTP log entries.