### PR TITLE
Add semaphore lock for node I/O access

### DIFF
--- a/src/interface/i2c_node.py
+++ b/src/interface/i2c_node.py
@@ -1,11 +1,14 @@
 '''RotorHazard I2C interface layer.'''
 import logging
+import gevent
 from monotonic import monotonic
 
 from Node import Node
 from RHInterface import READ_ADDRESS, MAX_RETRY_COUNT, validate_checksum, calculate_checksum
 
 logger = logging.getLogger(__name__)
+
+node_io_rlock_obj = gevent.lock.RLock()  # semaphore lock for node I/O access
 
 
 class I2CNode(Node):
@@ -19,76 +22,78 @@ class I2CNode(Node):
         '''
         Read i2c data given command, and data size.
         '''
-        self.inc_read_block_count(interface)
-        success = False
-        retry_count = 0
-        data = None
-        while success is False and retry_count <= MAX_RETRY_COUNT:
-            try:
-                def _read():
-                    self.io_request = monotonic()
-                    _data = self.i2c_helper.i2c.read_i2c_block_data(self.i2c_addr, command, size + 1)
-                    self.io_response = monotonic()
-                    if validate_checksum(_data):
-                        return _data
+        with node_io_rlock_obj:  # only allow one greenlet at a time
+            self.inc_read_block_count(interface)
+            success = False
+            retry_count = 0
+            data = None
+            while success is False and retry_count <= MAX_RETRY_COUNT:
+                try:
+                    def _read():
+                        self.io_request = monotonic()
+                        _data = self.i2c_helper.i2c.read_i2c_block_data(self.i2c_addr, command, size + 1)
+                        self.io_response = monotonic()
+                        if validate_checksum(_data):
+                            return _data
+                        else:
+                            return None
+                    data = self.i2c_helper.with_i2c(_read)
+                    if data:
+                        success = True
+                        data = data[:-1]
                     else:
-                        return None
-                data = self.i2c_helper.with_i2c(_read)
-                if data:
-                    success = True
-                    data = data[:-1]
-                else:
-                    # self.log('Invalid Checksum ({0}): {1}'.format(retry_count, data))
+                        # self.log('Invalid Checksum ({0}): {1}'.format(retry_count, data))
+                        retry_count = retry_count + 1
+                        if retry_count <= MAX_RETRY_COUNT:
+                            if retry_count > 1:  # don't log the occasional single retry
+                                interface.log('Retry (checksum) in read_block:  addr={0} cmd={1} size={2} retry={3} ts={4}'.format(self.i2c_addr, command, size, retry_count, self.i2c_helper.i2c_timestamp))
+                        else:
+                            interface.log('Retry (checksum) limit reached in read_block:  addr={0} cmd={1} size={2} retry={3} ts={4}'.format(self.i2c_addr, command, size, retry_count, self.i2c_helper.i2c_timestamp))
+                        self.inc_read_error_count(interface)
+                except IOError as err:
+                    interface.log('Read Error: ' + str(err))
+                    self.i2c_helper.i2c_end()
                     retry_count = retry_count + 1
                     if retry_count <= MAX_RETRY_COUNT:
                         if retry_count > 1:  # don't log the occasional single retry
-                            interface.log('Retry (checksum) in read_block:  addr={0} cmd={1} size={2} retry={3} ts={4}'.format(self.i2c_addr, command, size, retry_count, self.i2c_helper.i2c_timestamp))
+                            interface.log('Retry (IOError) in read_block:  addr={0} cmd={1} size={2} retry={3} ts={4}'.format(self.i2c_addr, command, size, retry_count, self.i2c_helper.i2c_timestamp))
                     else:
-                        interface.log('Retry (checksum) limit reached in read_block:  addr={0} cmd={1} size={2} retry={3} ts={4}'.format(self.i2c_addr, command, size, retry_count, self.i2c_helper.i2c_timestamp))
+                        interface.log('Retry (IOError) limit reached in read_block:  addr={0} cmd={1} size={2} retry={3} ts={4}'.format(self.i2c_addr, command, size, retry_count, self.i2c_helper.i2c_timestamp))
                     self.inc_read_error_count(interface)
