### PR TITLE
Improved accuracy in loop timing (2)

### DIFF
--- a/src/node/clock.cpp
+++ b/src/node/clock.cpp
@@ -1,0 +1,24 @@
+#include "config.h"
+#include "clock.h"
+
+Clock usclock;
+
+uint32_t Clock::tick()
+{
+    utime_t currentTick = micros();
+    // unsigned arithmetic to handle roll-over
+    uint32_t elapsed = currentTick - prevTick;
+    uint32_t elapsedMillis = (elapsed + excessMicros)/1000;
+    ATOMIC_BLOCK(ATOMIC_RESTORESTATE)
+    {
+        timeMillis += elapsedMillis;
+        excessMicros = elapsed - elapsedMillis*1000;
+    }
+    prevTick = currentTick;
+    return elapsed;
+}
+
+mtime_t Clock::millis()
+{
+    return timeMillis;
+}

--- a/src/node/clock.h
+++ b/src/node/clock.h
@@ -1,0 +1,22 @@
+#ifndef clock_h
+#define clock_h
+
+#include "util/rhtypes.h"
+
+class Clock
+{
+private:
+    utime_t prevTick = 0;
+    volatile mtime_t timeMillis = 0;
+    volatile uint16_t excessMicros = 0;
+public:
+    /**
+     * Returns elapsed microseconds since last tick.
+     */
+    uint32_t tick();
+    mtime_t millis();
+};
+
+extern Clock usclock;
+
+#endif

--- a/src/node/commands.cpp
+++ b/src/node/commands.cpp
@@ -57,7 +57,7 @@ void resetPairedNode(int pinState)
 }
 
 // Generic IO write command handler
-void Message::handleWriteCommand(bool serialFlag)
+void Message::handleWriteCommand(RssiNode& rssiNode, bool serialFlag)
 {
     uint8_t u8val;
     uint16_t u16val;
@@ -65,6 +65,8 @@ void Message::handleWriteCommand(bool serialFlag)
 
     buffer.flipForRead();
     bool actFlag = true;
+
+    Settings& settings = rssiNode.getSettings();
 
     switch (command)
     {
@@ -100,7 +102,7 @@ void Message::handleWriteCommand(bool serialFlag)
             break;
 
         case FORCE_END_CROSSING:  // kill current crossing flag regardless of RSSI value
-            rssiEndCrossing();
+            rssiNode.endCrossing();
             break;
 
         case RESET_PAIRED_NODE:  // reset paired node for ISP
@@ -132,10 +134,15 @@ void ioBufferWriteExtremum(Buffer& buf, const Extremum& e, mtime_t now)
 }
 
 // Generic IO read command handler
-void Message::handleReadCommand(bool serialFlag)
+void Message::handleReadCommand(RssiNode& rssiNode, bool serialFlag)
 {
     buffer.flipForWrite();
     bool actFlag = true;
+
+    Settings& settings = rssiNode.getSettings();
+    State& state = rssiNode.getState();
+    LastPass& lastPass = rssiNode.getLastPass();
+    History& history = rssiNode.getHistory();
 
     switch (command)
     {

--- a/src/node/commands.cpp
+++ b/src/node/commands.cpp
@@ -1,4 +1,5 @@
 #include "config.h"
+#include "clock.h"
 #include "rssi.h"
 #include "commands.h"
 
@@ -156,7 +157,7 @@ void Message::handleReadCommand(RssiNode& rssiNode, bool serialFlag)
 
         case READ_LAP_STATS:
             {
-            mtime_t now = millis();
+            mtime_t now = usclock.millis();
             buffer.write8(lastPass.lap);
             buffer.write16(uint16_t(now - lastPass.timestamp));  // ms since lap
             ioBufferWriteRssi(buffer, state.rssi);

--- a/src/node/commands.h
+++ b/src/node/commands.h
@@ -2,6 +2,7 @@
 #define commands_h
 
 #include "io.h"
+#include "rssi.h"
 
 // API level for node; increment when commands are modified
 #define NODE_API_LEVEL 25
@@ -13,8 +14,8 @@ public:
     Buffer buffer;  // request/response payload
 
     byte getPayloadSize();
-    void handleWriteCommand(bool serialFlag);
-    void handleReadCommand(bool serialFlag);
+    void handleWriteCommand(RssiNode& rssiNode, bool serialFlag);
+    void handleReadCommand(RssiNode& rssiNode, bool serialFlag);
 };
 
 #define MIN_FREQ 100

--- a/src/node/rhnode.cpp
+++ b/src/node/rhnode.cpp
@@ -28,6 +28,7 @@
 
 #include "config.h"
 #include <Wire.h>
+#include "clock.h"
 #include "rssi.h"
 #include "commands.h"
 #include "rheeprom.h"
@@ -381,7 +382,6 @@ void setStatusLed(bool onFlag)
     }
 }
 
-static mtime_t loopMillis = 0;
 static bool commsMonitorEnabledFlag = false;
 static mtime_t commsMonitorLastResetTime = 0;
 
@@ -391,10 +391,11 @@ void loop()
     Settings& settings = RssiNode::rssiNode.getSettings();
     State& state = RssiNode::rssiNode.getState();
 
-    mtime_t ms = millis();
-    if (ms > loopMillis)
+    const uint32_t elapsed = usclock.tick();
+    if (elapsed > 1000)
     {  // limit to once per millisecond
         // read raw RSSI close to taking timestamp
+        const mtime_t ms = usclock.millis();
         bool crossingFlag = RssiNode::rssiNode.process(rssiRead(), ms);
 
         // update settings and status LED
@@ -488,8 +489,6 @@ void loop()
             else
                 setStatusLed(ms % 2000 == 0);  // blink
         }
-
-        loopMillis = ms;
     }
 }
 

