### PR TITLE
Handle system-clock time jumps

### DIFF
--- a/src/server/RHRace.py
+++ b/src/server/RHRace.py
@@ -22,6 +22,7 @@ class RHRace():
         self.start_time_delay_secs = 0 # random-length race-start delay
         self.node_laps = {} # current race lap objects, by node
         self.node_has_finished = {}
+        self.any_races_started = False
         # concluded
         self.duration_ms = 0 # Duration in seconds, calculated when race is stopped
         self.end_time = 0 # Monotonic, updated when race is stopped


### PR DESCRIPTION
Monitor system clock and adjust PROGRAM_START_EPOCH_TIME if significant jump detected.

This can happen if NTP synchronization occurs after server starts up.

If change in slave startup-time detected then reset timeDiff median.

Have slave repeat join-cluster-response msg if system clock changed.

Stop monitoring after any race started (adjustments would be too disruptive to time values).