-            except IOError as err:
-                interface.log('Read Error: ' + str(err))
-                self.i2c_helper.i2c_end()
-                retry_count = retry_count + 1
-                if retry_count <= MAX_RETRY_COUNT:
-                    if retry_count > 1:  # don't log the occasional single retry
-                        interface.log('Retry (IOError) in read_block:  addr={0} cmd={1} size={2} retry={3} ts={4}'.format(self.i2c_addr, command, size, retry_count, self.i2c_helper.i2c_timestamp))
-                else:
-                    interface.log('Retry (IOError) limit reached in read_block:  addr={0} cmd={1} size={2} retry={3} ts={4}'.format(self.i2c_addr, command, size, retry_count, self.i2c_helper.i2c_timestamp))
-                self.inc_read_error_count(interface)
-        return data
+            return data
 
     def write_block(self, interface, command, data):
         '''
         Write i2c data given command, and data.
         '''
-        interface.inc_intf_write_block_count()
-        success = False
-        retry_count = 0
-        data_with_checksum = data
-        if self.api_level <= 19:
-            data_with_checksum.append(command)
-        data_with_checksum.append(calculate_checksum(data_with_checksum))
-        while success is False and retry_count <= MAX_RETRY_COUNT:
-            try:
-                def _write():
-                    # self.io_request = monotonic()
-                    self.i2c_helper.i2c.write_i2c_block_data(self.i2c_addr, command, data_with_checksum)
-                    # self.io_response = monotonic()
-                    return True
-                success = self.i2c_helper.with_i2c(_write)
-                if success is None:
-                    success = False
-            except IOError as err:
-                interface.log('Write Error: ' + str(err))
-                self.i2c_helper.i2c_end()
-                retry_count = retry_count + 1
-                if retry_count <= MAX_RETRY_COUNT:
-                    interface.log('Retry (IOError) in write_block:  addr={0} cmd={1} data={2} retry={3} ts={4}'.format(self.i2c_addr, command, data, retry_count, self.i2c_helper.i2c_timestamp))
-                else:
-                    interface.log('Retry (IOError) limit reached in write_block:  addr={0} cmd={1} data={2} retry={3} ts={4}'.format(self.i2c_addr, command, data, retry_count, self.i2c_helper.i2c_timestamp))
-                interface.inc_intf_write_error_count()
-        return success
+        with node_io_rlock_obj:  # only allow one greenlet at a time
+            interface.inc_intf_write_block_count()
+            success = False
+            retry_count = 0
+            data_with_checksum = data
+            if self.api_level <= 19:
+                data_with_checksum.append(command)
+            data_with_checksum.append(calculate_checksum(data_with_checksum))
+            while success is False and retry_count <= MAX_RETRY_COUNT:
+                try:
+                    def _write():
+                        # self.io_request = monotonic()
+                        self.i2c_helper.i2c.write_i2c_block_data(self.i2c_addr, command, data_with_checksum)
+                        # self.io_response = monotonic()
+                        return True
+                    success = self.i2c_helper.with_i2c(_write)
+                    if success is None:
+                        success = False
+                except IOError as err:
+                    interface.log('Write Error: ' + str(err))
+                    self.i2c_helper.i2c_end()
+                    retry_count = retry_count + 1
+                    if retry_count <= MAX_RETRY_COUNT:
+                        interface.log('Retry (IOError) in write_block:  addr={0} cmd={1} data={2} retry={3} ts={4}'.format(self.i2c_addr, command, data, retry_count, self.i2c_helper.i2c_timestamp))
+                    else:
+                        interface.log('Retry (IOError) limit reached in write_block:  addr={0} cmd={1} data={2} retry={3} ts={4}'.format(self.i2c_addr, command, data, retry_count, self.i2c_helper.i2c_timestamp))
+                    interface.inc_intf_write_error_count()
+            return success
 
 
 def discover(idxOffset, i2c_helper, *args, **kwargs):

--- a/src/interface/serial_node.py
+++ b/src/interface/serial_node.py
@@ -11,6 +11,8 @@ BOOTLOADER_CHILL_TIME = 2 # Delay for USB to switch from bootloader to serial mo
 
 logger = logging.getLogger(__name__)
 
+node_io_rlock_obj = gevent.lock.RLock()  # semaphore lock for node I/O access
+
 
 class SerialNode(Node):
     def __init__(self, index, port):
