### PR TITLE
Server Support for S32_BPill

### DIFF
--- a/doc/Software Setup.md
+++ b/doc/Software Setup.md
@@ -279,9 +279,9 @@ To install the RotorHazard server on these systems:
 
 1. Open up a command prompt and navigate to the ```src/server``` directory in the RotorHazard files (using the 'cd' command).
 
-1. Install the RotorHazard server dependencies using the 'requirements.txt' file, using one of the commands below. (Note that this command may require administrator access to the computer, and the command may take a few minutes to finish).
-  * On a Windows system the command to use will likely be:<br/>```python -m pip install -r requirements.txt```<br/><br/>
-  * On a Linux system the command to use will likely be:<br/>```sudo pip install -r requirements.txt```<br/>
+1. Install the RotorHazard server dependencies using the 'reqsNonPi.txt' file, using one of the commands below. (Note that this command may require administrator access to the computer, and the command may take a few minutes to finish).
+  * On a Windows system the command to use will likely be:<br/>```python -m pip install -r reqsNonPi.txt```<br/><br/>
+  * On a Linux system the command to use will likely be:<br/>```sudo pip install -r reqsNonPi.txt```<br/>
 
 
 To run the RotorHazard server on these systems:

--- a/doc/Software Setup.md
+++ b/doc/Software Setup.md
@@ -7,7 +7,7 @@ Note: If RotorHazard is already installed, see the [Updating an existing install
 ## Install System (Raspberry Pi)
 Note: Many of the setup commands below require that the Rasperry Pi has internet access.
 
-Start by installing Raspbian, following the official instructions here: https://www.raspberrypi.org/downloads/raspbian/. You may use either Desktop or Lite.
+Start by installing the Raspberry Pi OS, following the official instructions here: https://www.raspberrypi.org/software/operating-systems/#raspberry-pi-os-32-bit . You may use either Desktop or Lite.
 
 Configure the interface options on the Raspberry Pi.
 Open a Terminal window and enter the following command:
@@ -149,9 +149,13 @@ sudo python setup.py install
 ```
 
 ### Java Support
-Java enables calculating of IMD scores. If you started with RASPBIAN WITH DESKTOP, this step should not be necessary as Java is installed by default. Otherwise:
+Java enables the calculating of IMD scores, which is helpful for selecting frequency sets with less interference between VTXs. To determine if Java is installed, run the following command:
 ```
-sudo apt-get install openjdk-8-jdk
+java --version
+```
+If the response is "command not found" then Java may be installed with:
+```
+sudo apt-get install openjdk-11-jdk
 ```
 
 ## Prepare System
@@ -214,6 +218,10 @@ sudo systemctl stop rotorhazard
 To disable the service (so it no longer runs when the system starts up), enter:
 ```
 sudo systemctl disable rotorhazard.service
+```
+To query the status of the service:
+```
+sudo systemctl status rotorhazard.service
 ```
 
 ### Shutting down the System
@@ -280,8 +288,11 @@ To install the RotorHazard server on these systems:
 1. Open up a command prompt and navigate to the ```src/server``` directory in the RotorHazard files (using the 'cd' command).
 
 1. Install the RotorHazard server dependencies using the 'reqsNonPi.txt' file, using one of the commands below. (Note that this command may require administrator access to the computer, and the command may take a few minutes to finish).
-  * On a Windows system the command to use will likely be:<br/>```python -m pip install -r reqsNonPi.txt```<br/><br/>
-  * On a Linux system the command to use will likely be:<br/>```sudo pip install -r reqsNonPi.txt```<br/>
+  * On a Windows system the command to use will likely be:<br/>```python -m pip install -r reqsNonPi.txt```<br>
+
+Note: If the above command fails with a message like "error: Microsoft Visual C++ 14.0 is required", the Visual C++ Build Tools may downloaded (from [here](http://go.microsoft.com/fwlink/?LinkId=691126&fixForIE=.exe.)) and installed.<br>
+
+  * On a Linux system the command to use will likely be:<br/>```sudo pip install -r reqsNonPi.txt```
 
 
 To run the RotorHazard server on these systems:

--- a/doc/USB Nodes.md
+++ b/doc/USB Nodes.md
@@ -38,7 +38,7 @@ Multiple USB nodes would be configured like this:
 
 #### Node Code
 
-No changes to the standard RotorHazard node code are needed; the code may be uploaded (flashed) to the Arduino using [the "standard" method](Software%20Setup.md#install-receiver-node-code-arduinos) (via the Arduino IDE).  The NODE_NUMBER value (in "src/node/config.h") is ignored for USB nodes; it can be left at 0.
+The RotorHazard node code will need to be uploaded (flashed) to the Arduino using [the "standard" method](Software%20Setup.md#install-receiver-node-code-arduinos) (via the Arduino IDE).  The NODE_NUMBER value (in "src/node/config.h") is ignored for USB nodes; it can be left at 0.
 
 <br/>
 

--- a/src/interface/MockInterface.py
+++ b/src/interface/MockInterface.py
@@ -31,7 +31,7 @@ class MockInterface(BaseHardwareInterface):
             node.i2c_addr = 2 * index + 8 # Set current loop i2c_addr
             node.index = index
             node.api_valid_flag = True
-            node.api_level = 25
+            node.api_level = 32
             node.enter_at_level = 90
             node.exit_at_level = 80
             self.nodes.append(node) # Add new node to RHInterface
@@ -51,6 +51,12 @@ class MockInterface(BaseHardwareInterface):
         if self.update_thread is None:
             self.log('Starting background thread.')
             self.update_thread = gevent.spawn(self.update_loop)
+
+    def stop(self):
+        if self.update_thread:
+            self.log('Stopping background thread')
+            self.update_thread.kill(block=True, timeout=0.5)
+            self.update_thread = None
 
     def update_loop(self):
         try:
@@ -152,6 +158,9 @@ class MockInterface(BaseHardwareInterface):
 
     def force_end_crossing(self, node_index):
         pass
+
+    def jump_to_bootloader(self):
+        self.log("MockInterace - no jump-to-bootloader support")
 
     def inc_intf_read_block_count(self):
         pass

--- a/src/interface/MockInterface.py
+++ b/src/interface/MockInterface.py
@@ -162,6 +162,12 @@ class MockInterface(BaseHardwareInterface):
     def jump_to_bootloader(self):
         self.log("MockInterace - no jump-to-bootloader support")
 
+    def get_fwupd_serial_name(self):
+        return None
+
+    def close_fwupd_serial_port(self):
+        pass
+
     def inc_intf_read_block_count(self):
         pass
 

--- a/src/interface/Node.py
+++ b/src/interface/Node.py
@@ -6,6 +6,9 @@ class Node:
         self.api_level = 0
         self.api_valid_flag = False
         self.index = -1
+        self.multi_node_index = -1
+        self.multi_curnode_index_holder = None
+        self.rhfeature_flags = 0
         self.frequency = 0
         self.current_rssi = 0
         self.node_peak_rssi = 0

--- a/src/interface/Node.py
+++ b/src/interface/Node.py
@@ -8,6 +8,7 @@ class Node:
         self.index = -1
         self.multi_node_index = -1
         self.multi_curnode_index_holder = None
+        self.multi_node_slot_index = -1
         self.rhfeature_flags = 0
         self.frequency = 0
         self.current_rssi = 0

--- a/src/interface/i2c_helper.py
+++ b/src/interface/i2c_helper.py
@@ -1,6 +1,6 @@
 '''RotorHazard I2C interface layer.'''
 
-import smbus # For i2c comms
+import smbus2 # For i2c comms
 import gevent
 import logging
 from monotonic import monotonic
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 class I2CBus(object):
     def __init__(self, bus):
-        self.i2c = smbus.SMBus(bus) # Start i2c bus
+        self.i2c = smbus2.SMBus(bus) # Start i2c bus
         self.i2c_rlock_obj = gevent.lock.RLock()  # for limiting i2c to 1 read/write at a time
         self.i2c_timestamp = -1
 

--- a/src/interface/i2c_node.py
+++ b/src/interface/i2c_node.py
@@ -4,7 +4,7 @@ from monotonic import monotonic
 
 from Node import Node
 from RHInterface import READ_ADDRESS, READ_REVISION_CODE, MAX_RETRY_COUNT,\
-                        validate_checksum, calculate_checksum
+                        validate_checksum, calculate_checksum, unpack_16
 
 logger = logging.getLogger(__name__)
 
@@ -106,7 +106,8 @@ def discover(idxOffset, i2c_helper, isS32BPillFlag=False, *args, **kwargs):
             i2c_helper.i2c.read_i2c_block_data(addr, READ_ADDRESS, 1)
             node = I2CNode(index+idxOffset, addr, i2c_helper) # New node instance
             # read NODE_API_LEVEL and verification value:
-            rev_val = node.get_value_16(node, READ_REVISION_CODE)
+            data = node.read_block(None, READ_REVISION_CODE, 2, 2)
+            rev_val = unpack_16(data) if data != None else None
             if rev_val:
                 if (rev_val >> 8) == 0x25:  # if verify passed (fn defined) then set API level
                     node.api_level = rev_val & 0xFF

--- a/src/interface/serial_node.py
+++ b/src/interface/serial_node.py
@@ -191,8 +191,11 @@ def discover(idxOffset, config, isS32BPillFlag=False, *args, **kwargs):
             rev_val = None
             baud_idx = 0
             while rev_val == None and baud_idx < len(SERIAL_BAUD_RATES):
-                node_serial_obj = serial.Serial(port=comm, baudrate=SERIAL_BAUD_RATES[baud_idx], timeout=0.25)
+                node_serial_obj = serial.Serial(port=None, baudrate=SERIAL_BAUD_RATES[baud_idx], timeout=0.25)
                 node_serial_obj.setDTR(0)  # clear in case line is tied to node-processor reset
+                node_serial_obj.setRTS(0)
+                node_serial_obj.setPort(comm)
+                node_serial_obj.open()  # open port (now that DTR is configured for no change)
                 if baud_idx > 0:
                     gevent.sleep(BOOTLOADER_CHILL_TIME)  # delay needed for Arduino USB
                 node = SerialNode(index+idxOffset, node_serial_obj)

--- a/src/interface/serial_node.py
+++ b/src/interface/serial_node.py
@@ -2,12 +2,16 @@
 import logging
 import serial # For serial comms
 import gevent
+import time
 from monotonic import monotonic
 
 from Node import Node
-from RHInterface import MAX_RETRY_COUNT, validate_checksum, calculate_checksum
+from RHInterface import READ_REVISION_CODE, READ_MULTINODE_COUNT, MAX_RETRY_COUNT, \
+                        validate_checksum, calculate_checksum, pack_8, unpack_8, unpack_16, \
+                        WRITE_CURNODE_INDEX, READ_CURNODE_INDEX, JUMP_TO_BOOTLOADER
 
 BOOTLOADER_CHILL_TIME = 2 # Delay for USB to switch from bootloader to serial mode
+SERIAL_BAUD_RATES = [921600, 115200]
 
 logger = logging.getLogger(__name__)
 
@@ -15,11 +19,11 @@ node_io_rlock_obj = gevent.lock.RLock()  # semaphore lock for node I/O access
 
 
 class SerialNode(Node):
-    def __init__(self, index, port):
+    def __init__(self, index, node_serial_obj):
         Node.__init__(self)
         self.index = index
-        self.serial = serial.Serial(port=port, baudrate=115200, timeout=0.25)
-
+        self.serial = node_serial_obj
+        
     def node_log(self, interface, message):
         if interface:
             interface.log(message)
@@ -30,7 +34,7 @@ class SerialNode(Node):
     # Serial Common Functions
     #
 
-    def read_block(self, interface, command, size):
+    def read_block(self, interface, command, size, max_retries=MAX_RETRY_COUNT, check_multi_flag=True):
         '''
         Read serial data given command, and data size.
         '''
@@ -39,7 +43,11 @@ class SerialNode(Node):
             success = False
             retry_count = 0
             data = None
-            while success is False and retry_count <= MAX_RETRY_COUNT:
+            while success is False and retry_count <= max_retries:
+                if check_multi_flag:
+                    if self.multi_node_index >= 0:
+                        if not self.check_set_multi_node_index(interface):
+                            break
                 try:
                     self.io_request = monotonic()
                     self.serial.flushInput()
@@ -52,46 +60,48 @@ class SerialNode(Node):
                             data = data[:-1]
                         else:
                             retry_count = retry_count + 1
-                            if retry_count <= MAX_RETRY_COUNT:
-                                self.node_log(interface, 'Retry (bad length) in read_block:  port={0} cmd={1} size={2} retry={3}'.format(self.serial.port, command, size, retry_count))
-                            else:
-                                self.node_log(interface, 'Retry (bad length) limit reached in read_block:  port={0} cmd={1} size={2} retry={3}'.format(self.serial.port, command, size, retry_count))
-                            self.inc_read_error_count(interface)
-                            gevent.sleep(0.1)
+                            if check_multi_flag:  # log and count if regular query
+                                if retry_count <= max_retries:
+                                    self.node_log(interface, 'Retry (bad length) in read_block:  port={0} cmd={1} size={2} retry={3}'.format(self.serial.port, command, size, retry_count))
+                                else:
+                                    self.node_log(interface, 'Retry (bad length) limit reached in read_block:  port={0} cmd={1} size={2} retry={3}'.format(self.serial.port, command, size, retry_count))
+                                self.inc_read_error_count(interface)
+                                gevent.sleep(0.025)
                     else:
                         # self.log('Invalid Checksum ({0}): {1}'.format(retry_count, data))
                         retry_count = retry_count + 1
-                        if data and len(data) > 0:
-                            if retry_count <= MAX_RETRY_COUNT:
-                                if retry_count > 1:  # don't log the occasional single retry
+                        if check_multi_flag:  # log and count if regular query
+                            if data and len(data) > 0:
+                                if retry_count <= max_retries:
                                     self.node_log(interface, 'Retry (checksum) in read_block:  port={0} cmd={1} size={2} retry={3}'.format(self.serial.port, command, size, retry_count))
+                                else:
+                                    self.node_log(interface, 'Retry (checksum) limit reached in read_block:  port={0} cmd={1} size={2} retry={3}'.format(self.serial.port, command, size, retry_count))
                             else:
-                                self.node_log(interface, 'Retry (checksum) limit reached in read_block:  port={0} cmd={1} size={2} retry={3}'.format(self.serial.port, command, size, retry_count))
-                        else:
-                            if retry_count <= MAX_RETRY_COUNT:
+                                if retry_count <= max_retries:
                                     self.node_log(interface, 'Retry (no data) in read_block:  port={0} cmd={1} size={2} retry={3}'.format(self.serial.port, command, size, retry_count))
-                            else:
-                                self.node_log(interface, 'Retry (no data) limit reached in read_block:  port={0} cmd={1} size={2} retry={3}'.format(self.serial.port, command, size, retry_count))
-                        self.inc_read_error_count(interface)
-                        gevent.sleep(0.1)
+                                else:
+                                    self.node_log(interface, 'Retry (no data) limit reached in read_block:  port={0} cmd={1} size={2} retry={3}'.format(self.serial.port, command, size, retry_count))
+                            self.inc_read_error_count(interface)
+                            gevent.sleep(0.025)
                 except IOError as err:
                     self.node_log(interface, 'Read Error: ' + str(err))
                     retry_count = retry_count + 1
-                    if retry_count <= MAX_RETRY_COUNT:
-                        if retry_count > 1:  # don't log the occasional single retry
+                    if check_multi_flag:  # log and count if regular query
+                        if retry_count <= max_retries:
                             self.node_log(interface, 'Retry (IOError) in read_block:  port={0} cmd={1} size={2} retry={3}'.format(self.serial.port, command, size, retry_count))
-                    else:
-                        self.node_log(interface, 'Retry (IOError) limit reached in read_block:  port={0} cmd={1} size={2} retry={3}'.format(self.serial.port, command, size, retry_count))
-                    self.inc_read_error_count(interface)
-                    gevent.sleep(0.1)
+                        else:
+                            self.node_log(interface, 'Retry (IOError) limit reached in read_block:  port={0} cmd={1} size={2} retry={3}'.format(self.serial.port, command, size, retry_count))
+                        self.inc_read_error_count(interface)
+                        gevent.sleep(0.025)
             return data if success else None
 
-    def write_block(self, interface, command, data):
+    def write_block(self, interface, command, data, check_multi_flag=True):
         '''
         Write serial data given command, and data.
         '''
         with node_io_rlock_obj:  # only allow one greenlet at a time
-            interface.inc_intf_write_block_count()
+            if interface:
+                interface.inc_intf_write_block_count()
             success = False
             retry_count = 0
             data_with_checksum = bytearray()
@@ -99,6 +109,10 @@ class SerialNode(Node):
             data_with_checksum.extend(data)
             data_with_checksum.append(calculate_checksum(data_with_checksum[1:]))
             while success is False and retry_count <= MAX_RETRY_COUNT:
+                if check_multi_flag:
+                    if self.multi_node_index >= 0:
+                        if not self.check_set_multi_node_index(interface):
+                            break
                 try:
                     self.serial.write(data_with_checksum)
                     success = True
@@ -109,9 +123,51 @@ class SerialNode(Node):
                         self.node_log(interface, 'Retry (IOError) in write_block:  port={0} cmd={1} data={2} retry={3}'.format(self.serial.port, command, data, retry_count))
                     else:
                         self.node_log(interface, 'Retry (IOError) limit reached in write_block:  port={0} cmd={1} data={2} retry={3}'.format(self.serial.port, command, data, retry_count))
-                    interface.inc_intf_write_error_count()
-                    gevent.sleep(0.1)
+                    if interface:
+                        interface.inc_intf_write_error_count()
+                    gevent.sleep(0.025)
             return success
+
+    def check_set_multi_node_index(self, interface):
+        # check if need to set different node index on multi-node processor and set if needed
+        if self.multi_node_index == self.multi_curnode_index_holder[0]:
+            return True
+        success = False
+        chk_retry_count = 0
+        out_value = None
+        while success is False:
+            if self.write_block(interface, WRITE_CURNODE_INDEX, pack_8(self.multi_node_index), False):
+                data = self.read_block(interface, READ_CURNODE_INDEX, 1, 0, False)
+                out_value = unpack_8(data) if data != None else None
+            if out_value == self.multi_node_index:
+                success = True
+            else:
+                chk_retry_count = chk_retry_count + 1
+                self.inc_read_error_count(interface)
+                if chk_retry_count <= MAX_RETRY_COUNT*5:
+                    self.node_log(interface, 'Error setting WRITE_CURNODE_INDEX, old={0}, new={1}, idx={2}, retry={3}'.\
+                                  format(self.multi_curnode_index_holder[0], self.multi_node_index, self.index, chk_retry_count))
+                    gevent.sleep(0.025)
+                else:
+                    self.node_log(interface, 'Error setting WRITE_CURNODE_INDEX, retry limit reached, old={0}, new={1}, idx={2}, retry={3}'.\
+                                  format(self.multi_curnode_index_holder[0], self.multi_node_index, self.index, chk_retry_count))
+                    break
+        if success:
+            self.multi_curnode_index_holder[0] = self.multi_node_index
+        return success
+
+    def jump_to_bootloader(self, interface):
+        try:
+            if self.api_level >= 32:
+                self.node_log(interface, 'Sending JUMP_TO_BOOTLOADER message to serial node {0}'.format(self.index+1))
+                self.write_block(interface, JUMP_TO_BOOTLOADER, pack_8(0), False)
+                self.serial.flushInput()
+                time.sleep(0.1)
+                self.serial.flushInput()
+                self.serial.flushOutput()
+                self.serial.close()
+        except Exception as ex:
+            self.node_log(interface, 'Error sending JUMP_TO_BOOTLOADER message to serial node {0}: {1}'.format(self.index+1, ex))
 
 
 def discover(idxOffset, config, *args, **kwargs):
@@ -120,9 +176,51 @@ def discover(idxOffset, config, *args, **kwargs):
     if config_ser_ports:
         logger.info("Searching for serial nodes...")
         for index, comm in enumerate(config_ser_ports):
-            node = SerialNode(index+idxOffset, comm)
-            logger.info("...Serial node {0} found at port {1}".format(index+idxOffset+1, node.serial.name))
-            nodes.append(node)
-
-    gevent.sleep(BOOTLOADER_CHILL_TIME)
+            rev_val = None
+            baud_idx = 0
+            while rev_val == None and baud_idx < len(SERIAL_BAUD_RATES):
+                node_serial_obj = serial.Serial(port=comm, baudrate=SERIAL_BAUD_RATES[baud_idx], timeout=0.25)
+                node_serial_obj.setDTR(0)  # clear in case line is tied to node-processor reset
+                if baud_idx > 0:
+                    gevent.sleep(BOOTLOADER_CHILL_TIME)  # delay needed for Arduino USB
+                node = SerialNode(index+idxOffset, node_serial_obj)
+                multi_count = 1
+                try:               # handle serial multi-node processor
+                    data = node.read_block(None, READ_REVISION_CODE, 2, 2, False)
+                    rev_val = unpack_16(data) if data != None else None
+                    if rev_val and (rev_val >> 8) == 0x25:
+                        if (rev_val & 0xFF) >= 32:  # check node API level
+                            data = node.read_block(None, READ_MULTINODE_COUNT, 1, 2, False)
+                            multi_count = unpack_8(data) if data != None else None
+                        if multi_count is None or multi_count < 1 or multi_count > 32:
+                            logger.error('Bad READ_MULTINODE_COUNT value fetched from serial node:  ' + str(multi_count))
+                            multi_count = 1
+                except Exception:
+                    multi_count = 1
+                    logger.exception('Error fetching READ_MULTINODE_COUNT for serial node')
+                if rev_val == None:
+                    node_serial_obj.close()
+                    baud_idx += 1
+            if rev_val:
+                if multi_count <= 1:
+                    logger.info("...Serial node {0} found at port {1}, baudrate={2}".format(\
+                                index+idxOffset+1, node.serial.name, node.serial.baudrate))
+                    nodes.append(node)
+                else:
+                    node.multi_node_index = 0
+                    curnode_index_holder = [-1]  # tracker for index of current node for processor
+                    node.multi_curnode_index_holder = curnode_index_holder
+                    logger.info("...Serial (multi) node {0} found at port {1}, baudrate={2}".format(\
+                                index+idxOffset+1, node.serial.name, node.serial.baudrate))
+                    nodes.append(node)
+                    for nIdx in range(1, multi_count):
+                        idxOffset += 1
+                        node = SerialNode(index+idxOffset, node_serial_obj)
+                        node.multi_node_index = nIdx
+                        node.multi_curnode_index_holder = curnode_index_holder
+                        logger.info("...Serial (multi) node {0} found at port {1}, baudrate={2}".format(\
+                                    index+idxOffset+1, node.serial.name, node.serial.baudrate))
+                        nodes.append(node)
+            else:
+                logger.error('Unable to fetch revision code for serial node at "{0}"'.format(comm))
     return nodes

--- a/src/server/RHGPIO.py
+++ b/src/server/RHGPIO.py
@@ -1,0 +1,29 @@
+# Utility class for Raspberry Pi GPIO functions
+
+import time
+
+try:
+    import RPi.GPIO as GPIO
+    RealRPiGPIOFlag = True
+except ImportError:
+    import util.FakeRPiGPIO as GPIO
+    RealRPiGPIOFlag = False
+# if RPi.GPIO not available then use FakeRiGPIO from https://github.com/sn4k3/FakeRPi
+
+RHGPIO_S32ID_PIN = 25  # input is tied low on S32_BPill PCB
+
+S32BPillBoardFlag = False
+
+def isRealRPiGPIO():
+    return RealRPiGPIOFlag
+
+def isS32BPillBoard():
+    return S32BPillBoardFlag
+
+
+if RealRPiGPIOFlag:
+    GPIO.setmode(GPIO.BCM)
+    GPIO.setup(RHGPIO_S32ID_PIN, GPIO.IN, pull_up_down=GPIO.PUD_UP)
+    time.sleep(0.05)
+    S32BPillBoardFlag = not GPIO.input(RHGPIO_S32ID_PIN)
+    GPIO.setup(RHGPIO_S32ID_PIN, GPIO.IN)

--- a/src/server/RHGPIO.py
+++ b/src/server/RHGPIO.py
@@ -8,6 +8,9 @@ try:
 except ImportError:
     import util.FakeRPiGPIO as GPIO
     RealRPiGPIOFlag = False
+except:  # need extra exception catch for Travis CI tests
+    import util.FakeRPiGPIO as GPIO
+    RealRPiGPIOFlag = False
 # if RPi.GPIO not available then use FakeRiGPIO from https://github.com/sn4k3/FakeRPi
 
 RHGPIO_S32ID_PIN = 25  # input is tied low on S32_BPill PCB

--- a/src/server/RHUtils.py
+++ b/src/server/RHUtils.py
@@ -3,6 +3,7 @@ RotorHazard Helper and utility functions
 '''
 
 import os
+import sys
 import logging
 import platform
 import subprocess
@@ -58,7 +59,8 @@ def idAndLogSystemInfo():
         if modelStr and "raspberry pi" in modelStr.lower():
             IS_SYS_RASPBERRY_PI = True
             logger.info("Host machine: " + modelStr.strip('\0'))
-        logger.info("Host OS: {0} {1}".format(platform.system(), platform.release()))
+        logger.info("Host OS: {} {}".format(platform.system(), platform.release()))
+        logger.info("Python version: {}".format(sys.version.split('\n')[0].strip()))
     except Exception:
         logger.exception("Error in 'idAndLogSystemInfo()'")
 

--- a/src/server/RHUtils.py
+++ b/src/server/RHUtils.py
@@ -62,6 +62,9 @@ def idAndLogSystemInfo():
     except Exception:
         logger.exception("Error in 'idAndLogSystemInfo()'")
 
+def isSysRaspberryPi():
+    return IS_SYS_RASPBERRY_PI
+
 # Returns "primary" IP address for local host.  Based on:
 #  https://stackoverflow.com/questions/166506/finding-local-ip-addresses-using-pythons-stdlib
 #  and https://stackoverflow.com/questions/24196932/how-can-i-get-the-ip-address-from-nic-in-python

--- a/src/server/log.py
+++ b/src/server/log.py
@@ -38,6 +38,7 @@ FILELOG_LEVEL_STR = "FILELOG_LEVEL"
 FILELOG_NUM_KEEP_STR = "FILELOG_NUM_KEEP"
 CONSOLE_STREAM_STR = "CONSOLE_STREAM"
 LEVEL_NONE_STR = "NONE"
+LEVEL_NONE_VALUE = 9999
 
 socket_handler_obj = None
 queued_handler_obj = None
@@ -106,7 +107,7 @@ class SocketForwardHandler(logging.Handler):
 
 
 def early_stage_setup():
-    logging.addLevelName(0, LEVEL_NONE_STR)
+    logging.addLevelName(LEVEL_NONE_VALUE, LEVEL_NONE_STR)
     logging.basicConfig(
         stream=DEF_CONSOLE_STREAM,
         level=logging.INFO,
@@ -172,7 +173,7 @@ def later_stage_setup(config, socket):
 
     err_str = None
     (lvl, err_str) = get_logging_level_for_item(logging_config, CONSOLE_LEVEL_STR, err_str)
-    if lvl > 0:
+    if lvl > 0 and lvl < LEVEL_NONE_VALUE:
         stm_obj = sys.stdout if sys.stderr.name.find(logging_config[CONSOLE_STREAM_STR]) != 1 else sys.stderr
         hdlr_obj = logging.StreamHandler(stream=stm_obj)
         hdlr_obj.setLevel(lvl)
@@ -182,7 +183,7 @@ def later_stage_setup(config, socket):
             min_level = lvl
 
     (lvl, err_str) = get_logging_level_for_item(logging_config, SYSLOG_LEVEL_STR, err_str, logging.NOTSET)
-    if lvl > 0:
+    if lvl > 0 and lvl < LEVEL_NONE_VALUE:
         system_logger = logging.handlers.SysLogHandler("/dev/log", level=lvl) \
                         if platform.system() != "Windows" else \
                         logging.handlers.NTEventLogHandler("RotorHazard")
@@ -193,7 +194,7 @@ def later_stage_setup(config, socket):
             min_level = lvl
 
     (lvl, err_str) = get_logging_level_for_item(logging_config, FILELOG_LEVEL_STR, err_str)
-    if lvl > 0:
+    if lvl > 0 and lvl < LEVEL_NONE_VALUE:
         # put log files in subdirectory, and with date-timestamp in names
         (lfname, lfext) = os.path.splitext(LOG_FILENAME_STR)
         (num_old_del, err_str) = delete_old_log_files(logging_config[FILELOG_NUM_KEEP_STR], lfname, lfext, err_str)
@@ -230,7 +231,7 @@ def later_stage_setup(config, socket):
 
     socket_handler_obj = SocketForwardHandler(socket)
     # use same configuration as log file
-    if lvl > 0:
+    if lvl > 0 and lvl < LEVEL_NONE_VALUE:
         socket_handler_obj.setLevel(lvl)
     # configure log format with milliseconds as ".###" (not ",###")
     socket_handler_obj.setFormatter(logging.Formatter(fmt=FILELOG_FORMAT_STR, datefmt='%Y-%m-%d %H:%M:%S'))

--- a/src/server/reqsNonPi.txt
+++ b/src/server/reqsNonPi.txt
@@ -15,5 +15,3 @@ monotonic==1.5.*
 pyserial==3.4.*
 paho-mqtt==1.5.*
 websocket-client==0.57.*
-smbus2==0.4.0
-RPi.GPIO==0.7.*

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -107,10 +107,11 @@ if RHUtils.checkSetFileOwnerPi(log.LOG_DIR_NAME):
     logger.info("Changed '{0}' dir owner from 'root' to 'pi'".format(log.LOG_DIR_NAME))
 
 # command-line arguments:
-CMDARG_VERSION_LONG_STR = '--version'  # show program version and exit
-CMDARG_VERSION_SHORT_STR = '-v'        # show program version and exit
-CMDARG_ZIP_LOGS_STR = '--ziplogs'      # create logs .zip file
-CMDARG_JUMP_TO_BL_STR = '--jumptobl'   # send jump-to-bootloader command to node
+CMDARG_VERSION_LONG_STR = '--version'    # show program version and exit
+CMDARG_VERSION_SHORT_STR = '-v'          # show program version and exit
+CMDARG_ZIP_LOGS_STR = '--ziplogs'        # create logs .zip file
+CMDARG_JUMP_TO_BL_STR = '--jumptobl'     # send jump-to-bootloader command to node
+CMDARG_FLASH_BPILL_STR = '--flashbpill'  # flash firmware onto S32_BPill processor
 
 if __name__ == '__main__' and len(sys.argv) > 1:
     if CMDARG_VERSION_LONG_STR in sys.argv or CMDARG_VERSION_SHORT_STR in sys.argv:
@@ -119,8 +120,17 @@ if __name__ == '__main__' and len(sys.argv) > 1:
         log.create_log_files_zip(logger, Config.CONFIG_FILE_NAME, DB_FILE_NAME)
         sys.exit(0)
     if CMDARG_JUMP_TO_BL_STR not in sys.argv:  # handle jump-to-bootloader argument later
+        if CMDARG_FLASH_BPILL_STR in sys.argv:
+            argIdx = sys.argv.index(CMDARG_FLASH_BPILL_STR) + 1
+            portStr = Config.SERIAL_PORTS[0] if Config.SERIAL_PORTS and \
+                                                len(Config.SERIAL_PORTS) > 0 else None
+            srcStr = sys.argv[argIdx] if argIdx < len(sys.argv) else None
+            if srcStr and srcStr.startswith("--"):  # use next arg as src file (optional)
+                srcStr = None                       #  unless arg is switch param
+            successFlag = stm32loader.flash_file_to_stm32(portStr, srcStr)
+            sys.exit(0 if successFlag else 1)
         print("Unrecognized command-line argument(s): {0}".format(sys.argv[1:]))
-        sys.exit(0)
+        sys.exit(1)
 
 TEAM_NAMES_LIST = [str(unichr(i)) for i in range(65, 91)]  # list of 'A' to 'Z' strings
 DEF_TEAM_NAME = 'A'  # default team
@@ -148,6 +158,7 @@ serverInfoItems = None
 Use_imdtabler_jar_flag = False  # set True if IMDTabler.jar is available
 vrx_controller = None
 server_ipaddress_str = None
+Settings_note_msg_text = None
 
 RACE = RHRace.RHRace() # For storing race management variables
 
@@ -420,7 +431,9 @@ def render_settings():
         vrx_enabled=vrx_controller!=None,
         num_nodes=RACE.num_nodes,
         ConfigFile=Config.GENERAL['configFile'],
+        note_message_text=Settings_note_msg_text,
         cluster_has_slaves=(CLUSTER and CLUSTER.hasSlaves()),
+        node_fw_updatable=(INTERFACE.get_fwupd_serial_name()!=None),
         Debug=Config.GENERAL['DEBUG'])
 
 @APP.route('/streams')
@@ -478,8 +491,14 @@ def render_decoder():
 @APP.route('/imdtabler')
 def render_imdtabler():
     '''Route to IMDTabler page.'''
-
     return render_template('imdtabler.html', serverInfo=serverInfo, getOption=Options.get, __=__)
+
+@APP.route('/updatenodes')
+@requires_auth
+def render_updatenodes():
+    '''Route to update nodes page.'''
+    return render_template('updatenodes.html', serverInfo=serverInfo, getOption=Options.get, __=__, \
+                           fw_src_str=stm32loader.DEF_BINSRC_STR)
 
 # Debug Routes
 
@@ -557,6 +576,17 @@ def start_background_threads():
     if HEARTBEAT_THREAD is None:
         HEARTBEAT_THREAD = gevent.spawn(heartbeat_thread_function)
         logger.debug('Heartbeat thread started')
+
+def stop_background_threads():
+    try:
+        global HEARTBEAT_THREAD
+        if HEARTBEAT_THREAD:
+            logger.info('Stopping heartbeat thread')
+            HEARTBEAT_THREAD.kill(block=True, timeout=0.5)
+            HEARTBEAT_THREAD = None
+        INTERFACE.stop()
+    except Exception:
+        logger.error("Error stopping background threads")
 
 #
 # Socket IO Events
@@ -854,6 +884,7 @@ def set_all_frequencies(freqs):
 
 def hardware_set_all_frequencies(freqs):
     '''do hardware update for frequencies'''
+    logger.debug("Sending frequency values to nodes: " + str(freqs))
     for idx in range(RACE.num_nodes):
         INTERFACE.set_frequency(idx, freqs[idx])
 
@@ -944,6 +975,7 @@ def on_set_exit_at_level(data):
 
 def hardware_set_all_enter_ats(enter_at_levels):
     '''send update to nodes'''
+    logger.debug("Sending enter-at values to nodes: " + str(enter_at_levels))
     for idx in range(RACE.num_nodes):
         if enter_at_levels[idx]:
             INTERFACE.set_enter_at_level(idx, enter_at_levels[idx])
@@ -955,6 +987,7 @@ def hardware_set_all_enter_ats(enter_at_levels):
 
 def hardware_set_all_exit_ats(exit_at_levels):
     '''send update to nodes'''
+    logger.debug("Sending exit-at values to nodes: " + str(exit_at_levels))
     for idx in range(RACE.num_nodes):
         if exit_at_levels[idx]:
             INTERFACE.set_exit_at_level(idx, exit_at_levels[idx])
@@ -1814,9 +1847,13 @@ def on_shutdown_pi():
     trigger_event(Evt.SHUTDOWN)
     CLUSTER.emit('shutdown_pi')
     emit_priority_message(__('Server has shut down.'), True)
-    logger.info('Shutdown pi')
-    gevent.sleep(1);
-    os.system("sudo shutdown now")
+    logger.info('Performing system shutdown')
+    stop_background_threads()
+    gevent.sleep(0.5);
+    SOCKET_IO.stop()  # shut down flask http server
+    if RHUtils.isSysRaspberryPi():
+        gevent.sleep(0.5);
+        os.system("sudo shutdown now")
 
 @SOCKET_IO.on('reboot_pi')
 @catchLogExceptionsWrapper
@@ -1825,9 +1862,13 @@ def on_reboot_pi():
     trigger_event(Evt.SHUTDOWN)
     CLUSTER.emit('reboot_pi')
     emit_priority_message(__('Server is rebooting.'), True)
-    logger.info('Rebooting pi')
-    gevent.sleep(1);
-    os.system("sudo reboot now")
+    logger.info('Performing system reboot')
+    stop_background_threads()
+    gevent.sleep(0.5);
+    SOCKET_IO.stop()  # shut down flask http server
+    if RHUtils.isSysRaspberryPi():
+        gevent.sleep(0.5);
+        os.system("sudo reboot now")
 
 @SOCKET_IO.on('download_logs')
 @catchLogExceptionsWrapper
@@ -4170,6 +4211,36 @@ def emit_vrx_list(*args, **params):
     else:
         SOCKET_IO.emit('vrx_list', emit_payload)
 
+@SOCKET_IO.on('do_bpillfw_update')
+@catchLogExceptionsWrapper
+def do_bpillfw_update(data):
+    srcStr = data['src_file_str']
+    portStr = INTERFACE.get_fwupd_serial_name()
+    msgStr = "Performing S32_BPill update, port='{}', file: {}".format(portStr, srcStr)
+    logger.info(msgStr)
+    SOCKET_IO.emit('upd_messages_init', (msgStr + "\n"))
+    stop_background_threads()
+    gevent.sleep(0.1)
+    jump_to_node_bootloader()
+    INTERFACE.close_fwupd_serial_port()
+    s32Logger = logging.getLogger("stm32loader")
+    def doS32Log(msgStr):  # send message to update-messages window and log file
+        SOCKET_IO.emit('upd_messages_append', msgStr)
+        s32Logger.info(msgStr)
+        gevent.sleep(0.001)  # do thread yield to allow display updates
+    stm32loader.set_console_output_fn(doS32Log)
+    successFlag = stm32loader.flash_file_to_stm32(portStr, srcStr)
+    msgStr = "Node update " + ("succeeded" if successFlag else "failed")
+    logger.info(msgStr)
+    SOCKET_IO.emit('upd_messages_append', ("\n" + msgStr))
+    SOCKET_IO.emit('upd_messages_finish')  # show 'Close' button
+    stm32loader.set_console_output_fn(None)
+    gevent.sleep(0.2)
+    logger.info("Reinitializing RH interface")
+    initialize_rh_interface()
+    init_race_state()
+    start_background_threads()
+
 @SOCKET_IO.on('set_vrx_node')
 @catchLogExceptionsWrapper
 def set_vrx_node(data):
@@ -5287,21 +5358,49 @@ def determineHostAddress(maxRetrySecs=10):
     logger.info("Host machine is '{0}' at {1}".format(hNameStr, ipAddrStr))
     return ipAddrStr
 
-def stop_heartbeart_thread():
-    global HEARTBEAT_THREAD
-    if HEARTBEAT_THREAD:
-        logger.info('Stopping heartbeat thread')
-        HEARTBEAT_THREAD.kill(block=True, timeout=0.5)
-        HEARTBEAT_THREAD = None
-
 def jump_to_node_bootloader():
     try:
-        stop_heartbeart_thread()
-        INTERFACE.stop()
         INTERFACE.jump_to_bootloader()
-    except Exception as ex:
-        logger.info('Error executing jump to node bootloader:  ' + str(ex))
-    
+    except Exception:
+        logger.error("Error executing jump to node bootloader")
+
+def initialize_rh_interface():
+    try:
+        global INTERFACE, Settings_note_msg_text
+        Settings_note_msg_text = None
+        rh_interface_name = os.environ.get('RH_INTERFACE', 'RH') + "Interface"
+        try:
+            logger.debug("Initializing interface module: " + rh_interface_name)
+            interfaceModule = importlib.import_module(rh_interface_name)
+            INTERFACE = interfaceModule.get_hardware_interface(\
+                            config=Config, isS32BPillFlag=RHGPIO.isS32BPillBoard(), **hardwareHelpers)
+        except (ImportError, RuntimeError, IOError) as ex:
+            logger.info('Unable to initialize nodes via ' + rh_interface_name + ':  ' + str(ex))
+        if not INTERFACE or not INTERFACE.nodes or len(INTERFACE.nodes) <= 0:
+            if not Config.SERIAL_PORTS or len(Config.SERIAL_PORTS) <= 0:
+                interfaceModule = importlib.import_module('MockInterface')
+                INTERFACE = interfaceModule.get_hardware_interface(config=Config, **hardwareHelpers)
+                Settings_note_msg_text = __("Server is using simulated (mock) nodes")
+            else:
+                try:
+                    importlib.import_module('serial')
+                    logger.info('Unable to initialize specified serial node(s): {0}'.format(Config.SERIAL_PORTS))
+                    # enter serial port name so it's available for node firmware update
+                    if getattr(INTERFACE, "set_mock_fwupd_serial_obj"):
+                        INTERFACE.set_mock_fwupd_serial_obj(Config.SERIAL_PORTS[0])
+                        Settings_note_msg_text = __("Server is unable to communicate with node processor") + \
+                                ". " + __("If an S32_BPill board is connected, you may attempt to") +\
+                                " <a href=\"/updatenodes\">" + __("flash-update") + "</a> " + \
+                                __("its processor") + "."
+                except ImportError:
+                    logger.info("Unable to import library for serial node(s) - is 'pyserial' installed?")
+                    return False
+
+        RACE.num_nodes = len(INTERFACE.nodes)  # save number of nodes found
+        return True
+    except:
+        logger.exception("Error initializing RH interface")
+        return False
 
 #
 # Program Initialize
@@ -5329,7 +5428,10 @@ logger.info("Using log file: {0}".format(Current_log_path_name))
 
 if RHUtils.isSysRaspberryPi() and RHGPIO.isS32BPillBoard():
     logger.debug("Resetting S32_BPill processor")
+    s32logger = logging.getLogger("stm32loader")
+    stm32loader.set_console_output_fn(lambda msgStr: s32logger.info(msgStr))
     stm32loader.reset_to_run()
+    stm32loader.set_console_output_fn(None)
 
 hardwareHelpers = {}
 for helper in search_modules(suffix='helper'):
@@ -5338,28 +5440,23 @@ for helper in search_modules(suffix='helper'):
     except Exception as ex:
         logger.warning("Unable to create hardware helper '{0}':  {1}".format(helper.__name__, ex))
 
-interface_type = os.environ.get('RH_INTERFACE', 'RH')
-try:
-    interfaceModule = importlib.import_module(interface_type + 'Interface')
-    INTERFACE = interfaceModule.get_hardware_interface(\
-                    config=Config, isS32BPillFlag=RHGPIO.isS32BPillBoard(), **hardwareHelpers)
-except (ImportError, RuntimeError, IOError) as ex:
-    logger.info('Unable to initialize nodes via ' + interface_type + 'Interface:  ' + str(ex))
-if not INTERFACE or not INTERFACE.nodes or len(INTERFACE.nodes) <= 0:
-    if not Config.SERIAL_PORTS or len(Config.SERIAL_PORTS) <= 0:
-        interfaceModule = importlib.import_module('MockInterface')
-        INTERFACE = interfaceModule.get_hardware_interface(config=Config, **hardwareHelpers)
-    else:
-        try:
-            importlib.import_module('serial')
-            logger.info('Unable to initialize specified serial node(s): {0}'.format(Config.SERIAL_PORTS))
-        except ImportError:
-            logger.info("Unable to import library for serial node(s) - is 'pyserial' installed?")
-        log.wait_for_queue_empty()
-        sys.exit()
+resultFlag = initialize_rh_interface()
+if not resultFlag:
+    log.wait_for_queue_empty()
+    sys.exit(1)
 
 if len(sys.argv) > 0 and CMDARG_JUMP_TO_BL_STR in sys.argv:
+    stop_background_threads()
     jump_to_node_bootloader()
+    if CMDARG_FLASH_BPILL_STR in sys.argv:
+        argIdx = sys.argv.index(CMDARG_FLASH_BPILL_STR) + 1
+        portStr = Config.SERIAL_PORTS[0] if Config.SERIAL_PORTS and \
+                                            len(Config.SERIAL_PORTS) > 0 else None
+        srcStr = sys.argv[argIdx] if argIdx < len(sys.argv) else None
+        if srcStr and srcStr.startswith("--"):  # use next arg as src file (optional)
+            srcStr = None                       #  unless arg is switch param
+        successFlag = stm32loader.flash_file_to_stm32(portStr, srcStr)
+        sys.exit(0 if successFlag else 1)
     sys.exit(0)
 
 CLUSTER = ClusterNodeSet()
@@ -5392,8 +5489,6 @@ INTERFACE.pass_record_callback = pass_record_callback
 INTERFACE.new_enter_or_exit_at_callback = new_enter_or_exit_at_callback
 INTERFACE.node_crossing_callback = node_crossing_callback
 
-# Save number of nodes found
-RACE.num_nodes = len(INTERFACE.nodes)
 if RACE.num_nodes == 0:
     logger.warning('*** WARNING: NO RECEIVER NODES FOUND ***')
 else:
@@ -5569,17 +5664,19 @@ def start(port_val = Config.GENERAL['HTTP_PORT']):
     try:
         # the following fn does not return until the server is shutting down
         SOCKET_IO.run(APP, host='0.0.0.0', port=port_val, debug=True, use_reloader=False)
+        logger.info("Server is shutting down")
     except KeyboardInterrupt:
         logger.info("Server terminated by keyboard interrupt")
     except SystemExit:
         logger.info("Server terminated by system exit")
     except Exception:
-        logger.exception("Server exception:  ")
+        logger.exception("Server exception")
 
     Events.trigger(Evt.SHUTDOWN)
     rep_str = INTERFACE.get_intf_error_report_str(True)
     if rep_str:
         logger.info(rep_str)
+    stop_background_threads()
     log.wait_for_queue_empty()
 
 # Start HTTP server

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -1859,7 +1859,7 @@ def on_shutdown_pi():
         log.close_logging()
         os.system("sudo shutdown now")
     else:
-        logger.debug("Not executing system shutdown command because not RPi")
+        logger.warning("Not executing system shutdown command because not RPi")
 
 @SOCKET_IO.on('reboot_pi')
 @catchLogExceptionsWrapper
@@ -1879,12 +1879,12 @@ def on_reboot_pi():
         log.close_logging()
         os.system("sudo reboot now")
     else:
-        logger.debug("Not executing system reboot command because not RPi")
+        logger.warning("Not executing system reboot command because not RPi")
 
 @SOCKET_IO.on('kill_server')
 @catchLogExceptionsWrapper
 def on_kill_server():
-    '''Shutdown the raspberry pi.'''
+    '''Shutdown this server.'''
     trigger_event(Evt.SHUTDOWN)
     CLUSTER.emit('kill_server')
     emit_priority_message(__('Server has stopped.'), True)

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -2,7 +2,7 @@
 RELEASE_VERSION = "2.4.0-dev.1" # Public release version code
 SERVER_API = 29 # Server API version
 NODE_API_SUPPORTED = 18 # Minimum supported node version
-NODE_API_BEST = 25 # Most recent node API
+NODE_API_BEST = 32 # Most recent node API
 JSON_API = 3 # JSON API version
 
 # This must be the first import for the time being. It is
@@ -108,6 +108,7 @@ if RHUtils.checkSetFileOwnerPi(log.LOG_DIR_NAME):
 CMDARG_VERSION_LONG_STR = '--version'  # show program version and exit
 CMDARG_VERSION_SHORT_STR = '-v'        # show program version and exit
 CMDARG_ZIP_LOGS_STR = '--ziplogs'      # create logs .zip file
+CMDARG_JUMP_TO_BL_STR = '--jumptobl'   # send jump-to-bootloader command to node
 
 if __name__ == '__main__' and len(sys.argv) > 1:
     if CMDARG_VERSION_LONG_STR in sys.argv or CMDARG_VERSION_SHORT_STR in sys.argv:
@@ -115,7 +116,9 @@ if __name__ == '__main__' and len(sys.argv) > 1:
     if CMDARG_ZIP_LOGS_STR in sys.argv:
         log.create_log_files_zip(logger, Config.CONFIG_FILE_NAME, DB_FILE_NAME)
         sys.exit(0)
-    print("Unrecognized command-line argument(s): {0}".format(sys.argv[1:]))
+    if CMDARG_JUMP_TO_BL_STR not in sys.argv:  # handle jump-to-bootloader argument later
+        print("Unrecognized command-line argument(s): {0}".format(sys.argv[1:]))
+        sys.exit(0)
 
 TEAM_NAMES_LIST = [str(unichr(i)) for i in range(65, 91)]  # list of 'A' to 'Z' strings
 DEF_TEAM_NAME = 'A'  # default team
@@ -4503,6 +4506,7 @@ def check_win_condition(RACE, INTERFACE, **kwargs):
 
 @catchLogExceptionsWrapper
 def new_enter_or_exit_at_callback(node, is_enter_at_flag):
+    gevent.sleep(0.025)  # delay to avoid potential I/O error
     if is_enter_at_flag:
         logger.info('Finished capture of enter-at level for node {0}, level={1}, count={2}'.format(node.index+1, node.enter_at_level, node.cap_enter_at_count))
         on_set_enter_at_level({
@@ -5281,6 +5285,22 @@ def determineHostAddress(maxRetrySecs=10):
     logger.info("Host machine is '{0}' at {1}".format(hNameStr, ipAddrStr))
     return ipAddrStr
 
+def stop_heartbeart_thread():
+    global HEARTBEAT_THREAD
+    if HEARTBEAT_THREAD:
+        logger.info('Stopping heartbeat thread')
+        HEARTBEAT_THREAD.kill(block=True, timeout=0.5)
+        HEARTBEAT_THREAD = None
+
+def jump_to_node_bootloader():
+    try:
+        stop_heartbeart_thread()
+        INTERFACE.stop()
+        INTERFACE.jump_to_bootloader()
+    except Exception as ex:
+        logger.info('Error executing jump to node bootloader:  ' + str(ex))
+    
+
 #
 # Program Initialize
 #
@@ -5328,6 +5348,10 @@ if not INTERFACE or not INTERFACE.nodes or len(INTERFACE.nodes) <= 0:
         log.wait_for_queue_empty()
         sys.exit()
 
+if len(sys.argv) > 0 and CMDARG_JUMP_TO_BL_STR in sys.argv:
+    jump_to_node_bootloader()
+    sys.exit(0)
+
 CLUSTER = ClusterNodeSet()
 hasMirrors = False
 try:
@@ -5364,7 +5388,7 @@ if RACE.num_nodes == 0:
     logger.warning('*** WARNING: NO RECEIVER NODES FOUND ***')
 else:
     logger.info('Number of nodes found: {0}'.format(RACE.num_nodes))
-    # if I2C nodes then only report comm errors if >= 1.0%
+    # if I2C nodes then only report comm errors if > 1.0%
     if hasattr(INTERFACE.nodes[0], 'i2c_addr'):
         INTERFACE.set_intf_error_report_percent_limit(1.0)
 

--- a/src/server/templates/settings.html
+++ b/src/server/templates/settings.html
@@ -1556,6 +1556,11 @@
 			return false;
 		});
 
+		$('button#kill_server').click(function (event) {
+			socket.emit('kill_server');
+			return false;
+		});
+
 		$('button#download_logs').click(function (event) {
 			socket.emit('download_logs', {'emit_fn_name': 'settings_save_logs'});
 			return false;
@@ -2669,8 +2674,13 @@
 	</div>
 	<div class="panel-content">
 		<div class="control-set">
+			{% if is_raspberry_pi %}
 			<button data-mfp-src="#shutdown_confirm" class="btn-danger open-mfp-popup">{{ __('Shut Down') }}</button>
 			<button data-mfp-src="#reboot_confirm" class="btn-danger open-mfp-popup">{{ __('Reboot') }}</button>
+			{% endif %}
+			{% if Debug %}
+			<button data-mfp-src="#kill_server_confirm" class="btn-danger open-mfp-popup">{{ __('Kill Server') }}</button>
+			{% endif %}
 			<a href="/hardwarelog" class="debug button-like">{{ __('Server Log') }}</a>
 			<button id="download_logs">{{ __('Download Logs') }}</button>
 			{% if node_fw_updatable %}
@@ -2692,6 +2702,15 @@
 			<div class="popup-content">
 				<p>{{ __('Reboot server?') }}</p>
 				<p><button class="btn-danger" id="reboot_pi">{{ __('Reboot') }}</button>
+				<button class="cancel">{{ __('Cancel') }}</button></p>
+			</div>
+		</div>
+
+		<div id="kill_server_confirm" class="priority-message-interrupt mfp-hide popup">
+			<h2>{{ __('Alert') }}</h2>
+			<div class="popup-content">
+				<p>{{ __('Terminate RotorHazard server?') }}</p>
+				<p><button class="btn-danger" id="kill_server">{{ __('Kill Server') }}</button>
 				<button class="cancel">{{ __('Cancel') }}</button></p>
 			</div>
 		</div>

--- a/src/server/templates/settings.html
+++ b/src/server/templates/settings.html
@@ -1873,6 +1873,10 @@
 		<p><strong>{{ __('No configuration file was loaded. Falling back to default configuration.') | safe }}</strong></p>
 		<p>{{ __('Copy <em>server/config-dist.json</em> to <em>server/config.json</em> and then update settings for your server port number, admin username/password, and LED configuration.') | safe }}</p>
 	</div>
+{% elif note_message_text %}
+	<div class="config-none">
+		<p><strong>Note: </strong>{{ note_message_text | safe }}</p>
+	</div>
 {% endif %}
 
 <!--Client Messaging-->
@@ -2669,6 +2673,9 @@
 			<button data-mfp-src="#reboot_confirm" class="btn-danger open-mfp-popup">{{ __('Reboot') }}</button>
 			<a href="/hardwarelog" class="debug button-like">{{ __('Server Log') }}</a>
 			<button id="download_logs">{{ __('Download Logs') }}</button>
+			{% if node_fw_updatable %}
+			<a href="/updatenodes" class="debug button-like">{{ __('Update Nodes') }}</a>
+			{% endif %}
 		</div>
 
 		<div id="shutdown_confirm" class="priority-message-interrupt mfp-hide popup">

--- a/src/server/templates/updatenodes.html
+++ b/src/server/templates/updatenodes.html
@@ -1,7 +1,6 @@
 {% extends "layout.html" %} {% block title %}Firmware Update{% endblock %} {% block head %}
 
 <script type="text/javascript" charset="utf-8">
-	var data_dependencies = [];
 	var upd_msgs_text = "";
 
 	$(document).ready(function () {

--- a/src/server/templates/updatenodes.html
+++ b/src/server/templates/updatenodes.html
@@ -1,0 +1,62 @@
+{% extends "layout.html" %} {% block title %}Firmware Update{% endblock %} {% block head %}
+
+<script type="text/javascript" charset="utf-8">
+	var data_dependencies = [];
+	var upd_msgs_text = "";
+
+	$(document).ready(function () {
+
+		function set_updmsgs_text(text) {
+			upd_msgs_text = text + "\n";
+			$('#upd_messages').html($('<div/>').text(upd_msgs_text).html());
+		}
+
+		function append_to_updmsgs(text) {
+			upd_msgs_text = upd_msgs_text + text + "\n";
+			$('#upd_messages').text(upd_msgs_text);
+		}
+
+		socket.on('upd_messages_init', function (msg) {
+			set_updmsgs_text(msg);
+		});
+
+		socket.on('upd_messages_append', function (msg) {
+			append_to_updmsgs(msg);
+		});
+
+		socket.on('upd_messages_finish', function () {
+			$('#close_button_div').html("<a href=\"/settings\" class=\"debug button-like\">{{ __('Close') }}</a>");
+		});
+
+		$('button#do_update').click(function (event) {
+			$('button#do_update').prop('disabled', true);
+			var data = {
+				src_file_str: $('#src_file_str').val(),
+			};
+			socket.emit('do_bpillfw_update', data);
+			return false;
+		});
+	});
+</script>
+{% endblock %} {% block content %}
+
+<main class="page-updatenodes">
+<h2>{{ __('Update Node Firmware') }}</h2>
+
+The processor on the RotorHazard S32_BPill board will be flash-updated using the firmware file below:
+<br />
+<br />
+<input type="text" id="src_file_str" value="{{ fw_src_str }}" />
+<br />
+<br />
+<button id="do_update">{{ __('Update') }}</button>&nbsp;
+<a href="/settings" class="debug button-like">{{ __('Cancel') }}</a>
+<br />
+<br />
+<pre>
+<div id="upd_messages"></div>
+</pre>
+<div id="close_button_div"></div>
+
+</main>
+{% endblock %}

--- a/src/server/util/FakeRPiGPIO.py
+++ b/src/server/util/FakeRPiGPIO.py
@@ -1,0 +1,153 @@
+#from .PWM import PWM as PWMClass
+
+__author__ = 'Tiago'
+__documentation__ = 'http://sourceforge.net/p/raspberry-gpio-python/wiki/Examples/'
+
+RPI_REVISION = 1
+VERSION = 1
+
+BOARD = 0
+BCM = 1
+
+IN = 0
+OUT = 1
+
+INPUT = 0
+OUTPUT = 1
+SPI = 2
+I2C = 3
+HARD_PWM = 4
+SERIAL = 5
+UNKNOWN = -1
+
+PUD_DOWN = 0
+PUD_UP = 1
+PUD_OFF = -1
+
+LOW = 0
+HIGH = 1
+
+FALLING = 0
+RISING = 1
+BOTH = 2
+
+_setup_mode = BOARD
+_warnings = False
+
+
+def setmode(mode):
+    """
+    There are two ways of numbering the IO pins on a Raspberry Pi within RPi.GPIO. The first is using the BOARD numbering system. This refers to the pin numbers on the P1 header of the Raspberry Pi board. The advantage of using this numbering system is that your hardware will always work, regardless of the board revision of the RPi. You will not need to rewire your connector or change your code.
+    The second numbering system is the BCM numbers. This is a lower level way of working - it refers to the channel numbers on the Broadcom SOC. You have to always work with a diagram of which channel number goes to which pin on the RPi board. Your script could break between revisions of Raspberry Pi boards.
+    To specify which you are using using (mandatory):
+    :param mode:
+    :return:
+    """
+    _setup_mode = mode
+
+
+def setwarnings(mode):
+    """
+    It is possible that you have more than one script/circuit on the GPIO of your Raspberry Pi.
+    As a result of this, if RPi.GPIO detects that a pin has been configured to something other than the default (input),
+    you get a warning when you try to configure a script. To disable these warnings:
+    :param mode:
+    :return:
+    """
+    _warnings = mode
+
+
+def setup(channel, mode, initial=None, pull_up_down=None):
+    """
+    You need to set up every channel you are using as an input or an output. To configure a channel as an input:
+    :param channel:
+    :param mode:
+    :param initial:
+    :param pull_up_down:
+    :return:
+    """
+    pass
+
+
+def gpio_function(pin):
+    """
+    Shows the function of a GPIO channel.
+    will return a value from: GPIO.INPUT, GPIO.OUTPUT, GPIO.SPI, GPIO.I2C, GPIO.HARD_PWM, GPIO.SERIAL, GPIO.UNKNOWN
+    :param pin:
+    :return: GPIO.INPUT, GPIO.OUTPUT, GPIO.SPI, GPIO.I2C, GPIO.HARD_PWM, GPIO.SERIAL, GPIO.UNKNOWN
+    """
+    return None
+
+
+def input(channel):
+    """
+    To read the value of a GPIO pin:
+    :param channel:
+    :return:
+    """
+    return LOW
+
+
+def output(channel, state):
+    """
+    To set the output state of a GPIO pin:
+    :param channel:
+    :return:
+    """
+    return LOW
+
+
+def PWM(channel, frequency):
+    """
+    :param channel:
+    :param frequency:
+    To create a PWM instance:
+    :return:
+    """
+#    return PWMClass()
+    return None
+
+
+def cleanup(channel=None):
+    """
+    At the end any program, it is good practice to clean up any resources you might have used. This is no different with RPi.GPIO.
+    By returning all channels you have used back to inputs with no pull up/down, you can avoid accidental damage to your RPi by shorting out the pins.
+    Note that this will only clean up GPIO channels that your script has used.
+    :param channel: It is possible that you only want to clean up one channel, leaving some set up when your program exits
+    :return:
+    """
+    pass
+
+
+def wait_for_edge(channel, edge_type):
+    """
+    The wait_for_edge() function is designed to block execution of your program until an edge is detected.
+    :param channel:
+    :param edge_type:
+    :return:
+    """
+    pass
+
+
+def add_event_detect(channel, edge_type, callback=None, bouncetime=0):
+    """
+    The event_detected() function is designed to be used in a loop with other things, but unlike polling it is not going to miss the change in state of an input while the CPU is busy working on other things.
+    This could be useful when using something like Pygame or PyQt where there is a main loop listening and responding to GUI events in a timely basis.
+    :param channel:
+    :param edge_type:
+    :return:
+    """
+    pass
+
+
+def add_event_callback(channel, callback, bouncetime=0):
+    pass
+
+
+def remove_event_detect(channel):
+    """
+    If for some reason, your program no longer wishes to detect edge events, it is possible to stop them
+    :param channel:
+    :return:
+    """
+    pass

--- a/src/server/util/stm32loader.py
+++ b/src/server/util/stm32loader.py
@@ -722,7 +722,11 @@ class Stm32Bootloader:
 # Above code is from "stm32loader-0.5.1/stm32loader/bootloader.py"
 
 import serial
-import urllib2
+
+try:
+    from urllib.request import urlopen  # for Python 3
+except ImportError:
+    from urllib2 import urlopen  # for Python 2
 
 DEF_SERIAL_PORT = "/dev/serial0"
 DEF_BINSRC_STR = "http://www.rotorhazard.com/fw/dev/current/RH_S32_BPill_node.bin"
@@ -796,15 +800,14 @@ def reset_to_run():
 
 # download given URL to buffer
 def download_to_buffer(src_url):
-    u = urllib2.urlopen(src_url)
-    meta = u.info()
-    src_size = int(meta.getheaders("Content-Length")[0])
+    resp = urlopen(src_url)
+    src_size = int(resp.headers["Content-Length"])
     if src_size <= 0:
         raise RuntimeError("Source-data size is zero, aborting download from: {}".format(src_url))
     if src_size > 999999:
         raise RuntimeError("Source-data size too large ({}), aborting download from: {}".format(src_size, src_url))
     Console_output_fn("Downloading {} bytes from: {}".format(src_size, src_url))
-    return u.read(src_size)
+    return resp.read(src_size)
 
 
 # flash firmware to BPill at given port with data from given file/URL

--- a/src/server/util/stm32loader.py
+++ b/src/server/util/stm32loader.py
@@ -30,6 +30,8 @@ import time
 import traceback
 from functools import reduce
 
+Console_output_fn = print
+
 CHIP_IDS = {
     # see ST AN2606 Table 136 Bootloader device-dependent parameters
     # 16 to 32 KiB
@@ -300,7 +302,7 @@ class Stm32Bootloader:
     def debug(self, level, message):
         """Print the given message if its level is low enough."""
         if self.verbosity >= level:
-            print(message, file=sys.stderr)
+            Console_output_fn(message)
 
     def reset_from_system_memory(self):
         """Reset the MCU with boot0 enabled to enter the bootloader."""
@@ -318,7 +320,7 @@ class Stm32Bootloader:
 
         for attempt in range(self.SYNCHRONIZE_ATTEMPTS):
             if attempt:
-                print("Bootloader activation timeout -- retrying", file=sys.stderr)
+                self.debug(5, "Bootloader activation timeout -- retrying")
             self.write(self.Command.SYNCHRONIZE)
             read_data = bytearray(self.connection.read())
 
@@ -557,7 +559,7 @@ class Stm32Bootloader:
 
         previous_timeout_value = self.connection.timeout
         self.connection.timeout = 30
-        print("Extended erase (0x44), this can take ten seconds or more")
+        self.debug(5, "Extended erase (0x44), this can take ten seconds or more")
         try:
             self._wait_for_ack("0x44 erasing failed")
         finally:
@@ -722,9 +724,21 @@ class Stm32Bootloader:
 import serial
 import urllib2
 
+DEF_SERIAL_PORT = "/dev/serial0"
+DEF_BINSRC_STR = "http://www.rotorhazard.com/fw/dev/current/RH_S32_BPill_node.bin"
+
 GPIO_RESET_PIN = 17
 GPIO_BOOT0_PIN = 27
 
+# set function to use for console/log output
+def set_console_output_fn(conOutFn):
+    global Console_output_fn
+    if conOutFn:
+        Console_output_fn = conOutFn
+    else:
+        Console_output_fn = print
+
+# returns True if host system detected as Raspberry Pi
 def is_sys_raspberry_pi():
     try:
         modelStr = None
@@ -737,59 +751,69 @@ def is_sys_raspberry_pi():
         if modelStr and "raspberry pi" in modelStr.lower():
             return True
     except Exception as ex:
-        print("Error in 'is_sys_raspberry_pi()': " + str(ex))
+        Console_output_fn("Error in 'is_sys_raspberry_pi()': " + str(ex))
     return False
 
+# reset BPill processor into bootloader mode
 def reset_to_boot_0():
     try:
         import RPi.GPIO as GPIO
         GPIO.setmode(GPIO.BCM)
         GPIO.setup(GPIO_RESET_PIN, GPIO.OUT)
-        GPIO.output(GPIO_RESET_PIN, GPIO.HIGH)
+        GPIO.output(GPIO_RESET_PIN, GPIO.HIGH)  # reset pin high (inactive)
         GPIO.setup(GPIO_BOOT0_PIN, GPIO.OUT)
-        GPIO.output(GPIO_BOOT0_PIN, GPIO.HIGH)
+        GPIO.output(GPIO_BOOT0_PIN, GPIO.HIGH)  # boot0 pin high (active)
         time.sleep(0.01)
-        GPIO.output(GPIO_RESET_PIN, GPIO.LOW)
+        GPIO.output(GPIO_RESET_PIN, GPIO.LOW)   # reset pin low (active)
         time.sleep(0.05)
-        GPIO.output(GPIO_RESET_PIN, GPIO.HIGH)
+        GPIO.output(GPIO_RESET_PIN, GPIO.HIGH)  # reset pin high (inactive)
         time.sleep(0.1)
-        GPIO.output(GPIO_BOOT0_PIN, GPIO.LOW)
+        GPIO.output(GPIO_BOOT0_PIN, GPIO.LOW)   # boot0 pin low (inactive)
         GPIO.setup(GPIO_RESET_PIN, GPIO.IN)
         GPIO.setup(GPIO_BOOT0_PIN, GPIO.IN)
     except ImportError as ex:
-        print("ImportError in 'reset_to_boot_0()': " + str(ex))
+        Console_output_fn("ImportError in 'reset_to_boot_0()': " + str(ex))
     except Exception as ex:
-        print("Error in 'reset_to_boot_0()': " + str(ex))
+        Console_output_fn("Error in 'reset_to_boot_0()': " + str(ex))
 
+# reset BPill processor
 def reset_to_run():
     try:
         import RPi.GPIO as GPIO
         GPIO.setmode(GPIO.BCM)
         GPIO.setup(GPIO_RESET_PIN, GPIO.OUT)
-        GPIO.output(GPIO_RESET_PIN, GPIO.HIGH)
+        GPIO.output(GPIO_RESET_PIN, GPIO.HIGH)  # reset pin high (inactive)
         time.sleep(0.01)
-        GPIO.output(GPIO_RESET_PIN, GPIO.LOW)
+        GPIO.output(GPIO_RESET_PIN, GPIO.LOW)   # reset pin low (active)
         time.sleep(0.05)
-        GPIO.output(GPIO_RESET_PIN, GPIO.HIGH)
+        GPIO.output(GPIO_RESET_PIN, GPIO.HIGH)  # reset pin high (inactive)
         time.sleep(0.1)
         GPIO.setup(GPIO_RESET_PIN, GPIO.IN)
     except ImportError as ex:
-        print("ImportError in 'reset_to_run()': " + str(ex))
+        Console_output_fn("ImportError in 'reset_to_run()': " + str(ex))
     except Exception as ex:
-        print("Error in 'reset_to_run()': " + str(ex))
+        Console_output_fn("Error in 'reset_to_run()': " + str(ex))
 
+# download given URL to buffer
 def download_to_buffer(src_url):
     u = urllib2.urlopen(src_url)
     meta = u.info()
     src_size = int(meta.getheaders("Content-Length")[0])
+    if src_size <= 0:
+        raise RuntimeError("Source-data size is zero, aborting download from: {}".format(src_url))
     if src_size > 999999:
         raise RuntimeError("Source-data size too large ({}), aborting download from: {}".format(src_size, src_url))
-    print("Downloading {} bytes from: {}".format(src_size, src_url))
+    Console_output_fn("Downloading {} bytes from: {}".format(src_size, src_url))
     return u.read(src_size)
 
 
+# flash firmware to BPill at given port with data from given file/URL
 def flash_file_to_stm32(portStr, srcStr):
     try:
+        if not portStr:
+            portStr = DEF_SERIAL_PORT
+        if not srcStr:
+            srcStr = DEF_BINSRC_STR
 
         binaryData = None
         try:
@@ -799,7 +823,7 @@ def flash_file_to_stm32(portStr, srcStr):
                 with open(srcStr, "rb") as read_file:
                     binaryData = bytearray(read_file.read())
         except IOError as ex:
-            print(("Error loading file: " + str(ex)), file=sys.stderr)
+            Console_output_fn(("Error loading file: " + str(ex)))
             return False
         
         verboseFlag = False
@@ -809,7 +833,7 @@ def flash_file_to_stm32(portStr, srcStr):
         
         isRPiFlag = is_sys_raspberry_pi()
         
-        print("stm32loader using port %s" % portStr)
+        Console_output_fn("stm32loader using port %s" % portStr)
         try:
             serialObj = serial.Serial(port=None, baudrate=57600, parity=serial.PARITY_EVEN, timeout=3, \
                                       rtscts=False, dsrdtr=False)
@@ -818,7 +842,7 @@ def flash_file_to_stm32(portStr, srcStr):
             serialObj.setPort(portStr)
             serialObj.open()  # open port (now that DTR is configured for no change)
         except IOError as ex:
-            print(("Error opening serial port: " + str(ex)), file=sys.stderr)
+            Console_output_fn(("Error opening serial port: " + str(ex)))
             return False
         
         bootloaderObj = Stm32Bootloader(serialObj, verbosity=5)
@@ -829,37 +853,37 @@ def flash_file_to_stm32(portStr, srcStr):
             try:
                 bootloaderObj.reset_from_system_memory()
                 activatedFlag = True
-                print("Activated bootloader")
+                Console_output_fn("Activated bootloader")
             except CommandError:
                 activatedFlag = False
             if not activatedFlag:
                 # try to reset into bootloader mode via RPi GPIO outputs
                 bootloaderObj.SYNCHRONIZE_ATTEMPTS = 2
-                print("Resetting BPill with Boot0 via GPIO")
+                Console_output_fn("Resetting BPill with Boot0 via GPIO")
                 reset_to_boot_0()
                 try:
-                    print("Activating bootloader")
+                    Console_output_fn("Activating bootloader")
                     bootloaderObj.reset_from_system_memory()
                 except CommandError:
-                    print("Can't init into bootloader - ensure that Boot0 jumper is installed and RH server is not running", file=sys.stderr)
-                    print("Resetting BPill via GPIO")
+                    Console_output_fn("Can't init into bootloader - ensure that Boot0 jumper is installed and RH server is not running")
+                    Console_output_fn("Resetting BPill via GPIO")
                     reset_to_run()
                     return False
         else:
             try:
-                print("Activating bootloader")
+                Console_output_fn("Activating bootloader")
                 bootloaderObj.reset_from_system_memory()
             except CommandError:
-                print("Can't init into bootloader - ensure that Boot0 is enabled and reset the device.", file=sys.stderr)
+                Console_output_fn("Can't init into bootloader - ensure that Boot0 is enabled and reset the device")
                 bootloaderObj.reset_from_flash()
                 return False
     
         successFlag = False
         try:
             bootVersion = bootloaderObj.get()
-            print("Device bootloader version: 0x%X" % bootVersion)
+            Console_output_fn("Device bootloader version: 0x%X" % bootVersion)
             deviceId = bootloaderObj.get_id()
-            print("Device chip id: 0x%X (%s)" % (deviceId, CHIP_IDS.get(deviceId, "Unknown")))
+            Console_output_fn("Device chip id: 0x%X (%s)" % (deviceId, CHIP_IDS.get(deviceId, "Unknown")))
             successFlag = True
             
             try:
@@ -869,50 +893,51 @@ def flash_file_to_stm32(portStr, srcStr):
                 else:
                     flash_size, device_uid = bootloaderObj.get_flash_size_and_uid_f4()
                 device_uid_string = bootloaderObj.format_uid(device_uid)
-                print("Device UID: %s" % device_uid_string)
-                print("Flash size: %d KiB" % flash_size)
+                Console_output_fn("Device UID: %s" % device_uid_string)
+                Console_output_fn("Flash size: %d KiB" % flash_size)
             except CommandError as e:
-                print("Error reading chip family data: " + str(e))
+                Console_output_fn("Error reading chip family data: " + str(e))
             
         except Exception as ex:
-            print("Unable to communicate with device: %s" % ex)
+            Console_output_fn("Unable to communicate with device: %s" % ex)
     
         if successFlag:
-            if binaryData:
-                if verboseFlag:
-                    bootloaderObj.verbosity = 10
-                
-                print("Erasing memory")
-                bootloaderObj.erase_memory()
+            if verboseFlag:
+                bootloaderObj.verbosity = 10
+            
+            Console_output_fn("Erasing memory")
+            bootloaderObj.erase_memory()
     
+            if binaryData:
                 bootloaderObj.write_memory_data(memoryAddress, binaryData)
-        
                 read_data = bootloaderObj.read_memory_data(memoryAddress, len(binaryData))
                 try:
                     Stm32Bootloader.verify_data(read_data, binaryData)
-                    print("Verification OK")
+                    Console_output_fn("Verification OK")
                 except DataMismatchError as e:
                     successFlag = False
-                    print("Verification FAILED: %s" % e, file=sys.stdout)
-                    
+                    Console_output_fn("Verification FAILED: %s" % e, file=sys.stdout)
                 if successFlag and goAddress >= 0:
                     bootloaderObj.go(goAddress)
+            else:
+                Console_output_fn("Source file is empty; device firmware erased")
     
         serialObj.close()
     
         if isRPiFlag:
-            print("Resetting BPill via GPIO")
+            Console_output_fn("Resetting BPill via GPIO")
             reset_to_run()
     
         return successFlag
 
-    except:
+    except Exception as ex:
+        Console_output_fn("Error in stm32loader 'flash_file_to_stm32()': " + str(ex))
         traceback.print_exc()
         return False
 
 
 if __name__ == '__main__':
-    portStr = sys.argv[1] if len(sys.argv) > 1 else "/dev/serial0"
-    srcStr = sys.argv[2] if len(sys.argv) > 2 else  "http://www.rotorhazard.com/fw/dev/current/RH_S32_BPill_node.bin"
+    portStr = sys.argv[1] if len(sys.argv) > 1 else None
+    srcStr = sys.argv[2] if len(sys.argv) > 2 else None
     successFlag = flash_file_to_stm32(portStr, srcStr)
     sys.exit(0 if successFlag else 1)

--- a/src/server/util/stm32loader.py
+++ b/src/server/util/stm32loader.py
@@ -1,0 +1,896 @@
+# Authors: Ivan A-R, Floris Lambrechts
+# GitHub repository: https://github.com/florisla/stm32loader
+#
+# This file is part of stm32loader.
+#
+# stm32loader is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free
+# Software Foundation; either version 3, or (at your option) any later
+# version.
+#
+# stm32loader is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with stm32loader; see the file LICENSE.  If not see
+# <http://www.gnu.org/licenses/>.
+
+"""Talk to an STM32 native bootloader (see ST AN3155)."""
+
+
+from __future__ import print_function
+
+import math
+import operator
+import struct
+import sys
+import time
+from functools import reduce
+
+CHIP_IDS = {
+    # see ST AN2606 Table 136 Bootloader device-dependent parameters
+    # 16 to 32 KiB
+    0x412: "STM32F10x Low-density",
+    0x444: "STM32F03xx4/6",
+    # 64 to 128 KiB
+    0x410: "STM32F10x Medium-density",
+    0x420: "STM32F10x Medium-density value line",
+    0x460: "STM32G0x1",
+    # 256 to 512 KiB (5128 Kbyte is probably a typo?)
+    0x414: "STM32F10x High-density",
+    0x428: "STM32F10x High-density value line",
+    # 768 to 1024 KiB
+    0x430: "STM3210xx XL-density",
+    # flash size to be looked up
+    0x416: "STM32L1xxx6(8/B) Medium-density ultralow power line",
+    0x411: "STM32F2xxx",
+    0x433: "STM32F4xxD/E",
+    # STM32F3
+    0x432: "STM32F373xx/378xx",
+    0x422: "STM32F302xB(C)/303xB(C)/358xx",
+    0x439: "STM32F301xx/302x4(6/8)/318xx",
+    0x438: "STM32F303x4(6/8)/334xx/328xx",
+    0x446: "STM32F302xD(E)/303xD(E)/398xx",
+    # RM0090 in ( 38.6.1 MCU device ID code )
+    0x413: "STM32F405xx/07xx and STM32F415xx/17xx",
+    0x419: "STM32F42xxx and STM32F43xxx",
+    0x449: "STM32F74xxx/75xxx",
+    0x451: "STM32F76xxx/77xxx",
+    # RM0394 46.6.1 MCU device ID code
+    0x435: "STM32L4xx",
+    # see ST AN4872
+    # requires parity None
+    0x11103: "BlueNRG",
+    # STM32F0 RM0091 Table 136. DEV_ID and REV_ID field values
+    0x440: "STM32F030x8",
+    0x445: "STM32F070x6",
+    0x448: "STM32F070xB",
+    0x442: "STM32F030xC",
+    # Cortex-M0 MCU with hardware TCP/IP and MAC
+    # (SweetPeas custom bootloader)
+    0x801: "Wiznet W7500",
+}
+
+
+class Stm32LoaderError(Exception):
+    """Generic exception type for errors occurring in stm32loader."""
+
+
+class CommandError(Stm32LoaderError, IOError):
+    """Exception: a command in the STM32 native bootloader failed."""
+
+
+class PageIndexError(Stm32LoaderError, ValueError):
+    """Exception: invalid page index given."""
+
+
+class DataLengthError(Stm32LoaderError, ValueError):
+    """Exception: invalid data length given."""
+
+
+class DataMismatchError(Stm32LoaderError):
+    """Exception: data comparison failed."""
+
+
+class ShowProgress:
+    """
+    Show progress through a progress bar, as a context manager.
+
+    Return the progress bar object on context enter, allowing the
+    caller to to call next().
+
+    Allow to supply the desired progress bar as None, to disable
+    progress bar output.
+    """
+
+    class _NoProgressBar:
+        """
+        Stub to replace a real progress.bar.Bar.
+
+        Use this if you don't want progress bar output, or if
+        there's an ImportError of progress module.
+        """
+
+        def next(self):  # noqa
+            """Do nothing; be compatible to progress.bar.Bar."""
+
+        def finish(self):
+            """Do nothing; be compatible to progress.bar.Bar."""
+
+    def __init__(self, progress_bar_type):
+        """
+        Construct the context manager object.
+
+        :param progress_bar_type type: Type of progress bar to use.
+           Set to None if you don't want progress bar output.
+        """
+        self.progress_bar_type = progress_bar_type
+        self.progress_bar = None
+
+    def __call__(self, message, maximum):
+        """
+        Return a context manager for a progress bar.
+
+        :param str message: Message to show next to the progress bar.
+        :param int maximum: Maximum value of the progress bar (value at 100%).
+          E.g. 256.
+        :return ShowProgress: Context manager object.
+        """
+        if not self.progress_bar_type:
+            self.progress_bar = self._NoProgressBar()
+        else:
+            self.progress_bar = self.progress_bar_type(
+                message, max=maximum, suffix="%(index)d/%(max)d"
+            )
+
+        return self
+
+    def __enter__(self):
+        """Enter context: return progress bar to allow calling next()."""
+        return self.progress_bar
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Exit context: clean up by finish()ing the progress bar."""
+        self.progress_bar.finish()
+
+
+class Stm32Bootloader:
+    """Talk to the STM32 native bootloader."""
+
+    # pylint: disable=too-many-public-methods
+
+    class Command:
+        """STM32 native bootloader command values."""
+
+        # pylint: disable=too-few-public-methods
+        # FIXME turn into intenum
+
+        # See ST AN3155, AN4872
+        GET = 0x00
+        GET_VERSION = 0x01
+        GET_ID = 0x02
+        READ_MEMORY = 0x11
+        GO = 0x21
+        WRITE_MEMORY = 0x31
+        ERASE = 0x43
+        READOUT_PROTECT = 0x82
+        READOUT_UNPROTECT = 0x92
+        # these not supported on BlueNRG
+        EXTENDED_ERASE = 0x44
+        WRITE_PROTECT = 0x63
+        WRITE_UNPROTECT = 0x73
+
+        # not used so far
+        READOUT_PROTECT = 0x82
+        READOUT_UNPROTECT = 0x92
+
+        # not really listed under commands, but still...
+        # 'wake the bootloader' == 'activate USART' == 'synchronize'
+        SYNCHRONIZE = 0x7F
+
+    class Reply:
+        """STM32 native bootloader reply status codes."""
+
+        # pylint: disable=too-few-public-methods
+        # FIXME turn into intenum
+
+        # See ST AN3155, AN4872
+        ACK = 0x79
+        NACK = 0x1F
+
+    UID_ADDRESS = {
+        # No unique id for these parts
+        "F0": None,
+        # ST RM0008 section 30.1 Unique device ID register
+        # F101, F102, F103, F105, F107
+        "F1": 0x1FFFF7E8,
+        # ST RM0366 section 29.1 Unique device ID register
+        # ST RM0365 section 34.1 Unique device ID register
+        # ST RM0316 section 34.1 Unique device ID register
+        # ST RM0313 section 32.1 Unique device ID register
+        # F303/328/358/398, F301/318, F302, F37x
+        "F3": 0x1FFFF7AC,
+        # ST RM0090 section 39.1 Unique device ID register
+        # F405/415, F407/417, F427/437, F429/439
+        "F4": 0x1FFF7A10,
+        # ST RM0385 section 41.2 Unique device ID register
+        "F7": 0x1FF0F420,
+        # ST RM0394 47.1 Unique device ID register (96 bits)
+        "L4": 0x1FFF7590,
+        # ST RM0444 section 38.1 Unique device ID register
+        "G0": 0x1FFF7590,
+    }
+
+    UID_SWAP = [[1, 0], [3, 2], [7, 6, 5, 4], [11, 10, 9, 8]]
+
+    # Part does not support unique ID feature
+    UID_NOT_SUPPORTED = 0
+    # stm32loader does not know the address for the unique ID
+    UID_ADDRESS_UNKNOWN = -1
+
+    FLASH_SIZE_ADDRESS = {
+        # ST RM0360 section 27.1 Memory size data register
+        # F030x4/x6/x8/xC, F070x6/xB
+        "F0": 0x1FFFF7CC,
+        # ST RM0008 section 30.2 Memory size registers
+        # F101, F102, F103, F105, F107
+        "F1": 0x1FFFF7E0,
+        # ST RM0366 section 29.2 Memory size data register
+        # ST RM0365 section 34.2 Memory size data register
+        # ST RM0316 section 34.2 Memory size data register
+        # ST RM0313 section 32.2 Flash memory size data register
+        # F303/328/358/398, F301/318, F302, F37x
+        "F3": 0x1FFFF7CC,
+        # ST RM0090 section 39.2 Flash size
+        # F405/415, F407/417, F427/437, F429/439
+        "F4": 0x1FFF7A22,
+        # ST RM0385 section 41.2 Flash size
+        "F7": 0x1FF0F442,
+        # ST RM0394
+        "L4": 0x1FFF75E0,
+        # ST RM0444 section 38.2 Flash memory size data register
+        "G0": 0x1FFF75E0,
+    }
+
+    DATA_TRANSFER_SIZE = 256  # bytes
+    FLASH_PAGE_SIZE = 1024  # bytes
+
+    SYNCHRONIZE_ATTEMPTS = 2
+
+    def __init__(self, connection, verbosity=5, show_progress=None):
+        """
+        Construct the Stm32Bootloader object.
+
+        The supplied connection can be any object that supports
+        read() and write().  Optionally, it may also offer
+        enable_reset() and enable_boot0(); it should advertise this by
+        setting TOGGLES_RESET and TOGGLES_BOOT0 to True.
+
+        The default implementation is stm32loader.connection.SerialConnection,
+        but a straight pyserial serial.Serial object can also be used.
+
+        :param connection: Object supporting read() and write().
+          E.g. serial.Serial().
+        :param int verbosity: Verbosity level. 0 is quite, 10 is verbose.
+        :param ShowProgress show_progress: ShowProgress context manager.
+           Set to None to disable progress bar output.
+        """
+        self.connection = connection
+        self.verbosity = verbosity
+        self.show_progress = show_progress or ShowProgress(None)
+        self.extended_erase = False
+
+    def write(self, *data):
+        """Write the given data to the MCU."""
+        for data_bytes in data:
+            if isinstance(data_bytes, int):
+                data_bytes = struct.pack("B", data_bytes)
+            self.connection.write(data_bytes)
+
+    def write_and_ack(self, message, *data):
+        """Write data to the MCU and wait until it replies with ACK."""
+        # this is a separate method from write() because a keyword
+        # argument after *args is not possible in Python 2
+        self.write(*data)
+        return self._wait_for_ack(message)
+
+    def debug(self, level, message):
+        """Print the given message if its level is low enough."""
+        if self.verbosity >= level:
+            print(message, file=sys.stderr)
+
+    def reset_from_system_memory(self):
+        """Reset the MCU with boot0 enabled to enter the bootloader."""
+        self._enable_boot0(True)
+        self._reset()
+
+        # Try the 0x7F synchronize that selects UART in bootloader mode
+        # (see ST application notes AN3155 and AN2606).
+        # If we are right after reset, it returns ACK, otherwise first
+        # time nothing, then NACK.
+        # This is not documented in STM32 docs fully, but ST official
+        # tools use the same algorithm.
+        # This is likely an artifact/side effect of each command being
+        # 2-bytes and having xor of bytes equal to 0xFF.
+
+        for attempt in range(self.SYNCHRONIZE_ATTEMPTS):
+            if attempt:
+                print("Bootloader activation timeout -- retrying", file=sys.stderr)
+            self.write(self.Command.SYNCHRONIZE)
+            read_data = bytearray(self.connection.read())
+
+            if read_data and read_data[0] in (self.Reply.ACK, self.Reply.NACK):
+                # success
+                return
+
+        # not successful
+        raise CommandError("Bad reply from bootloader")
+
+    def reset_from_flash(self):
+        """Reset the MCU with boot0 disabled."""
+        self._enable_boot0(False)
+        self._reset()
+
+    def command(self, command, description):
+        """
+        Send the given command to the MCU.
+
+        Raise CommandError if there's no ACK replied.
+        """
+        self.debug(10, "*** Command: %s" % description)
+        ack_received = self.write_and_ack("Command", command, command ^ 0xFF)
+        if not ack_received:
+            raise CommandError("%s (%s) failed: no ack" % (description, command))
+
+    def get(self):
+        """Return the bootloader version and remember supported commands."""
+        self.command(self.Command.GET, "Get")
+        length = bytearray(self.connection.read())[0]
+        version = bytearray(self.connection.read())[0]
+        self.debug(10, "    Bootloader version: " + hex(version))
+        data = bytearray(self.connection.read(length))
+        if self.Command.EXTENDED_ERASE in data:
+            self.extended_erase = True
+        self.debug(10, "    Available commands: " + ", ".join(hex(b) for b in data))
+        self._wait_for_ack("0x00 end")
+        return version
+
+    def get_version(self):
+        """
+        Return the bootloader version.
+
+        Read protection status readout is not yet implemented.
+        """
+        self.command(self.Command.GET_VERSION, "Get version")
+        data = bytearray(self.connection.read(3))
+        version = data[0]
+        option_byte1 = data[1]
+        option_byte2 = data[2]
+        self._wait_for_ack("0x01 end")
+        self.debug(10, "    Bootloader version: " + hex(version))
+        self.debug(10, "    Option byte 1: " + hex(option_byte1))
+        self.debug(10, "    Option byte 2: " + hex(option_byte2))
+        return version
+
+    def get_id(self):
+        """Send the 'Get ID' command and return the device (model) ID."""
+        self.command(self.Command.GET_ID, "Get ID")
+        length = bytearray(self.connection.read())[0]
+        id_data = bytearray(self.connection.read(length + 1))
+        self._wait_for_ack("0x02 end")
+        _device_id = reduce(lambda x, y: x * 0x100 + y, id_data)
+        return _device_id
+
+    def get_flash_size(self, device_family):
+        """Return the MCU's flash size in bytes."""
+        flash_size_address = self.FLASH_SIZE_ADDRESS[device_family]
+        flash_size_bytes = self.read_memory(flash_size_address, 2)
+        flash_size = flash_size_bytes[0] + (flash_size_bytes[1] << 8)
+        return flash_size
+
+    def get_flash_size_and_uid_f4(self):
+        """
+        Return device_uid and flash_size for F4 family.
+
+        For some reason, F4 (at least, NUCLEO F401RE) can't read the 12 or 2
+        bytes for UID and flash size directly.
+        Reading a whole chunk of 256 bytes at 0x1FFFA700 does work and
+        requires some data extraction.
+        """
+        data_start_addr = 0x1FFF7A00
+        flash_size_lsb_addr = 0x22
+        uid_lsb_addr = 0x10
+        data = self.read_memory(data_start_addr, self.DATA_TRANSFER_SIZE)
+        device_uid = data[uid_lsb_addr : uid_lsb_addr + 12]
+        flash_size = data[flash_size_lsb_addr] + data[flash_size_lsb_addr + 1] << 8
+        return flash_size, device_uid
+
+    def get_uid(self, deviceId):
+        """
+        Send the 'Get UID' command and return the device UID.
+
+        Return UID_NOT_SUPPORTED if the device does not have
+        a UID.
+        Return UIT_ADDRESS_UNKNOWN if the address of the device's
+        UID is not known.
+
+        :param str deviceId: Device family name such as "F1".
+          See UID_ADDRESS.
+        :return byterary: UID bytes of the device, or 0 or -1 when
+          not available.
+        """
+        uid_address = self.UID_ADDRESS.get(deviceId, self.UID_ADDRESS_UNKNOWN)
+        if uid_address is None:
+            return self.UID_NOT_SUPPORTED
+        if uid_address == self.UID_ADDRESS_UNKNOWN:
+            return self.UID_ADDRESS_UNKNOWN
+
+        uid = self.read_memory(uid_address, 12)
+        return uid
+
+    @classmethod
+    def format_uid(cls, uid):
+        """Return a readable string from the given UID."""
+        if uid == cls.UID_NOT_SUPPORTED:
+            return "UID not supported in this part"
+        if uid == cls.UID_ADDRESS_UNKNOWN:
+            return "UID address unknown"
+
+        swapped_data = [[uid[b] for b in part] for part in Stm32Bootloader.UID_SWAP]
+        uid_string = "-".join("".join(format(b, "02X") for b in part) for part in swapped_data)
+        return uid_string
+
+    def read_memory(self, address, length):
+        """
+        Return the memory contents of flash at the given address.
+
+        Supports maximum 256 bytes.
+        """
+        if length > self.DATA_TRANSFER_SIZE:
+            raise DataLengthError("Can not read more than 256 bytes at once.")
+        self.command(self.Command.READ_MEMORY, "Read memory")
+        self.write_and_ack("0x11 address failed", self._encode_address(address))
+        nr_of_bytes = (length - 1) & 0xFF
+        checksum = nr_of_bytes ^ 0xFF
+        self.write_and_ack("0x11 length failed", nr_of_bytes, checksum)
+        return bytearray(self.connection.read(length))
+
+    def go(self, address):
+        """Send the 'Go' command to start execution of firmware."""
+        # pylint: disable=invalid-name
+        self.command(self.Command.GO, "Go")
+        self.write_and_ack("0x21 go failed", self._encode_address(address))
+
+    def write_memory(self, address, data):
+        """
+        Write the given data to flash at the given address.
+
+        Supports maximum 256 bytes.
+        """
+        nr_of_bytes = len(data)
+        if nr_of_bytes == 0:
+            return
+        if nr_of_bytes > self.DATA_TRANSFER_SIZE:
+            raise DataLengthError("Can not write more than 256 bytes at once.")
+        self.command(self.Command.WRITE_MEMORY, "Write memory")
+        self.write_and_ack("0x31 address failed", self._encode_address(address))
+
+        # pad data length to multiple of 4 bytes
+        if nr_of_bytes % 4 != 0:
+            padding_bytes = 4 - (nr_of_bytes % 4)
+            nr_of_bytes += padding_bytes
+            # append value 0xFF: flash memory value after erase
+            data = bytearray(data)
+            data.extend([0xFF] * padding_bytes)
+
+        self.debug(10, "    %s bytes to write" % [nr_of_bytes])
+        checksum = reduce(operator.xor, data, nr_of_bytes - 1)
+        self.write_and_ack("0x31 programming failed", nr_of_bytes - 1, data, checksum)
+        self.debug(10, "    Write memory done")
+
+    def erase_memory(self, pages=None):
+        """
+        Erase flash memory at the given pages.
+
+        Set pages to None to erase the full memory.
+        :param iterable pages: Iterable of integer page addresses, zero-based.
+          Set to None to trigger global mass erase.
+        """
+        if self.extended_erase:
+            # use erase with two-byte addresses
+            self.extended_erase_memory(pages)
+            return
+
+        self.command(self.Command.ERASE, "Erase memory")
+        if pages:
+            # page erase, see ST AN3155
+            if len(pages) > 255:
+                raise PageIndexError(
+                    "Can not erase more than 255 pages at once.\n"
+                    "Set pages to None to do global erase or supply fewer pages."
+                )
+            page_count = (len(pages) - 1) & 0xFF
+            page_numbers = bytearray(pages)
+            checksum = reduce(operator.xor, page_numbers, page_count)
+            self.write(page_count, page_numbers, checksum)
+        else:
+            # global erase: n=255 (page count)
+            self.write(255, 0)
+
+        self._wait_for_ack("0x43 erase failed")
+        self.debug(10, "    Erase memory done")
+
+    def extended_erase_memory(self, pages=None):
+        """
+        Erase flash memory using two-byte addressing at the given pages.
+
+        Set pages to None to erase the full memory.
+
+        Not all devices support the extended erase command.
+
+        :param iterable pages: Iterable of integer page addresses, zero-based.
+          Set to None to trigger global mass erase.
+        """
+        self.command(self.Command.EXTENDED_ERASE, "Extended erase memory")
+        if pages:
+            # page erase, see ST AN3155
+            if len(pages) > 65535:
+                raise PageIndexError(
+                    "Can not erase more than 65535 pages at once.\n"
+                    "Set pages to None to do global erase or supply fewer pages."
+                )
+            page_count = (len(pages) & 0xFF) - 1
+            page_count_bytes = bytearray(struct.pack(">H", page_count))
+            page_bytes = bytearray(len(pages) * 2)
+            for i, page in enumerate(pages):
+                struct.pack_into(">H", page_bytes, i * 2, page)
+            checksum = reduce(operator.xor, page_count_bytes)
+            checksum = reduce(operator.xor, page_bytes, checksum)
+            self.write(page_count_bytes, page_bytes, checksum)
+        else:
+            # global mass erase: n=0xffff (page count) + checksum
+            # TO DO: support 0xfffe bank 1 erase / 0xfffe bank 2 erase
+            self.write(b"\xff\xff\x00")
+
+        previous_timeout_value = self.connection.timeout
+        self.connection.timeout = 30
+        print("Extended erase (0x44), this can take ten seconds or more")
+        try:
+            self._wait_for_ack("0x44 erasing failed")
+        finally:
+            self.connection.timeout = previous_timeout_value
+        self.debug(10, "    Extended Erase memory done")
+
+    def write_protect(self, pages):
+        """Enable write protection on the given flash pages."""
+        self.command(self.Command.WRITE_PROTECT, "Write protect")
+        nr_of_pages = (len(pages) - 1) & 0xFF
+        page_numbers = bytearray(pages)
+        checksum = reduce(operator.xor, page_numbers, nr_of_pages)
+        self.write_and_ack("0x63 write protect failed", nr_of_pages, page_numbers, checksum)
+        self.debug(10, "    Write protect done")
+
+    def write_unprotect(self):
+        """Disable write protection of the flash memory."""
+        self.command(self.Command.WRITE_UNPROTECT, "Write unprotect")
+        self._wait_for_ack("0x73 write unprotect failed")
+        self.debug(10, "    Write Unprotect done")
+
+    def readout_protect(self):
+        """Enable readout protection of the flash memory."""
+        self.command(self.Command.READOUT_PROTECT, "Readout protect")
+        self._wait_for_ack("0x82 readout protect failed")
+        self.debug(10, "    Read protect done")
+
+    def readout_unprotect(self):
+        """
+        Disable readout protection of the flash memory.
+
+        Beware, this will erase the flash content.
+        """
+        self.command(self.Command.READOUT_UNPROTECT, "Readout unprotect")
+        self._wait_for_ack("0x92 readout unprotect failed")
+        self.debug(20, "    Mass erase -- this may take a while")
+        time.sleep(20)
+        self.debug(20, "    Unprotect / mass erase done")
+        self.debug(20, "    Reset after automatic chip reset due to readout unprotect")
+        self.reset_from_system_memory()
+
+    def read_memory_data(self, address, length):
+        """
+        Return flash content from the given address and byte count.
+
+        Length may be more than 256 bytes.
+        """
+        data = bytearray()
+        chunk_count = int(math.ceil(length / float(self.DATA_TRANSFER_SIZE)))
+        self.debug(5, "Read %d chunks at address 0x%X..." % (chunk_count, address))
+        with self.show_progress("Reading", maximum=chunk_count) as progress_bar:
+            while length:
+                read_length = min(length, self.DATA_TRANSFER_SIZE)
+                self.debug(
+                    10,
+                    "Read %(len)d bytes at 0x%(address)X"
+                    % {"address": address, "len": read_length},
+                )
+                data = data + self.read_memory(address, read_length)
+                progress_bar.next()
+                length = length - read_length
+                address = address + read_length
+        return data
+
+    def write_memory_data(self, address, data):
+        """
+        Write the given data to flash.
+
+        Data length may be more than 256 bytes.
+        """
+        length = len(data)
+        chunk_count = int(math.ceil(length / float(self.DATA_TRANSFER_SIZE)))
+        offset = 0
+        self.debug(5, "Write %d chunks at address 0x%X..." % (chunk_count, address))
+
+        with self.show_progress("Writing", maximum=chunk_count) as progress_bar:
+            while length:
+                write_length = min(length, self.DATA_TRANSFER_SIZE)
+                self.debug(
+                    10,
+                    "Write %(len)d bytes at 0x%(address)X"
+                    % {"address": address, "len": write_length},
+                )
+                self.write_memory(address, data[offset : offset + write_length])
+                progress_bar.next()
+                length -= write_length
+                offset += write_length
+                address += write_length
+
+    @staticmethod
+    def verify_data(read_data, reference_data):
+        """
+        Raise an error if the given data does not match its reference.
+
+        Error type is DataMismatchError.
+
+        :param read_data: Data to compare.
+        :param reference_data: Data to compare, as reference.
+        :return None:
+        """
+        if read_data == reference_data:
+            return
+
+        if len(read_data) != len(reference_data):
+            raise DataMismatchError(
+                "Data length does not match: %d bytes vs %d bytes."
+                % (len(read_data), len(reference_data))
+            )
+
+        # data differs; find out where and raise VerifyError
+        for address, data_pair in enumerate(zip(reference_data, read_data)):
+            reference_byte, read_byte = data_pair
+            if reference_byte != read_byte:
+                raise DataMismatchError(
+                    "Verification data does not match read data. "
+                    "First mismatch at address: 0x%X read 0x%X vs 0x%X expected."
+                    % (address, bytearray([read_byte])[0], bytearray([reference_byte])[0])
+                )
+
+    def _reset(self):
+        """Enable or disable the reset IO line (if possible)."""
+        if not hasattr(self.connection, "enable_reset"):
+            return
+        self.connection.enable_reset(True)
+        time.sleep(0.1)
+        self.connection.enable_reset(False)
+        time.sleep(0.5)
+
+    def _enable_boot0(self, enable=True):
+        """Enable or disable the boot0 IO line (if possible)."""
+        if not hasattr(self.connection, "enable_boot0"):
+            return
+
+        self.connection.enable_boot0(enable)
+
+    def _wait_for_ack(self, info=""):
+        """Read a byte and raise CommandError if it's not ACK."""
+        read_data = bytearray(self.connection.read())
+        if not read_data:
+            raise CommandError("Can't read port or timeout")
+        reply = read_data[0]
+        if reply == self.Reply.NACK:
+            raise CommandError("NACK " + info)
+        if reply != self.Reply.ACK:
+            raise CommandError("Unknown response. " + info + ": " + hex(reply))
+
+        return 1
+
+    @staticmethod
+    def _encode_address(address):
+        """Return the given address as big-endian bytes with a checksum."""
+        # address in four bytes, big-endian
+        address_bytes = bytearray(struct.pack(">I", address))
+        # checksum as single byte
+        checksum_byte = struct.pack("B", reduce(operator.xor, address_bytes))
+        return address_bytes + checksum_byte
+
+#=================================================================================#
+
+# Above code is from "stm32loader-0.5.1/stm32loader/bootloader.py"
+
+import serial
+import urllib2
+
+GPIO_RESET_PIN = 17
+GPIO_BOOT0_PIN = 27
+
+def is_sys_raspberry_pi():
+    try:
+        modelStr = None
+        try:
+            fileHnd = open("/proc/device-tree/model", "r")
+            modelStr = fileHnd.read()
+            fileHnd.close()
+        except:
+            pass
+        if modelStr and "raspberry pi" in modelStr.lower():
+            return True
+    except Exception:
+        print("Error in 'is_sys_raspberry_pi()'")
+    return False
+
+def reset_to_boot_0():
+    try:
+        import RPi.GPIO as GPIO
+        GPIO.setmode(GPIO.BCM)
+        GPIO.setup(GPIO_RESET_PIN, GPIO.OUT)
+        GPIO.output(GPIO_RESET_PIN, GPIO.HIGH)
+        GPIO.setup(GPIO_BOOT0_PIN, GPIO.OUT)
+        GPIO.output(GPIO_BOOT0_PIN, GPIO.HIGH)
+        time.sleep(0.01)
+        GPIO.output(GPIO_RESET_PIN, GPIO.LOW)
+        time.sleep(0.05)
+        GPIO.output(GPIO_RESET_PIN, GPIO.HIGH)
+        time.sleep(0.1)
+        GPIO.output(GPIO_BOOT0_PIN, GPIO.LOW)
+        GPIO.setup(GPIO_RESET_PIN, GPIO.IN)
+        GPIO.setup(GPIO_BOOT0_PIN, GPIO.IN)
+    except Exception:
+        print("Error in 'reset_to_boot_0()'")
+
+def reset_to_run():
+    try:
+        import RPi.GPIO as GPIO
+        GPIO.setmode(GPIO.BCM)
+        GPIO.setup(GPIO_RESET_PIN, GPIO.OUT)
+        GPIO.output(GPIO_RESET_PIN, GPIO.HIGH)
+        time.sleep(0.01)
+        GPIO.output(GPIO_RESET_PIN, GPIO.LOW)
+        time.sleep(0.05)
+        GPIO.output(GPIO_RESET_PIN, GPIO.HIGH)
+        time.sleep(0.1)
+        GPIO.setup(GPIO_RESET_PIN, GPIO.IN)
+    except Exception:
+        print("Error in 'reset_to_run()'")
+
+def download_to_buffer(src_url):
+    u = urllib2.urlopen(src_url)
+    meta = u.info()
+    src_size = int(meta.getheaders("Content-Length")[0])
+    if src_size > 999999:
+        raise RuntimeError("Source-data size too large ({}), aborting download from: {}".format(src_size, src_url))
+    print("Downloading {} bytes from: {}".format(src_size, src_url))
+    return u.read(src_size)
+
+
+if __name__ == '__main__':
+    
+    portStr = sys.argv[1] if len(sys.argv) > 1 else "/dev/serial0"
+    srcStr = sys.argv[2] if len(sys.argv) > 2 else  "http://www.rotorhazard.com/fw/dev/current/RH_S32_BPill_node.bin"
+    
+    binaryData = None
+    if srcStr.startswith("http://") or srcStr.startswith("https://") or srcStr.startswith("ftp://"):
+        binaryData = bytearray(download_to_buffer(srcStr))
+
+    elif len(srcStr) > 0:
+        with open(srcStr, "rb") as read_file:
+            binaryData = bytearray(read_file.read())
+    
+    verboseFlag = False
+    memoryAddress = 0x08000000
+    goAddress = 0x08000000
+    family = "F1"
+    
+    isRPiFlag = is_sys_raspberry_pi()
+    
+    print("stm32loader using port %s" % portStr)
+    serialObj = serial.Serial(port=None, baudrate=57600, parity=serial.PARITY_EVEN, timeout=3, \
+                              rtscts=False, dsrdtr=False)
+    serialObj.setDTR(0)  # clear in case line is tied to node-processor reset
+    serialObj.setRTS(0)
+    serialObj.setPort(portStr)
+    serialObj.open()  # open port (now that DTR is configured for no change)
+    
+    bootloaderObj = Stm32Bootloader(serialObj, verbosity=5)
+    
+    if isRPiFlag:
+        bootloaderObj.SYNCHRONIZE_ATTEMPTS = 1
+        # first try to see if processor already in bootloader mode
+        try:
+            bootloaderObj.reset_from_system_memory()
+            activatedFlag = True
+            print("Activated bootloader")
+        except CommandError:
+            activatedFlag = False
+        if not activatedFlag:
+            # try to reset into bootloader mode via RPi GPIO outputs
+            bootloaderObj.SYNCHRONIZE_ATTEMPTS = 2
+            print("Resetting BPill with Boot0 via GPIO")
+            reset_to_boot_0()
+            try:
+                print("Activating bootloader")
+                bootloaderObj.reset_from_system_memory()
+            except CommandError:
+                print("Can't init into bootloader - ensure that BOOT0 jumper is installed and RH server is not running", file=sys.stderr)
+                print("Resetting BPill via GPIO")
+                reset_to_run()
+                sys.exit(1)
+
+    else:
+        try:
+            print("Activating bootloader")
+            bootloaderObj.reset_from_system_memory()
+        except CommandError:
+            print("Can't init into bootloader. Ensure that BOOT0 is enabled and reset the device.", file=sys.stderr)
+            bootloaderObj.reset_from_flash()
+            sys.exit(1)
+
+    successFlag = False
+    try:
+        bootVersion = bootloaderObj.get()
+        print("Device bootloader version: 0x%X" % bootVersion)
+        deviceId = bootloaderObj.get_id()
+        print("Device chip id: 0x%X (%s)" % (deviceId, CHIP_IDS.get(deviceId, "Unknown")))
+        successFlag = True
+        
+        try:
+            if family != "F4":
+                flash_size = bootloaderObj.get_flash_size(family)
+                device_uid = bootloaderObj.get_uid(family)
+            else:
+                flash_size, device_uid = bootloaderObj.get_flash_size_and_uid_f4()
+            device_uid_string = bootloaderObj.format_uid(device_uid)
+            print("Device UID: %s" % device_uid_string)
+            print("Flash size: %d KiB" % flash_size)
+        except CommandError as e:
+            print("Error reading chip family data: " + str(e))
+        
+    except Exception as ex:
+        print("Unable to communicate with device: %s" % ex)
+
+    if successFlag:
+        if binaryData:
+            if verboseFlag:
+                bootloaderObj.verbosity = 10
+            
+            print("Erasing memory")
+            bootloaderObj.erase_memory()
+
+            bootloaderObj.write_memory_data(memoryAddress, binaryData)
+    
+            read_data = bootloaderObj.read_memory_data(memoryAddress, len(binaryData))
+            try:
+                Stm32Bootloader.verify_data(read_data, binaryData)
+                print("Verification OK")
+            except DataMismatchError as e:
+                successFlag = False
+                print("Verification FAILED: %s" % e, file=sys.stdout)
+                
+            if successFlag and goAddress >= 0:
+                bootloaderObj.go(goAddress)
+
+    serialObj.close()
+
+    if isRPiFlag:
+        print("Resetting BPill via GPIO")
+        reset_to_run()

--- a/src/server/util/stm32loader.py
+++ b/src/server/util/stm32loader.py
@@ -729,7 +729,7 @@ except ImportError:
     from urllib2 import urlopen  # for Python 2
 
 DEF_SERIAL_PORT = "/dev/serial0"
-DEF_BINSRC_STR = "http://www.rotorhazard.com/fw/dev/current/RH_S32_BPill_node.bin"
+DEF_BINSRC_STR = "http://www.rotorhazard.com/fw/rel/current/RH_S32_BPill_node.bin"
 
 GPIO_RESET_PIN = 17
 GPIO_BOOT0_PIN = 27
@@ -850,16 +850,16 @@ def flash_file_to_stm32(portStr, srcStr):
         
         bootloaderObj = Stm32Bootloader(serialObj, verbosity=5)
         
+        gpioResetFlag = False
         if isRPiFlag:
             bootloaderObj.SYNCHRONIZE_ATTEMPTS = 1
             # first try to see if processor already in bootloader mode
             try:
                 bootloaderObj.reset_from_system_memory()
-                activatedFlag = True
                 Console_output_fn("Activated bootloader")
             except CommandError:
-                activatedFlag = False
-            if not activatedFlag:
+                gpioResetFlag = True
+            if gpioResetFlag:
                 # try to reset into bootloader mode via RPi GPIO outputs
                 bootloaderObj.SYNCHRONIZE_ATTEMPTS = 2
                 Console_output_fn("Resetting BPill with Boot0 via GPIO")
@@ -927,7 +927,7 @@ def flash_file_to_stm32(portStr, srcStr):
     
         serialObj.close()
     
-        if isRPiFlag:
+        if gpioResetFlag:
             Console_output_fn("Resetting BPill via GPIO")
             reset_to_run()
     


### PR DESCRIPTION
Initial server support for the S32_BPill board.

Same code should work for both Arduino-based and new S32_BPill boards.

For S32_BPill has new 'Update Node Firmware' page (via new 'Update Nodes' button).

Will show message at top of Settings page if S32_BPill with processor that needs flashing (or if mock nodes are in use).

PR also has some general mods for better Python3 compatibility (including using 'smbus2' library instead of 'smbus').

Made server shutdown cleaner (calling 'SOCKET_IO.stop()'); added 'Kill Server' button if server-debug enabled.

Added 'src/server/'reqsNonPi.txt' file to be used in place of 'requirements.txt' on systems that don't support the 'RPi.GPIO' library.