### PR TITLE
Split timer updates

### DIFF
--- a/doc/Cluster.md
+++ b/doc/Cluster.md
@@ -32,8 +32,7 @@ Additional options may be configured, for example:
 
 ### Clock Synchronization
 
-It is important that all timers have their clocks synchronized.
-You can use NTP to do this.
+The accuracy of reported split times will be higher if all timers have their clocks synchronized. Adding precision real-time clock (RTC) devices like the [DS3231](https://www.adafruit.com/product/3013) to all the timers can accomplish this, or NTP can be configured (if internet is available during races) as shown below.
 
 On all timers:
 
@@ -71,6 +70,10 @@ Then, restart rng-tools with
 ### Notes
 
 Missed/incorrect split times will have no impact on the recording of lap times by the master timer.
+
+The status of connected slave timers may be viewed on the *Settings* page in the *System* section. Clicking on the slave-timer address will bring up the web-GUI for the timer. The "*Seconds since last contact*" value should always be less than 20 (higher values indicate network communications problems).
+
+Doing normal operation, lap history-data will not be saved on the slave timer(s). To view lap history-data and perform marshaling on a slave timer, hit the '*Save Laps*' button on the slave timer before the race is saved or discarded on the master, and then go to the *Marshal* page on the slave timer.
 
 A slave can also be a master, but sub-splits are not propagated upwards.
 

--- a/src/server/RHRace.py
+++ b/src/server/RHRace.py
@@ -18,6 +18,7 @@ class RHRace():
         self.timer_running = False
         self.start_time = 0 # datetime
         self.start_time_monotonic = 0 # monotonic
+        self.start_time_epoch_ms = 0 # ms since 1970-01-01
         self.node_laps = {} # current race lap objects, by node
         self.status_tied_str = 'Race is tied; continuing'  # shown when Most Laps Wins race tied
         self.status_crossing = 'Waiting for cross'  # indicator for Most Laps Wins race

--- a/src/server/log.py
+++ b/src/server/log.py
@@ -103,6 +103,7 @@ def early_stage_setup():
             "engineio.client",
             "sqlalchemy",
             "urllib3",
+            "requests",
             "PIL"
             ]:
         logging.getLogger(name).setLevel(logging.WARN)

--- a/src/server/templates/settings.html
+++ b/src/server/templates/settings.html
@@ -246,10 +246,10 @@
 		socket.on('cluster_status', function (msg) {
 			cluster_table_html = '';
 			if (msg.slaves && msg.slaves.length > 0) {
-				cluster_table_html += '<tr><th>'+__('Address')+'</th><th>'+__('Time since last contact (s)')+'</th></tr>';
+				cluster_table_html += '<tr><th>'+__('Address')+'</th><th>'+__('Seconds since last contact')+'</th></tr>';
 				for (i=0; i < msg.slaves.length; i++) {
 					cluster_table_html += '<tr>';
-					cluster_table_html += '<td>' + msg.slaves[i].address + '</td>';
+					cluster_table_html += '<td><a href="' + msg.slaves[i].address + '">' + msg.slaves[i].address + '</a></td>';
 					cluster_table_html += '<td>' + msg.slaves[i].last_contact + '</td>';
 					cluster_table_html += '</tr>';
 				}
@@ -2349,6 +2349,9 @@
 		<div id="env-data-table" class="control-set">
 		</div>
 		<br />
+		<div class="control-set">
+			{{ __('Cluster Status:') }}
+		</div>
 		<div id="cluster-status-table" class="control-set">
 		</div>
 		<br />

--- a/src/tests/test_server.py
+++ b/src/tests/test_server.py
@@ -260,12 +260,15 @@ class ServerTest(unittest.TestCase):
         server.RACE.race_status = 1
         node = Node()
         node.index = 0
-        server.pass_record_callback(node, server.RACE.start_time_monotonic + 19.8, 0)
+        server.RACE.start_time_monotonic = 10
+        server.RACE.start_time_epoch_ms = server.monotonic_to_epoch_millis(server.RACE.start_time_monotonic)
+        server.pass_record_callback(node, 19.8+server.RACE.start_time_monotonic, 0)
+        gevent.sleep(0.1)
         resp = self.get_response('pass_record')
         self.assertIn('node', resp)
         self.assertIn('frequency', resp)
         self.assertIn('timestamp', resp)
-        self.assertEqual(resp['timestamp'], server.monotonic_to_milliseconds(server.RACE.start_time_monotonic) + 19800)
+        self.assertEqual(resp['timestamp'], server.monotonic_to_epoch_millis(server.RACE.start_time_monotonic) + 19800)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Now corrects for mismatched system clocks.

Sets slave node frequencies at startup.

Added slave-check-query/response every 10 seconds.

Fixed issue with deleting laps containing split laps.