### PR TITLE
Fixed pass crossing issues with maxLapsWin races

### DIFF
--- a/src/interface/BaseHardwareInterface.py
+++ b/src/interface/BaseHardwareInterface.py
@@ -46,6 +46,8 @@ class BaseHardwareInterface(object):
         if node.scan_interval == 0:
             if cross_flag is not None and cross_flag != node.crossing_flag:  # if 'crossing' status changed
                 node.crossing_flag = cross_flag
+                if cross_flag:
+                    node.pass_crossing_flag = True  # will be cleared when lap-pass is processed
                 if callable(self.node_crossing_callback):
                     cross_list.append(node)
 

--- a/src/interface/Node.py
+++ b/src/interface/Node.py
@@ -20,6 +20,7 @@ class Node:
         self.lap_timestamp = -1
         self.loop_time = 10
         self.crossing_flag = False
+        self.pass_crossing_flag = False
         self.debug_pass_count = 0
 
         self.enter_at_level = 0

--- a/src/server/RHRace.py
+++ b/src/server/RHRace.py
@@ -25,6 +25,7 @@ class RHRace():
         self.duration_ms = 0 # Duration in seconds, calculated when race is stopped
         self.end_time = 0 # Monotonic, updated when race is stopped
         self.laps_winner_name = None  # set to name of winner in first-to-X-laps race
+        self.winning_lap_id = 0  # tracks winning lap-id if race tied during first-to-X-laps race
         # leaderboard/cache
         self.results = None # current race results
         self.cacheStatus = CacheStatus.INVALID # whether cache is valid


### PR DESCRIPTION
Fixed issue where time-expired maxLapsWin race can remain tied if more than one VTX is crossing when winning pass occurs.

Added 'pass_crossing_flag' to node (to handle cases where 'crossing_flag' could be cleared before being detected in 'check_most_laps_win()' fn).

Fixed issue with maxLapsWins team race where time-expired race would remain tied after additional lap if another (tied) VTX is crossing at the same time.

Added log-debug outputs to 'check_most_laps_win()' and 'get_team_laps_info()'.