### PR TITLE
Add Next Heat Behavior option

### DIFF
--- a/src/server/server.py
+++ b/src/server/server.py
@@ -1939,6 +1939,13 @@ def on_delete_race_format():
         emit_priority_message(__('Format change prevented by active race: Stop and save/discard laps'), False, nobroadcast=True)
         logger.info("Format change prevented by active race")
 
+@SOCKET_IO.on("set_next_heat_behavior")
+@catchLogExceptionsWrapper
+def on_set_next_heat_behavior(data):
+    next_heat_behavior = int(data['next_heat_behavior'])
+    Options.set("nextHeatBehavior", next_heat_behavior)
+    logger.info("set next heat behavior to %s" % next_heat_behavior)
+
 # LED Effects
 
 def emit_led_effect_setup(**params):
@@ -4830,6 +4837,7 @@ def db_reset_options_defaults():
 
     Options.set("startThreshLowerAmount", "0")
     Options.set("startThreshLowerDuration", "0")
+    Options.set("nextHeatBehavior", "0")
 
     logger.info("Reset global settings")
 
@@ -4961,7 +4969,8 @@ def recover_database():
             "osd_lapHeader",
             "osd_positionHeader",
             "startThreshLowerAmount",
-            "startThreshLowerDuration"
+            "startThreshLowerDuration",
+            "nextHeatBehavior"
         ]
         carryOver = {}
         for opt in carryoverOpts:

--- a/src/server/templates/race.html
+++ b/src/server/templates/race.html
@@ -174,6 +174,10 @@
 			$('#led_brightness_value').html($('#set_led_brightness').val());
 		}
 
+		if ('{{ getOption('nextHeatBehavior') }}' == '1') {
+			$('#set_next_heat_behavior').val(1);
+		}
+
 		// set up node local store
 		for (i = 0; i < {{ num_nodes }}; i++) {
 			rotorhazard.nodes[i] = new nodeModel();
@@ -602,24 +606,25 @@
 
 			var selectedHeat = $('#set_current_heat').val();
 			var selectedClass = rotorhazard.heats[selectedHeat].class_id;
-			var otherHeats = [];
-			for (heat_i in rotorhazard.heats) {
-				if (rotorhazard.heats[heat_i].class_id == selectedClass) {
-					otherHeats.push(heat_i);
-				}
-			}
 
-			if (otherHeats.length > 1) {
-				var newHeat = null;
-				if (otherHeats[otherHeats.length - 1] == selectedHeat) {
-					newHeat = otherHeats[0];
-				} else {
-					while (otherHeats[otherHeats.length - 1] != selectedHeat) {
-						newHeat = otherHeats.pop();
+			if ('{{ getOption('nextHeatBehavior') }}' != '1') {
+				var otherHeats = [];
+				for (heat_i in rotorhazard.heats) {
+					if (rotorhazard.heats[heat_i].class_id == selectedClass) {
+						otherHeats.push(heat_i);
 					}
 				}
-
-				$('#set_current_heat').val(newHeat).change();
+				if (otherHeats.length > 1) {
+					var newHeat = null;
+					if (otherHeats[otherHeats.length - 1] == selectedHeat) {
+						newHeat = otherHeats[0];
+					} else {
+						while (otherHeats[otherHeats.length - 1] != selectedHeat) {
+							newHeat = otherHeats.pop();
+						}
+					}
+					$('#set_current_heat').val(newHeat).change();
+				}
 			}
 
 			return false;
@@ -959,6 +964,13 @@
 			if ($(this).find('option').length > 1)
 				socket.emit('set_race_format', data);
 		});
+
+		$('#set_next_heat_behavior').change(function (event) {
+			var data = {
+				next_heat_behavior: parseInt($(this).val())
+			};
+			socket.emit('set_next_heat_behavior', data);
+		})
 
 		/* Calibration Profiles */
 		socket.on('node_tuning', function (msg) {
@@ -1579,6 +1591,15 @@
 				<select id="set_min_lap_behavior">
 					<option value="0">{{ __('Highlight Short Laps') }}</option>
 					<option value="1">{{ __('Discard New Short Laps') }}</option>
+				</select>
+			</li>
+			<li>
+				<div class="label-block">
+					<label for="set_next_heat_behavior">{{ __('Next Heat Behavior') }}</label>
+				</div>
+				<select id="set_next_heat_behavior">
+					<option value="0">{{ __('Auto-Switch After Race Save') }}</option>
+					<option value="1">{{ __('Manually Switch Heats') }}</option>
 				</select>
 			</li>
 		</ol>

--- a/src/server/templates/settings.html
+++ b/src/server/templates/settings.html
@@ -104,6 +104,10 @@
 			$('#set_pilotSort').val('callsign');
 		}
 
+		if ('{{ getOption('nextHeatBehavior') }}' == '1') {
+			$('#set_next_heat_behavior').val(1);
+		}
+
 		// populate frequency selects
 		$('.frequency_table').each(function(){
 			$(this).html(freq.buildSelect());
@@ -647,6 +651,13 @@
 				start_thresh_lower_duration: start_thresh_lower_duration_val
 			};
 			socket.emit('set_start_thresh_lower_duration', data);
+		})
+
+		$('#set_next_heat_behavior').change(function (event) {
+			var data = {
+				next_heat_behavior: parseInt($(this).val())
+			};
+			socket.emit('set_next_heat_behavior', data);
 		})
 
 		/* Heats */
@@ -1883,6 +1894,18 @@
 		<div class="control-set">
 			<button id="add_heat">+ {{ __('Add Heat') }}</button>
 		</div>
+
+		<ol class="form">
+			<li>
+				<div class="label-block">
+					<label for="set_next_heat_behavior">{{ __('Next Heat Behavior') }}</label>
+				</div>
+				<select id="set_next_heat_behavior">
+					<option value="0">{{ __('Auto-Switch After Race Save') }}</option>
+					<option value="1">{{ __('Manually Switch Heats') }}</option>
+				</select>
+			</li>
+		</ol>
 
 		<h3>Heat generator</h3>
 		<ol class="form">


### PR DESCRIPTION
Adds 'Next Heat Behavior' option widget to "Settings | Heats" and "Run | Race Management".  Controls whether or not the next heat is switched to after a race is run and saved.

Functionality is similar to PR #341, but done a bit differently under the hood.