### PR TITLE
Power down unused rx modules

### DIFF
--- a/src/interface/RHInterface.py
+++ b/src/interface/RHInterface.py
@@ -440,11 +440,11 @@ class RHInterface(BaseHardwareInterface):
                 WRITE_FREQUENCY,
                 READ_FREQUENCY,
                 frequency)
-        else:  # if freq=0 (node disabled) then write default freq, but save 0 value
+        else:  # if freq=0 (node disabled) then write frequency value to power down rx module, but save 0 value
             self.set_and_validate_value_16(node,
                 WRITE_FREQUENCY,
                 READ_FREQUENCY,
-                5800)
+                1111)
             node.frequency = 0
 
     def transmit_enter_at_level(self, node, level):

--- a/src/node/config.h
+++ b/src/node/config.h
@@ -29,6 +29,7 @@
 // Set to 0 for standard RotorHazard USB node wiring; set to 1 for ArduVidRx USB node wiring
 //   See here for an ArduVidRx example: http://www.etheli.com/ArduVidRx/hw/index.html#promini
 #define ARDUVIDRX_WIRING_FLAG 0
+#define CHORUS_WIRING_FLAG 0
 
 #if ARDUVIDRX_WIRING_FLAG
 #define RX5808_DATA_PIN 10             //DATA output line to RX5808 module

--- a/src/node/rhnode.cpp
+++ b/src/node/rhnode.cpp
@@ -61,6 +61,10 @@ void i2cReceive(int byteCount);
 bool i2cReadAndValidateIoBuffer(byte expectedSize);
 void i2cTransmit();
 void setRxModule(uint16_t frequency);
+void resetRxModule();
+void setupRxModule();
+void powerDownRxModule();
+static bool rxPoweredDown = false;
 
 #if (!defined(NODE_NUMBER)) || (!NODE_NUMBER)
 // Configure the I2C address based on input-pin level.
@@ -172,8 +176,17 @@ void setup()
         eepromWriteWord(EEPROM_ADRW_CHECKWORD, EEPROM_CHECK_VALUE);
     }
 
-    setRxModule(settings.vtxFreq);  // Setup rx module to default frequency
-
+    resetRxModule(); 
+    if (settings.vtxFreq == 1111) // frequency value to power down rx module
+    {
+        powerDownRxModule();
+        rxPoweredDown = true;
+    }
+    else
+    {
+        setRxModule(settings.vtxFreq);  // Setup rx module to default frequency
+    }
+            
     rssiInit();
 }
 
