### PR TITLE
Update doc for WS2812b LED Support

### DIFF
--- a/doc/Software Setup.md
+++ b/doc/Software Setup.md
@@ -81,24 +81,10 @@ For the S32_BPill board, the recommended method for installing the currently-rel
 The installation of a real-time clock module allows the RotorHazard timer to maintain the correct date and time even when an internet connection is not available.  See '[doc/Real Time Clock.md](Real%20Time%20Clock.md)' for more information.
 
 ### WS2812b LED Support
-The ws2812b controls are provided by the following project:
-https://github.com/jgarff/rpi_ws281x
 
-Clone the repository onto the Pi and initiate Scons:
-```
-cd ~
-sudo git clone https://github.com/jgarff/rpi_ws281x.git
-cd rpi_ws281x
-sudo scons
-```
+Support for WS2812b LED strips (and panels) is provided by the Python library '[rpi-ws281x](https://github.com/rpi-ws281x/rpi-ws281x-python)' (which is among the libraries installed via the `sudo pip install -r requirements.txt` command.
 
-Install the Python library:
-```
-cd python
-sudo python setup.py install
-```
-
-Note: The **LED_COUNT** value will need to be set in the `src/server/config.json` file. See the `src/server/config-dist.json` file for the default configuration of the 'LED' settings.  The following items may be set:
+The **LED_COUNT** value needs to be set in the `src/server/config.json` file. See the `src/server/config-dist.json` file for the default configuration of the 'LED' settings.  The following items may be set:
 ```
 LED_COUNT:  Number of LED pixels in strip (or panel)
 LED_PIN:  GPIO pin connected to the pixels (default 10 uses SPI '/dev/spidev0.0')
@@ -112,11 +98,6 @@ PANEL_ROTATE:  Optional panel-rotation value (default 0)
 INVERTED_PANEL_ROWS:  Optional panel row-inversion (default false)
 ```
 If specified, the **LED_STRIP** value must be one of: 'RGB', 'RBG', 'GRB', 'GBR', 'BRG', 'BGR', 'RGBW', 'RBGW', 'GRBW',  'GBRW', 'BRGW', 'BGRW'
-
-The LED library requires direct memory and GPIO access. When enabled, RotorHazard must be run with `sudo`.
-```
-sudo python server.py
-```
 
 ### INA219 Voltage/Current Support
 The ina219 interface is provided by the following project:

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -5679,13 +5679,17 @@ else:
     logger.debug('LED: disabled (configured LED_COUNT is <= 0)')
 if strip:
     # Initialize the library (must be called once before other functions).
-    strip.begin()
-    led_manager = LEDEventManager(Events, strip)
-    led_effects = Plugins(prefix='led_handler')
-    led_effects.discover()
-    for led_effect in led_effects:
-        led_manager.registerEffect(led_effect)
-    init_LED_effects()
+    try:
+        strip.begin()
+        led_manager = LEDEventManager(Events, strip)
+        led_effects = Plugins(prefix='led_handler')
+        led_effects.discover()
+        for led_effect in led_effects:
+            led_manager.registerEffect(led_effect)
+        init_LED_effects()
+    except:
+        logger.exception("Error initializing LED support")
+        led_manager = NoLEDManager()
 elif CLUSTER and CLUSTER.hasRecEventsSecondaries():
     led_manager = ClusterLEDManager()
     led_effects = Plugins(prefix='led_handler')

--- a/src/server/ws281x_leds.py
+++ b/src/server/ws281x_leds.py
@@ -11,7 +11,7 @@ def get_pixel_interface(config, brightness, *args, **kwargs):
     try:
         pixelModule = importlib.import_module('rpi_ws281x')
         Pixel = getattr(pixelModule, 'Adafruit_NeoPixel')
-        logger.info('LED: selecting library "rpi_ws2812x"')
+        logger.info('LED: selecting library "rpi_ws281x"')
     except ImportError:
         pixelModule = importlib.import_module('neopixel')
         Pixel = getattr(pixelModule, 'Adafruit_NeoPixel')


### PR DESCRIPTION
The current Python 'rpi_ws281x' library no longer needs a native library to be installed.  (If one is installed it tends to interfere with the Python 'rpi_ws281x' library, resulting in 'neopixel' being used by the RH server.)  Previous commit adds 'rpi-ws281x' to 'requirements.txt' (looks to be less than 500K, so small burden if not used).

Removed doc instructions for native library, and fixed reference to "rpi_ws2812x" in log output (should be "rpi_ws281x"). Added exception catch around 'strip.begin()'.

Also took out note saying that it needs 'sudo', as I've successfully run it lots of times without 'sudo'.