@@ -32,82 +34,84 @@ class SerialNode(Node):
         '''
         Read serial data given command, and data size.
         '''
-        self.inc_read_block_count(interface)
-        success = False
-        retry_count = 0
-        data = None
-        while success is False and retry_count <= MAX_RETRY_COUNT:
-            try:
-                self.io_request = monotonic()
-                self.serial.flushInput()
-                self.serial.write(bytearray([command]))
-                data = bytearray(self.serial.read(size + 1))
-                self.io_response = monotonic()
-                if validate_checksum(data):
-                    if len(data) == size + 1:
-                        success = True
-                        data = data[:-1]
-                    else:
-                        retry_count = retry_count + 1
-                        if retry_count <= MAX_RETRY_COUNT:
-                            self.node_log(interface, 'Retry (bad length) in read_block:  port={0} cmd={1} size={2} retry={3}'.format(self.serial.port, command, size, retry_count))
+        with node_io_rlock_obj:  # only allow one greenlet at a time
+            self.inc_read_block_count(interface)
+            success = False
+            retry_count = 0
+            data = None
+            while success is False and retry_count <= MAX_RETRY_COUNT:
+                try:
+                    self.io_request = monotonic()
+                    self.serial.flushInput()
+                    self.serial.write(bytearray([command]))
+                    data = bytearray(self.serial.read(size + 1))
+                    self.io_response = monotonic()
+                    if validate_checksum(data):
+                        if len(data) == size + 1:
+                            success = True
+                            data = data[:-1]
                         else:
-                            self.node_log(interface, 'Retry (bad length) limit reached in read_block:  port={0} cmd={1} size={2} retry={3}'.format(self.serial.port, command, size, retry_count))
+                            retry_count = retry_count + 1
+                            if retry_count <= MAX_RETRY_COUNT:
+                                self.node_log(interface, 'Retry (bad length) in read_block:  port={0} cmd={1} size={2} retry={3}'.format(self.serial.port, command, size, retry_count))
+                            else:
+                                self.node_log(interface, 'Retry (bad length) limit reached in read_block:  port={0} cmd={1} size={2} retry={3}'.format(self.serial.port, command, size, retry_count))
+                            self.inc_read_error_count(interface)
+                            gevent.sleep(0.1)
+                    else:
+                        # self.log('Invalid Checksum ({0}): {1}'.format(retry_count, data))
+                        retry_count = retry_count + 1
+                        if data and len(data) > 0:
+                            if retry_count <= MAX_RETRY_COUNT:
+                                if retry_count > 1:  # don't log the occasional single retry
+                                    self.node_log(interface, 'Retry (checksum) in read_block:  port={0} cmd={1} size={2} retry={3}'.format(self.serial.port, command, size, retry_count))
+                            else:
+                                self.node_log(interface, 'Retry (checksum) limit reached in read_block:  port={0} cmd={1} size={2} retry={3}'.format(self.serial.port, command, size, retry_count))
+                        else:
+                            if retry_count <= MAX_RETRY_COUNT:
+                                    self.node_log(interface, 'Retry (no data) in read_block:  port={0} cmd={1} size={2} retry={3}'.format(self.serial.port, command, size, retry_count))
+                            else:
+                                self.node_log(interface, 'Retry (no data) limit reached in read_block:  port={0} cmd={1} size={2} retry={3}'.format(self.serial.port, command, size, retry_count))
                         self.inc_read_error_count(interface)
                         gevent.sleep(0.1)
-                else:
-                    # self.log('Invalid Checksum ({0}): {1}'.format(retry_count, data))
+                except IOError as err:
+                    self.node_log(interface, 'Read Error: ' + str(err))
                     retry_count = retry_count + 1
-                    if data and len(data) > 0:
-                        if retry_count <= MAX_RETRY_COUNT:
-                            if retry_count > 1:  # don't log the occasional single retry
-                                self.node_log(interface, 'Retry (checksum) in read_block:  port={0} cmd={1} size={2} retry={3}'.format(self.serial.port, command, size, retry_count))
-                        else:
-                            self.node_log(interface, 'Retry (checksum) limit reached in read_block:  port={0} cmd={1} size={2} retry={3}'.format(self.serial.port, command, size, retry_count))
+                    if retry_count <= MAX_RETRY_COUNT:
+                        if retry_count > 1:  # don't log the occasional single retry
+                            self.node_log(interface, 'Retry (IOError) in read_block:  port={0} cmd={1} size={2} retry={3}'.format(self.serial.port, command, size, retry_count))
                     else:
