### PR TITLE
Add untracked 'user' folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ config.json
 db_bkp
 /src/libraries
 logs
+/src/server/static/user/*
+!/src/server/static/user/README.md

--- a/src/server/static/user/README.md
+++ b/src/server/static/user/README.md
@@ -1,0 +1,3 @@
+# User Folder
+
+Place user- or timer-specific images here. This folder is not tracked by Git and will not be destroyed in a Git-based server upgrade.

--- a/src/server/templates/home.html
+++ b/src/server/templates/home.html
@@ -23,7 +23,7 @@
 <div class="header">
 	<h1>
 		{% if getOption("timerLogo") %}
-			<img src="./static/{{ getOption('timerLogo') }}" alt="{{ getOption('timerName') }}" />
+			<img src="./static/user/{{ getOption('timerLogo') }}" alt="{{ getOption('timerName') }}" />
 		{% else %}
 			<img src="./static/image/RotorHazard Logo.svg" alt="{{ getOption('timerName') }}" />
 		{% endif %}

--- a/src/server/templates/settings.html
+++ b/src/server/templates/settings.html
@@ -2443,9 +2443,9 @@
 			<li>
 				<div class="label-block">
 					<label for="set_timer_logo">{{ __('Timer Logo') }}</label>
-					<p class="desc">{{ __('File path relative to RotorHazard/server/static') }}</p>
+					<p class="desc">{{ __('File path relative to RotorHazard/server/static/user') }}</p>
 				</div>
-				<input type="text" id="set_timer_logo" class="set-option" data-option="timerLogo" value="{{ getOption('timerLogo') }}" placeholder="image/group-logo.png">
+				<input type="text" id="set_timer_logo" class="set-option" data-option="timerLogo" value="{{ getOption('timerLogo') }}" placeholder="group-logo.png">
 			</li>
 			<li>
 				<div class="label-block">


### PR DESCRIPTION
- Adds /user/ folder within src/server/static (Flask will only read within this folder)
- Update gitignore to ignore files within this folder
- Add README to explain folder purpose; also allows otherwise empty folder to be populated on checkout
- Update templates to load from /user/ folder
- Closes #356