### PR TITLE
Removing this declaration stops the menu header from being hidden on iOS

### DIFF
--- a/src/server/static/rotorhazard.css
+++ b/src/server/static/rotorhazard.css
@@ -13,7 +13,6 @@ body {
 	padding: 0;
 	display: flex;
 	flex-direction: column;
-	height: 100vh;
 }
 
 body>* {


### PR DESCRIPTION
I can't verify if this is generating any other issues. Not a frontend person.