-                        if retry_count <= MAX_RETRY_COUNT:
-                                self.node_log(interface, 'Retry (no data) in read_block:  port={0} cmd={1} size={2} retry={3}'.format(self.serial.port, command, size, retry_count))
-                        else:
-                            self.node_log(interface, 'Retry (no data) limit reached in read_block:  port={0} cmd={1} size={2} retry={3}'.format(self.serial.port, command, size, retry_count))
+                        self.node_log(interface, 'Retry (IOError) limit reached in read_block:  port={0} cmd={1} size={2} retry={3}'.format(self.serial.port, command, size, retry_count))
                     self.inc_read_error_count(interface)
                     gevent.sleep(0.1)
-            except IOError as err:
-                self.node_log(interface, 'Read Error: ' + str(err))
-                retry_count = retry_count + 1
-                if retry_count <= MAX_RETRY_COUNT:
-                    if retry_count > 1:  # don't log the occasional single retry
-                        self.node_log(interface, 'Retry (IOError) in read_block:  port={0} cmd={1} size={2} retry={3}'.format(self.serial.port, command, size, retry_count))
-                else:
-                    self.node_log(interface, 'Retry (IOError) limit reached in read_block:  port={0} cmd={1} size={2} retry={3}'.format(self.serial.port, command, size, retry_count))
-                self.inc_read_error_count(interface)
-                gevent.sleep(0.1)
-        return data if success else None
+            return data if success else None
 
     def write_block(self, interface, command, data):
         '''
         Write serial data given command, and data.
         '''
-        interface.inc_intf_write_block_count()
-        success = False
-        retry_count = 0
-        data_with_checksum = bytearray()
-        data_with_checksum.append(command)
-        data_with_checksum.extend(data)
-        data_with_checksum.append(calculate_checksum(data_with_checksum[1:]))
-        while success is False and retry_count <= MAX_RETRY_COUNT:
-            try:
-                self.serial.write(data_with_checksum)
-                success = True
-            except IOError as err:
-                self.node_log(interface, 'Write Error: ' + str(err))
-                retry_count = retry_count + 1
-                if retry_count <= MAX_RETRY_COUNT:
-                    self.node_log(interface, 'Retry (IOError) in write_block:  port={0} cmd={1} data={2} retry={3}'.format(self.serial.port, command, data, retry_count))
-                else:
-                    self.node_log(interface, 'Retry (IOError) limit reached in write_block:  port={0} cmd={1} data={2} retry={3}'.format(self.serial.port, command, data, retry_count))
-                interface.inc_intf_write_error_count()
-                gevent.sleep(0.1)
-        return success
+        with node_io_rlock_obj:  # only allow one greenlet at a time
+            interface.inc_intf_write_block_count()
+            success = False
+            retry_count = 0
+            data_with_checksum = bytearray()
+            data_with_checksum.append(command)
+            data_with_checksum.extend(data)
+            data_with_checksum.append(calculate_checksum(data_with_checksum[1:]))
+            while success is False and retry_count <= MAX_RETRY_COUNT:
+                try:
+                    self.serial.write(data_with_checksum)
+                    success = True
+                except IOError as err:
+                    self.node_log(interface, 'Write Error: ' + str(err))
+                    retry_count = retry_count + 1
+                    if retry_count <= MAX_RETRY_COUNT:
+                        self.node_log(interface, 'Retry (IOError) in write_block:  port={0} cmd={1} data={2} retry={3}'.format(self.serial.port, command, data, retry_count))
+                    else:
+                        self.node_log(interface, 'Retry (IOError) limit reached in write_block:  port={0} cmd={1} data={2} retry={3}'.format(self.serial.port, command, data, retry_count))
+                    interface.inc_intf_write_error_count()
+                    gevent.sleep(0.1)
+            return success
 
 
 def discover(idxOffset, config, *args, **kwargs):


### PR DESCRIPTION
Use gevent RLock to only allow one greenlet at a time to access I2C and serial comms to nodes.