@@ -181,8 +194,6 @@ void setup()
 
 void SERIAL_SENDBIT1()
 {
-    digitalWrite(RX5808_CLK_PIN, LOW);
-    delayMicroseconds(300);
     digitalWrite(RX5808_DATA_PIN, HIGH);
     delayMicroseconds(300);
     digitalWrite(RX5808_CLK_PIN, HIGH);
@@ -193,8 +204,6 @@ void SERIAL_SENDBIT1()
 
 void SERIAL_SENDBIT0()
 {
-    digitalWrite(RX5808_CLK_PIN, LOW);
-    delayMicroseconds(300);
     digitalWrite(RX5808_DATA_PIN, LOW);
     delayMicroseconds(300);
     digitalWrite(RX5808_CLK_PIN, HIGH);
@@ -205,16 +214,14 @@ void SERIAL_SENDBIT0()
 
 void SERIAL_ENABLE_LOW()
 {
-    delayMicroseconds(100);
     digitalWrite(RX5808_SEL_PIN, LOW);
-    delayMicroseconds(100);
+    delayMicroseconds(200);
 }
 
 void SERIAL_ENABLE_HIGH()
 {
-    delayMicroseconds(100);
     digitalWrite(RX5808_SEL_PIN, HIGH);
-    delayMicroseconds(100);
+    delayMicroseconds(200);
 }
 
 // Calculate rx5808 register hex value for given frequency in MHz
@@ -235,24 +242,8 @@ void setRxModule(uint16_t frequency)
     // Get the hex value to send to the rx module
     uint16_t vtxHex = freqMhzToRegVal(frequency);
 
-    // bit bash out 25 bits of data / Order: A0-3, !R/W, D0-D19 / A0=0, A1=0, A2=0, A3=1, RW=0, D0-19=0
-    SERIAL_ENABLE_HIGH();
-    delay(2);
-    SERIAL_ENABLE_LOW();
-    SERIAL_SENDBIT0();
-    SERIAL_SENDBIT0();
-    SERIAL_SENDBIT0();
-    SERIAL_SENDBIT1();
-    SERIAL_SENDBIT0();
 
-    for (i = 20; i > 0; i--)
-        SERIAL_SENDBIT0();  // Remaining zeros
-
-    SERIAL_ENABLE_HIGH();  // Clock the data in
-    delay(2);
-    SERIAL_ENABLE_LOW();
-
-    // Second is the channel data from the lookup table, 20 bytes of register data are sent, but the
+    //Channel data from the lookup table, 20 bytes of register data are sent, but the
     // MSB 4 bits are zeros register address = 0x1, write, data0-15=vtxHex data15-19=0x0
     SERIAL_ENABLE_HIGH();
     SERIAL_ENABLE_LOW();
@@ -282,11 +273,76 @@ void setRxModule(uint16_t frequency)
         SERIAL_SENDBIT0();
 
     SERIAL_ENABLE_HIGH();  // Finished clocking data in
-    delay(2);
 
-    digitalWrite(RX5808_SEL_PIN, LOW);
-    digitalWrite(RX5808_CLK_PIN, LOW);
+}
+
+// Reset rx5808 module to wake up from power down
+void resetRxModule()
+{  
+    uint8_t i;  // Used in the for loops
+  
+    SERIAL_ENABLE_HIGH();
+    SERIAL_ENABLE_LOW();
+
+    SERIAL_SENDBIT1();  // Register 0xF
+    SERIAL_SENDBIT1();
+    SERIAL_SENDBIT1();
+    SERIAL_SENDBIT1();
+
+    SERIAL_SENDBIT1();  // Write to register
+
+    for (int i = 20; i > 0; i--) {
+        SERIAL_SENDBIT0();
+    }
+
+    SERIAL_ENABLE_HIGH();  // Finished clocking data in
+
+    setupRxModule();
+}
+
+// Set power options on the rx5808 module
+void setRxModulePower(uint32_t options)
+{
+    uint8_t i;  // Used in the for loops
+
+    SERIAL_ENABLE_HIGH();
+    SERIAL_ENABLE_LOW();
+
+    SERIAL_SENDBIT0();  // Register 0xA
+    SERIAL_SENDBIT1();
+    SERIAL_SENDBIT0();
+    SERIAL_SENDBIT1();
+
+    SERIAL_SENDBIT1();  // Write to register
+
+    for (i = 20; i > 0; i--)
+    {
+        if (options & 0x1)
+        {  // Is bit high or low?
+            SERIAL_SENDBIT1();
+        }
+        else
+        {
+            SERIAL_SENDBIT0();
+        }
+        options >>= 1;  // Shift bits along to check the next one
+    }
+
+    SERIAL_ENABLE_HIGH();  // Finished clocking data in
+
     digitalWrite(RX5808_DATA_PIN, LOW);
+}
+
+// Power down rx5808 module
+void powerDownRxModule() 
+{   
+    setRxModulePower(0b11111111111111111111);
+}
+
+// Power down rx5808 module unused features to save some power
+void setupRxModule() 
+{   
+    setRxModulePower(0b11010000110111110011);
 }
 
 // Read the RSSI value for the current channel
@@ -352,7 +408,21 @@ void loop()
             {
                 newVtxFreq = settings.vtxFreq;
             }
-            setRxModule(newVtxFreq);
+            if (newVtxFreq == 1111) // frequency value to power down rx module
+            {
+                powerDownRxModule();
+                rxPoweredDown = true;
+            }
+            else
+            {
+                if (rxPoweredDown)
+                {
+                    resetRxModule();
+                    rxPoweredDown = false; 
+                }
+                setRxModule(newVtxFreq);
+            }
+            
             state.activatedFlag = true;
 
             if (changeFlags & FREQ_CHANGED)

--- a/src/node/rhnode.cpp
+++ b/src/node/rhnode.cpp
@@ -135,6 +135,8 @@ void setup()
     pinMode(RX5808_DATA_PIN, OUTPUT);
     pinMode(RX5808_CLK_PIN, OUTPUT);
     digitalWrite(RX5808_SEL_PIN, HIGH);
+    digitalWrite(RX5808_DATA_PIN, LOW);
+    digitalWrite(RX5808_CLK_PIN, LOW);
 
     // init pin used to reset paired Arduino via RESET_PAIRED_NODE command
     pinMode(NODE_RESET_PIN, INPUT_PULLUP);
@@ -177,7 +179,6 @@ void setup()
     }
 
     resetRxModule(); 