--- a/src/node/rssi.cpp
+++ b/src/node/rssi.cpp
@@ -18,9 +18,9 @@
 #define FILTER_IMPL FILTER_MEDIAN
 
 #define PEAK_SENDBUFFER_SINGLE SinglePeakSendBuffer
-#define PEAK_SENDBUFFFER_MULTI MultiSendBuffer<Extremum,10>
+#define PEAK_SENDBUFFER_MULTI MultiPeakSendBuffer<10>
 #define NADIR_SENDBUFFER_SINGLE SingleNadirSendBuffer
-#define NADIR_SENDBUFFFER_MULTI MultiSendBuffer<Extremum,10>
+#define NADIR_SENDBUFFER_MULTI MultiNadirSendBuffer<10>
 
 //select the send buffer to use here
 #define PEAK_SENDBUFFER_IMPL PEAK_SENDBUFFER_SINGLE

--- a/src/node/test/good-clock.cpp
+++ b/src/node/test/good-clock.cpp
@@ -1,0 +1,43 @@
+#include <ArduinoUnitTests.h>
+#include <Godmode.h>
+#include "clock.h"
+
+unittest(clock_under)
+{
+  GodmodeState* nano = GODMODE();
+  nano->reset();
+  nano->micros = 400;
+  Clock clock;
+  assertEqual(400, clock.tick());
+  assertEqual(0, clock.millis());
+  nano->micros = 1000;
+  assertEqual(600, clock.tick());
+  assertEqual(1, clock.millis());
+}
+
+unittest(clock_over)
+{
+  GodmodeState* nano = GODMODE();
+  nano->reset();
+  nano->micros = 1500;
+  Clock clock;
+  assertEqual(1500, clock.tick());
+  assertEqual(1, clock.millis());
+  nano->micros = 3000;
+  assertEqual(1500, clock.tick());
+  assertEqual(3, clock.millis());
+}
+
+unittest(clock_rollover)
+{
+    GodmodeState* nano = GODMODE();
+    nano->reset();
+    nano->micros = 0xFFFFFFFF;
+    Clock clock;
+    assertEqual(0xFFFFFFFF, clock.tick());
+    nano->micros = 1000;
+    assertEqual(1001, clock.tick());
+    assertEqual(0xFFFFFFFF/1000+1, clock.millis());
+}
+
+unittest_main()

