### PR TITLE
Send durations instead of last-times.

### DIFF
--- a/src/interface/RHInterface.py
+++ b/src/interface/RHInterface.py
@@ -199,13 +199,13 @@ class RHInterface(BaseHardwareInterface):
                         if node.api_level >= 21:
                             offset_peakRssi = 11
                             offset_peakFirstTime = 12
-                            if node.api_level >= 26:
+                            if node.api_level >= 33:
                                 offset_peakDuration = 14
                             else:
                                 offset_peakLastTime = 14
                             offset_nadirRssi = 11
                             offset_nadirFirstTime = 12
-                            if node.api_level >= 26:
+                            if node.api_level >= 33:
                                 offset_nadirDuration = 14
                             else:
                                 offset_nadirLastTime = 14
@@ -244,7 +244,7 @@ class RHInterface(BaseHardwareInterface):
                                         if node.is_valid_rssi(rssi_val):
                                             pn_history.peakRssi = rssi_val
                                             pn_history.peakFirstTime = unpack_16(data[offset_peakFirstTime:]) # ms *since* the first peak time
-                                            if node.api_level >= 26:
+                                            if node.api_level >= 33:
                                                 pn_history.peakLastTime = pn_history.peakFirstTime - unpack_16(data[offset_peakDuration:])   # ms *since* the last peak time
                                             else:
                                                 pn_history.peakLastTime = unpack_16(data[offset_peakLastTime:])   # ms *since* the last peak time
@@ -255,7 +255,7 @@ class RHInterface(BaseHardwareInterface):
                                         if node.is_valid_rssi(rssi_val):
                                             pn_history.nadirRssi = rssi_val
                                             pn_history.nadirFirstTime = unpack_16(data[offset_nadirFirstTime:])
-                                            if node.api_level >= 26:
+                                            if node.api_level >= 33:
                                                 pn_history.nadirLastTime = pn_history.nadirFirstTime - unpack_16(data[offset_nadirDuration:])
                                             else:
                                                 pn_history.nadirLastTime = unpack_16(data[offset_nadirLastTime:])
@@ -325,7 +325,7 @@ class RHInterface(BaseHardwareInterface):
 
         # process any nodes with new laps detected
         self.process_updates(upd_list)
-        
+
         if startThreshLowerNode:
             logger.info("For node {0} restoring EnterAt to {1} and ExitAt to {2}"\
                     .format(startThreshLowerNode.index+1, startThreshLowerNode.enter_at_level, \
@@ -517,7 +517,7 @@ class RHInterface(BaseHardwareInterface):
     # log comm errors if error percentage is >= this value
     def set_intf_error_report_percent_limit(self, percentVal):
         self.intf_error_report_limit = percentVal / 100;
-    
+
     def get_intf_error_report_str(self, forceFlag=False):
         if self.intf_read_block_count <= 0:
             return None

--- a/src/interface/RHInterface.py
+++ b/src/interface/RHInterface.py
@@ -199,10 +199,16 @@ class RHInterface(BaseHardwareInterface):
                         if node.api_level >= 21:
                             offset_peakRssi = 11
                             offset_peakFirstTime = 12
-                            offset_peakLastTime = 14
+                            if node.api_level >= 26:
+                                offset_peakDuration = 14
+                            else:
+                                offset_peakLastTime = 14
                             offset_nadirRssi = 11
                             offset_nadirFirstTime = 12
-                            offset_nadirLastTime = 14
+                            if node.api_level >= 26:
+                                offset_nadirDuration = 14
+                            else:
+                                offset_nadirLastTime = 14
                         else:
                             offset_peakRssi = 11
                             offset_peakFirstTime = 12
@@ -238,7 +244,10 @@ class RHInterface(BaseHardwareInterface):
                                         if node.is_valid_rssi(rssi_val):
                                             pn_history.peakRssi = rssi_val
                                             pn_history.peakFirstTime = unpack_16(data[offset_peakFirstTime:]) # ms *since* the first peak time
-                                            pn_history.peakLastTime = unpack_16(data[offset_peakLastTime:])   # ms *since* the last peak time
+                                            if node.api_level >= 26:
+                                                pn_history.peakLastTime = pn_history.peakFirstTime - unpack_16(data[offset_peakDuration:])   # ms *since* the last peak time
+                                            else:
+                                                pn_history.peakLastTime = unpack_16(data[offset_peakLastTime:])   # ms *since* the last peak time
                                         elif rssi_val > 0:
                                             self.log('History peak RSSI reading ({0}) out of range on Node {1}; rejected'.format(rssi_val, node.index+1))
                                     else:
@@ -246,7 +255,10 @@ class RHInterface(BaseHardwareInterface):
                                         if node.is_valid_rssi(rssi_val):
                                             pn_history.nadirRssi = rssi_val
                                             pn_history.nadirFirstTime = unpack_16(data[offset_nadirFirstTime:])
-                                            pn_history.nadirLastTime = unpack_16(data[offset_nadirLastTime:])
+                                            if node.api_level >= 26:
+                                                pn_history.nadirLastTime = pn_history.nadirFirstTime - unpack_16(data[offset_nadirDuration:])
+                                            else:
+                                                pn_history.nadirLastTime = unpack_16(data[offset_nadirLastTime:])
                                         elif rssi_val > 0:
                                             self.log('History nadir RSSI reading ({0}) out of range on Node {1}; rejected'.format(rssi_val, node.index+1))
                                 else:

--- a/src/node/commands.cpp
+++ b/src/node/commands.cpp
@@ -128,7 +128,7 @@ void ioBufferWriteExtremum(Buffer& buf, const Extremum& e, mtime_t now)
 {
     ioBufferWriteRssi(buf, e.rssi);
     buf.write16(uint16_t(now - e.firstTime));
-    buf.write16(uint16_t(now - e.firstTime - e.duration));
+    buf.write16(e.duration);
 }
 
 // Generic IO read command handler

--- a/src/node/commands.h
+++ b/src/node/commands.h
@@ -4,7 +4,7 @@
 #include "io.h"
 
 // API level for node; increment when commands are modified
-#define NODE_API_LEVEL 26
+#define NODE_API_LEVEL 33
 
 class Message
 {

--- a/src/node/commands.h
+++ b/src/node/commands.h
@@ -4,7 +4,7 @@
 #include "io.h"
 
 // API level for node; increment when commands are modified
-#define NODE_API_LEVEL 25
+#define NODE_API_LEVEL 26
 
 class Message
 {


### PR DESCRIPTION
This avoids any chance of last-time being out-of-order compared to
first-time due to overflow.