-
     if (settings.vtxFreq == 1111) // frequency value to power down rx module
     {
         powerDownRxModule();
@@ -187,7 +188,7 @@ void setup()
     {
         setRxModule(settings.vtxFreq);  // Setup rx module to default frequency
     }
-
+            
     rssiInit();
 }
 
@@ -195,8 +196,6 @@ void setup()
 
 void SERIAL_SENDBIT1()
 {
-    digitalWrite(RX5808_CLK_PIN, LOW);
-    delayMicroseconds(300);
     digitalWrite(RX5808_DATA_PIN, HIGH);
     delayMicroseconds(300);
     digitalWrite(RX5808_CLK_PIN, HIGH);
@@ -207,8 +206,6 @@ void SERIAL_SENDBIT1()
 
 void SERIAL_SENDBIT0()
 {
-    digitalWrite(RX5808_CLK_PIN, LOW);
-    delayMicroseconds(300);
     digitalWrite(RX5808_DATA_PIN, LOW);
     delayMicroseconds(300);
     digitalWrite(RX5808_CLK_PIN, HIGH);
@@ -219,16 +216,14 @@ void SERIAL_SENDBIT0()
 
 void SERIAL_ENABLE_LOW()
 {
-    delayMicroseconds(100);
     digitalWrite(RX5808_SEL_PIN, LOW);
-    delayMicroseconds(100);
+    delayMicroseconds(200);
 }
 
 void SERIAL_ENABLE_HIGH()
 {
-    delayMicroseconds(100);
     digitalWrite(RX5808_SEL_PIN, HIGH);
-    delayMicroseconds(100);
+    delayMicroseconds(200);
 }
 
 // Calculate rx5808 register hex value for given frequency in MHz
@@ -249,24 +244,8 @@ void setRxModule(uint16_t frequency)
     // Get the hex value to send to the rx module
     uint16_t vtxHex = freqMhzToRegVal(frequency);
 
-    // bit bash out 25 bits of data / Order: A0-3, !R/W, D0-D19 / A0=0, A1=0, A2=0, A3=1, RW=0, D0-19=0
-    SERIAL_ENABLE_HIGH();
-    delay(2);
-    SERIAL_ENABLE_LOW();
-    SERIAL_SENDBIT0();
-    SERIAL_SENDBIT0();
-    SERIAL_SENDBIT0();
-    SERIAL_SENDBIT1();
-    SERIAL_SENDBIT0();
 
-    for (i = 20; i > 0; i--)
-        SERIAL_SENDBIT0();  // Remaining zeros
-
-    SERIAL_ENABLE_HIGH();  // Clock the data in
-    delay(2);
-    SERIAL_ENABLE_LOW();
-
-    // Second is the channel data from the lookup table, 20 bytes of register data are sent, but the
+    //Channel data from the lookup table, 20 bytes of register data are sent, but the
     // MSB 4 bits are zeros register address = 0x1, write, data0-15=vtxHex data15-19=0x0
     SERIAL_ENABLE_HIGH();
     SERIAL_ENABLE_LOW();
@@ -296,20 +275,14 @@ void setRxModule(uint16_t frequency)
         SERIAL_SENDBIT0();
 
     SERIAL_ENABLE_HIGH();  // Finished clocking data in
-    delay(2);
 
-    digitalWrite(RX5808_SEL_PIN, LOW);
-    digitalWrite(RX5808_CLK_PIN, LOW);
-    digitalWrite(RX5808_DATA_PIN, LOW);
-
-    setupRxModule();
 }
 
 // Reset rx5808 module to wake up from power down
 void resetRxModule()
 {  
     uint8_t i;  // Used in the for loops
-
+  
     SERIAL_ENABLE_HIGH();
     SERIAL_ENABLE_LOW();
 
@@ -451,6 +424,7 @@ void loop()
                 }
                 setRxModule(newVtxFreq);
             }
+            
             state.activatedFlag = true;
 
             if (changeFlags & FREQ_CHANGED)


### PR DESCRIPTION
It is possible to reduce the power consumption of the rx module by disabling some functions that are not necessary for the lap timer.
This can be done by changing the "Power Down Control Register".
Disabling features such as the audio modulator, etc. saves about 0.1 W of power per node.
Also, if the node is not in use, it can be turned off completely. This saves about 0.56 W per node.

I have an 8 node lap timer. I use it for training almost every day. If I fly alone, turning off 7 unused nodes reduces power consumption by about 40%.