--- a/src/node/test/good-crossing_fast.cpp
+++ b/src/node/test/good-crossing_fast.cpp
@@ -9,18 +9,22 @@
 unittest(fastCrossing) {
   GodmodeState* nano = GODMODE();
   nano->reset();
-  rssiSetFilter(&testFilter);
-  rssiInit();
+  RssiNode& rssiNode = RssiNode::rssiNode;
+  rssiNode.setFilter(&testFilter);
+  State& state = rssiNode.getState();
+  LastPass& lastPass = rssiNode.getLastPass();
+  History& history = rssiNode.getHistory();
+  rssiNode.start();
 
   state.activatedFlag = true;
 
   // prime the state with some background signal
   sendSignal(nano, 50);
-  assertFalse(rssiStateValid());
+  assertFalse(rssiNode.isStateValid());
   // more signal needed
   sendSignal(nano, 50);
   assertEqual(2*N_2*1000-1000, state.lastloopMicros);
-  assertTrue(rssiStateValid());
+  assertTrue(rssiNode.isStateValid());
   assertEqual(50, (int)state.rssi);
   assertEqual(timestamp(2), (int)state.rssiTimestamp);
   assertEqual(50, (int)state.lastRssi);

--- a/src/node/test/good-crossing_gradual.cpp
+++ b/src/node/test/good-crossing_gradual.cpp
@@ -9,15 +9,19 @@
 unittest(gradualCrossing) {
   GodmodeState* nano = GODMODE();
   nano->reset();
-  rssiSetFilter(&testFilter);
-  rssiInit();
+  RssiNode& rssiNode = RssiNode::rssiNode;
+  rssiNode.setFilter(&testFilter);
+  State& state = rssiNode.getState();
+  LastPass& lastPass = rssiNode.getLastPass();
+  History& history = rssiNode.getHistory();
+  rssiNode.start();
 
   state.activatedFlag = true;
 
   // prime the state with some background signal
   sendSignal(nano, 50);
   sendSignal(nano, 50);
-  assertTrue(rssiStateValid());
+  assertTrue(rssiNode.isStateValid());
 
   // enter
   for(int signal = 50; signal<130; signal++) {

--- a/src/node/test/good-crossing_slow.cpp
+++ b/src/node/test/good-crossing_slow.cpp
@@ -9,15 +9,19 @@
 unittest(slowCrossing) {
   GodmodeState* nano = GODMODE();
   nano->reset();
-  rssiSetFilter(&testFilter);
-  rssiInit();
+  RssiNode& rssiNode = RssiNode::rssiNode;
+  rssiNode.setFilter(&testFilter);
+  State& state = rssiNode.getState();
+  LastPass& lastPass = rssiNode.getLastPass();
+  History& history = rssiNode.getHistory();
+  rssiNode.start();
 
   state.activatedFlag = true;
 
   // prime the state with some background signal
   sendSignal(nano, 50);
   sendSignal(nano, 50);
-  assertTrue(rssiStateValid());
+  assertTrue(rssiNode.isStateValid());
 
   // enter
   sendSignal(nano, 130);

--- a/src/node/test/good-freqNotSet.cpp
+++ b/src/node/test/good-freqNotSet.cpp
@@ -6,15 +6,19 @@
 unittest(freqNotSet) {
   GodmodeState* nano = GODMODE();
   nano->reset();
-  rssiInit();
+  RssiNode& rssiNode = RssiNode::rssiNode;
+  State& state = rssiNode.getState();
+  LastPass& lastPass = rssiNode.getLastPass();
+  History& history = rssiNode.getHistory();
+  rssiNode.start();
 
   state.activatedFlag = false;
 
   sendSignal(nano, 43);
-  assertFalse(rssiStateValid());
+  assertFalse(rssiNode.isStateValid());
   sendSignal(nano, 43);
   assertEqual(2*N_2*1000-1000, state.lastloopMicros);
-  assertFalse(rssiStateValid());
+  assertFalse(rssiNode.isStateValid());
   assertEqual(0, (int)state.rssi);
   assertEqual(0, (int)state.rssiTimestamp);
   assertEqual(0, (int)state.lastRssi);

--- a/src/node/test/good-history.cpp
+++ b/src/node/test/good-history.cpp
@@ -2,6 +2,59 @@
 #include <Godmode.h>
 #include "../rssi.h"
 #include "util.h"
+#include "../util/single-sendbuffer.h"
+
+unittest(historyBuffer_prefers_biggest_peak) {
+    Extremum e = {23, 2, 100};
+    SinglePeakSendBuffer buffer;
+    assertTrue(buffer.addIfAvailable(e));
+    e.rssi = 20;
+    buffer.addOrDiscard(e);
+    e = buffer.first();
+    assertEqual(23, (int)e.rssi);
+    e.rssi = 27;
+    buffer.addOrDiscard(e);
+    e = buffer.first();
+    assertEqual(27, (int)e.rssi);
+}
+
+unittest(historyBuffer_merges_peak) {
+    Extremum e = {23, 2, 100};
+    SinglePeakSendBuffer buffer;
+    assertTrue(buffer.addIfAvailable(e));
+    e.firstTime = 102, e.duration = 10;
+    buffer.addOrDiscard(e);
+    e = buffer.first();
+    assertEqual(23, (int)e.rssi);
+    assertEqual(2, e.firstTime);
+    assertEqual(110, e.duration);
+}
+
+unittest(historyBuffer_prefers_smallest_nadir) {
+    Extremum e = {23, 2, 100};
+    SingleNadirSendBuffer buffer;
+    assertTrue(buffer.addIfAvailable(e));
+    e.rssi = 27;
+    buffer.addOrDiscard(e);
+    e = buffer.first();
+    assertEqual(23, (int)e.rssi);
+    e.rssi = 20;
+    buffer.addOrDiscard(e);
+    e = buffer.first();
+    assertEqual(20, (int)e.rssi);
+}
+
+unittest(historyBuffer_merges_nadir) {
+    Extremum e = {23, 2, 100};
+    SingleNadirSendBuffer buffer;
+    assertTrue(buffer.addIfAvailable(e));
+    e.firstTime = 102, e.duration = 10;
+    buffer.addOrDiscard(e);
+    e = buffer.first();
+    assertEqual(23, (int)e.rssi);
+    assertEqual(2, e.firstTime);
+    assertEqual(110, e.duration);
+}
 
 /**
  * Tests history buffer.

--- a/src/node/test/good-history.cpp
+++ b/src/node/test/good-history.cpp
@@ -62,9 +62,12 @@ unittest(historyBuffer_merges_nadir) {
 unittest(historyBuffer_withoutReads) {
   GodmodeState* nano = GODMODE();
   nano->reset();
-  rssiSetFilter(&testFilter);
-  rssiInit();
-  rssiStateReset();
+  RssiNode& rssiNode = RssiNode::rssiNode;
+  rssiNode.setFilter(&testFilter);
+  State& state = rssiNode.getState();
+  History& history = rssiNode.getHistory();
+  rssiNode.start();
+  rssiNode.resetState();
 
   state.activatedFlag = true;
 
@@ -130,9 +133,12 @@ unittest(historyBuffer_withoutReads) {
 unittest(historyBuffer_withReads) {
   GodmodeState* nano = GODMODE();
   nano->reset();
-  rssiSetFilter(&testFilter);
-  rssiInit();
-  rssiStateReset();
+  RssiNode& rssiNode = RssiNode::rssiNode;
+  rssiNode.setFilter(&testFilter);
+  State& state = rssiNode.getState();
+  History& history = rssiNode.getHistory();
+  rssiNode.start();
+  rssiNode.resetState();
 
   state.activatedFlag = true;
 

--- a/src/node/test/good-multihistory.cpp
+++ b/src/node/test/good-multihistory.cpp
@@ -65,10 +65,14 @@ MultiNadirSendBuffer<1> testNadirBuffer1;
 unittest(historyBuffer_multi1_withoutReads) {
   GodmodeState* nano = GODMODE();
   nano->reset();
-  rssiSetSendBuffers(&testPeakBuffer1, &testNadirBuffer1);
-  rssiSetFilter(&testFilter);
-  rssiInit();
-  rssiStateReset();
+  RssiNode& rssiNode = RssiNode::rssiNode;
+  rssiNode.setSendBuffers(&testPeakBuffer1, &testNadirBuffer1);
+  rssiNode.setFilter(&testFilter);
+  State& state = rssiNode.getState();
+  LastPass& lastPass = rssiNode.getLastPass();
+  History& history = rssiNode.getHistory();
+  rssiNode.start();
+  rssiNode.resetState();
 
   state.activatedFlag = true;
 
@@ -134,9 +138,13 @@ unittest(historyBuffer_multi1_withoutReads) {
 unittest(historyBuffer_multi1_withReads) {
   GodmodeState* nano = GODMODE();
   nano->reset();
-  rssiSetSendBuffers(&testPeakBuffer1, &testNadirBuffer1);
-  rssiInit();
-  rssiStateReset();
+  RssiNode& rssiNode = RssiNode::rssiNode;
+  rssiNode.setSendBuffers(&testPeakBuffer1, &testNadirBuffer1);
+  State& state = rssiNode.getState();
+  LastPass& lastPass = rssiNode.getLastPass();
+  History& history = rssiNode.getHistory();
+  rssiNode.start();
+  rssiNode.resetState();
 
   state.activatedFlag = true;
 

--- a/src/node/test/util.h
+++ b/src/node/test/util.h
@@ -1,4 +1,4 @@
-#include "../util/median-filter.h"
+#include "../rssi.h"
 
 MedianFilter<rssi_t, SmoothingSamples, 0> testFilter;
 
@@ -9,7 +9,7 @@ const static int N_TS = testFilter.getTimestampCapacity();
 
 void sendSignal(GodmodeState* nano, int rssi) {
   for(int t=0; t<N_2; t++) {
-    rssiProcess(rssi, millis());
+    RssiNode::rssiNode.process(rssi, millis());
     milliTick(nano);
   }
 }

--- a/src/node/util/rhtypes.h
+++ b/src/node/util/rhtypes.h
@@ -20,5 +20,6 @@ struct Extremum
 #define isNadirValid(x) ((x).rssi != MAX_RSSI)
 #define invalidatePeak(x) ((x).rssi = 0)
 #define invalidateNadir(x) ((x).rssi = MAX_RSSI)
+#define endTime(x) ((x).firstTime + (x).duration)
 
 #endif

--- a/src/node/util/single-sendbuffer.h
+++ b/src/node/util/single-sendbuffer.h
@@ -4,8 +4,6 @@
 #include "rhtypes.h"
 #include "sendbuffer.h"
 
-#define endTime(x) ((x).firstTime + (x).duration)
-
 class SinglePeakSendBuffer : public SendBuffer<Extremum>
 {
     private:

--- a/src/server/Results.py
+++ b/src/server/Results.py
@@ -1074,7 +1074,7 @@ def check_win_fastest_consecutive(RACE, **kwargs):
         if len(leaderboard) > 1:
             fast_lap = leaderboard[0]['consecutives_raw']
 
-            if fast_lap > 3: # must have at least 3 laps
+            if fast_lap and fast_lap > 3: # must have at least 3 laps
                 # check for tie
                 if leaderboard[1]['consecutives_raw'] == fast_lap:
                     logger.info('Race tied at %s', leaderboard[1]['consecutives'])


### PR DESCRIPTION
Note: to avoid the hassle of conflicts this branch is based off my other PR - merge in order.

I noticed we are using millis() to track a 1ms interval for the main loop. I googled millis() to discover it is approx 1ms accurate - not good. So I rewrote the loop timing to use micros().
