### PR TITLE
Store band and channel with frequency

### DIFF
--- a/src/server/server.py
+++ b/src/server/server.py
@@ -5130,26 +5130,23 @@ def recover_database(dbfile, **kwargs):
         # RSSI reduced by half for 2.0.0
         if migrate_db_api < 23:
             for profile in profiles_query_data:
-                if hasattr(profile, 'enter_ats') and profile.enter_ats:
-                    enter_ats = json.loads(profile.enter_ats)
+                if 'enter_ats' in profile and profile['enter_ats']:
+                    enter_ats = json.loads(profile['enter_ats'])
                     enter_ats["v"] = [val/2 for val in enter_ats["v"]]
-                    profile.enter_ats = json.dumps(enter_ats)
-                if hasattr(profile, 'exit_ats') and profile.exit_ats:
-                    exit_ats = json.loads(profile.exit_ats)
+                    profile['enter_ats'] = json.dumps(enter_ats)
+                if 'exit_ats' in profile and profile['exit_ats']:
+                    exit_ats = json.loads(profile['exit_ats'])
                     exit_ats["v"] = [val/2 for val in exit_ats["v"]]
-                    profile.exit_ats = json.dumps(exit_ats)
+                    profile['exit_ats'] = json.dumps(exit_ats)
 
         # Convert frequencies
         if migrate_db_api < 30:
             for profile in profiles_query_data:
-                if profile.frequencies:
-                    freqs = json.loads(profile.frequencies)
-                    f_obj = {
-                        'b': None,
-                        'c': None,
-                        'f': freqs['f']
-                    }
-                    profile.frequencies = json.dumps(f_obj)
+                if 'frequencies' in profile and profile['frequencies']:
+                    freqs = json.loads(profile['frequencies'])
+                    freqs["b"] = [None for i in range(max(RACE.num_nodes,8))]
+                    freqs["c"] = [None for i in range(max(RACE.num_nodes,8))]
+                    profile['frequencies'] = json.dumps(freqs)
 
         recover_status['stage_0'] = True
     except Exception as ex:
@@ -5249,7 +5246,7 @@ def recover_database(dbfile, **kwargs):
             if profiles_query_data:
                 restore_table(Database.Profiles, profiles_query_data, defaults={
                         'name': __("Migrated Profile"),
-                        'frequencies': json.dumps({'f': default_frequencies()}),
+                        'frequencies': json.dumps(default_frequencies()),
                         'enter_ats': json.dumps({'v': [None for i in range(max(RACE.num_nodes,8))]}),
                         'exit_ats': json.dumps({'v': [None for i in range(max(RACE.num_nodes,8))]}),
                         'f_ratio': None

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -3427,11 +3427,19 @@ def emit_race_status(**params):
 def emit_frequency_data(**params):
     '''Emits node data.'''
     profile_freqs = json.loads(getCurrentProfile().frequencies)
+
+    fdata = []
+    for idx in range(RACE.num_nodes):
+        fdata.append({
+                'band': profile_freqs["b"][idx],
+                'channel': profile_freqs["c"][idx],
+                'frequency': profile_freqs["f"][idx]
+            })
+
     emit_payload = {
-            'band': profile_freqs["b"][:RACE.num_nodes],
-            'channel': profile_freqs["c"][:RACE.num_nodes],
-            'frequency': profile_freqs["f"][:RACE.num_nodes]
+            'fdata': fdata
         }
+
     if ('nobroadcast' in params):
         emit('frequency_data', emit_payload)
     else:

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -4998,8 +4998,17 @@ def get_legacy_table_data(metadata, table_name, filter_crit=None, filter_value=N
     try:
         table = Table(table_name, metadata, autoload=True)
         if filter_crit is None:
-            return table.select().execute().fetchall()
-        return table.select().execute().filter(filter_crit==filter_value).fetchall()
+            data = table.select().execute().fetchall()
+        else:
+            data = table.select().execute().filter(filter_crit==filter_value).fetchall()
+
+        output = []
+        for row in data:
+            d = dict(row.items())
+            output.append(d)
+
+        return output
+
     except Exception as ex:
         logger.warning('Unable to read "{0}" table from previous database: {1}'.format(table_name, ex))
 

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -4723,7 +4723,7 @@ def assign_frequencies():
             'channel': freqs["c"][idx]
             })
 
-        logger.info('Frequency set: Node {0} Frequency {1}'.format(idx+1, freqs["f"][idx]))
+        logger.info('Frequency set: Node {0} B:{1} Ch:{2} Freq:{3}'.format(idx+1, freqs["b"][idx], freqs["c"][idx], freqs["f"][idx]))
     DB.session.commit()
 
 def emit_current_log_file_to_socket():

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -5102,11 +5102,11 @@ def recover_database(dbfile, **kwargs):
         # RSSI reduced by half for 2.0.0
         if migrate_db_api < 23:
             for profile in profiles_query_data:
-                if hasattr(profile, 'enter_ats'):
+                if hasattr(profile, 'enter_ats') and profile.enter_ats:
                     enter_ats = json.loads(profile.enter_ats)
                     enter_ats["v"] = [val/2 for val in enter_ats["v"]]
                     profile.enter_ats = json.dumps(enter_ats)
-                if hasattr(profile, 'exit_ats'):
+                if hasattr(profile, 'exit_ats') and profile.exit_ats:
                     exit_ats = json.loads(profile.exit_ats)
                     exit_ats["v"] = [val/2 for val in exit_ats["v"]]
                     profile.exit_ats = json.dumps(exit_ats)
@@ -5144,11 +5144,14 @@ def recover_database(dbfile, **kwargs):
                     if row['node_index'] == 0:
                         new_row = {}
                         new_row['id'] = row['heat_id']
-                        new_row['note'] = row['note']
-                        new_row['class_id'] = row['class_id']
+                        if 'note' in row:
+                            new_row['note'] = row['note']
+                        if 'class_id' in row:
+                            new_row['class_id'] = row['class_id']
                         heat_extracted_meta.append(new_row)
 
                 restore_table(Database.Heat, heat_extracted_meta, defaults={
+                        'note': None,
                         'class_id': Database.CLASS_ID_NONE,
                         'results': None,
                         'cacheStatus': Results.CacheStatus.INVALID
@@ -5206,9 +5209,10 @@ def recover_database(dbfile, **kwargs):
             if profiles_query_data:
                 restore_table(Database.Profiles, profiles_query_data, defaults={
                         'name': __("Migrated Profile"),
-                        'frequencies': json.dumps(default_frequencies()),
+                        'frequencies': json.dumps({'f': default_frequencies()}),
                         'enter_ats': json.dumps({'v': [None for i in range(max(RACE.num_nodes,8))]}),
-                        'exit_ats': json.dumps({'v': [None for i in range(max(RACE.num_nodes,8))]})
+                        'exit_ats': json.dumps({'v': [None for i in range(max(RACE.num_nodes,8))]}),
+                        'f_ratio': None
                     })
             else:
                 db_reset_profile()

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -5102,11 +5102,11 @@ def recover_database(dbfile, **kwargs):
         # RSSI reduced by half for 2.0.0
         if migrate_db_api < 23:
             for profile in profiles_query_data:
-                if profile.enter_ats:
+                if hasattr(profile, 'enter_ats'):
                     enter_ats = json.loads(profile.enter_ats)
                     enter_ats["v"] = [val/2 for val in enter_ats["v"]]
                     profile.enter_ats = json.dumps(enter_ats)
-                if profile.exit_ats:
+                if hasattr(profile, 'exit_ats'):
                     exit_ats = json.loads(profile.exit_ats)
                     exit_ats["v"] = [val/2 for val in exit_ats["v"]]
                     profile.exit_ats = json.dumps(exit_ats)

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -922,6 +922,8 @@ def hardware_set_all_frequencies(freqs):
         trigger_event(Evt.FREQUENCY_SET, {
             'nodeIndex': idx,
             'frequency': freqs["f"][idx],
+            'band': freqs["b"][idx],
+            'channel': freqs["c"][idx]
             })
 
 @catchLogExceptionsWrapper
@@ -4717,6 +4719,8 @@ def assign_frequencies():
         trigger_event(Evt.FREQUENCY_SET, {
             'nodeIndex': idx,
             'frequency': freqs["f"][idx],
+            'band': freqs["b"][idx],
+            'channel': freqs["c"][idx]
             })
 
         logger.info('Frequency set: Node {0} Frequency {1}'.format(idx+1, freqs["f"][idx]))

--- a/src/server/static/rotorhazard.js
+++ b/src/server/static/rotorhazard.js
@@ -1534,7 +1534,6 @@ function build_team_leaderboard(leaderboard, display_type, meta) {
 /* Frequency Table */
 var freq = {
 	frequencies: {
-		'—': 0,
 		R1: 5658,
 		R2: 5695,
 		R3: 5732,
@@ -1612,61 +1611,117 @@ var freq = {
 		S6: 5878,
 		S7: 5914,
 		S8: 5839,
-		'N/A': 'n/a'
+	},
+	getFObjbyFData: function(fData) {
+		var keyNames = Object.keys(this.frequencies);
+
+		if (fData.frequency == 0) {
+			return {
+				key: '—',
+				fString: 0,
+				band: null,
+				channel: null,
+				frequency: 0
+			}
+		}
+
+		var fKey = "" + fData.band + fData.channel;
+		if (fKey in this.frequencies) {
+			if (this.frequencies[fKey] == fData.frequency) {
+				return {
+					key: fKey,
+					fString: fKey + ':' + this.frequencies[fKey],
+					band: fData.band,
+					channel: fData.channel,
+					frequency: fData.frequency
+				}
+			}
+		}
+
+		return this.findByFreq(fData.frequency)
 	},
 	getFObjbyKey: function(key) {
 		var regex = /([A-Za-z]*)([0-9]*)/;
 		var parts = key.match(regex);
-		return {
-			key: key,
-			fString: key + ':' + this.frequencies[key],
-			band: parts[1],
-			channel: parts[2],
-			frequency: this.frequencies[key]
+		if (parts && parts.length == 3) {
+			return {
+				key: key,
+				fString: key + ':' + this.frequencies[key],
+				band: parts[1],
+				channel: parts[2],
+				frequency: this.frequencies[key]
+			}
 		}
+		return false;
 	},
 	getFObjbyFString: function(fstring) {
+		if (fstring == 0) {
+			return {
+				key: '—',
+				fString: 0,
+				band: null,
+				channel: null,
+				frequency: 0
+			}
+		}
+
+		if (fstring == "n/a") {
+			return {
+				key: __("X"),
+				fString: "n/a",
+				band: null,
+				channel: null,
+				frequency: frequency
+			}
+		}
 		var regex = /([A-Za-z]*)([0-9]*):([0-9]{4})/;
 		var parts = fstring.match(regex);
-		return {
-			key: "" + parts[1] + parts[2],
-			fString: fstring,
-			band: parts[1],
-			channel: parts[2],
-			frequency: parts[3]
+		if (parts && parts.length == 4) {
+			return {
+				key: "" + parts[1] + parts[2],
+				fString: fstring,
+				band: parts[1],
+				channel: parts[2],
+				frequency: parts[3]
+			}
 		}
+		return false;
 	},
 	findByFreq: function(frequency) {
+		if (frequency == 0) {
+			return {
+				key: '—',
+				fString: 0,
+				band: null,
+				channel: null,
+				frequency: 0
+			}
+		}
 		var keyNames = Object.keys(this.frequencies);
 		for (var i in keyNames) {
 			if (this.frequencies[keyNames[i]] == frequency) {
 				var fObj = this.getFObjbyKey(keyNames[i]);
-
-				return fObj;
+				if (fObj) return fObj;
 			}
 		}
 		return {
-			key: null,
+			key: __("X"),
 			fString: "n/a",
 			band: null,
 			channel: null,
 			frequency: frequency
-		};
+		}
 	},
 	buildSelect: function() {
-		var output = '';
+		var output = '<option value="0">' + __('Disabled') + '</option>';
 		var keyNames = Object.keys(this.frequencies);
 		for (var i in keyNames) {
-			if (this.frequencies[keyNames[i]] == 0) {
-				output += '<option value="0">' + __('Disabled') + '</option>';
-			} else if (this.frequencies[keyNames[i]] == 'n/a') {
-				output += '<option value="n/a">' + __('N/A') + '</option>';
-			} else {
-				output += '<option value="' + keyNames[i] + ':' + this.frequencies[keyNames[i]] + '">' + keyNames[i] + ' ' + this.frequencies[keyNames[i]] + '</option>';
-			}
+			output += '<option value="' + keyNames[i] + ':' + this.frequencies[keyNames[i]] + '">' + keyNames[i] + ' ' + this.frequencies[keyNames[i]] + '</option>';
 		}
+		output += '<option value="n/a">' + __('N/A') + '</option>';
 		return output;
 	},
+	/*
 	updateSelects: function() {
 		for (var i in rotorhazard.nodes) {
 			var freqExists = $('#f_table_' + i + ' option[value=' + rotorhazard.nodes[i].frequency + ']').length;
@@ -1677,16 +1732,22 @@ var freq = {
 			}
 		}
 	},
+	*/
+	updateBlock: function(fObj, node_idx) {
+		// populate channel block
+		var channelBlock = $('.channel-block[data-node="' + node_idx + '"]');
+		if (fObj.frequency == 0) {
+			channelBlock.children('.ch').html('—');
+			channelBlock.children('.fr').html('');
+		} else {
+			channelBlock.children('.ch').html(fObj.key);
+			channelBlock.children('.fr').html(fObj.frequency);
+		}
+	},
 	updateBlocks: function() {
 		// populate channel blocks
 		for (var i in rotorhazard.nodes) {
-			var channelBlock = $('.channel-block[data-node="' + i + '"]');
-			channelBlock.children('.ch').html(this.findByFreq(rotorhazard.nodes[i].frequency));
-			if (rotorhazard.nodes[i].frequency == 0) {
-				channelBlock.children('.fr').html('');
-			} else {
-				channelBlock.children('.fr').html(rotorhazard.nodes[i].frequency);
-			}
+			this.updateBlock(rotorhazard.nodes[i].fObj, i);
 		}
 	}
 }

--- a/src/server/static/rotorhazard.js
+++ b/src/server/static/rotorhazard.js
@@ -1614,14 +1614,44 @@ var freq = {
 		S8: 5839,
 		'N/A': 'n/a'
 	},
+	getFObjbyKey: function(key) {
+		var regex = /([A-Za-z]*)([0-9]*)/;
+		var parts = key.match(regex);
+		return {
+			key: key,
+			fString: key + ':' + this.frequencies[key],
+			band: parts[1],
+			channel: parts[2],
+			frequency: this.frequencies[key]
+		}
+	},
+	getFObjbyFString: function(fstring) {
+		var regex = /([A-Za-z]*)([0-9]*):([0-9]{4})/;
+		var parts = fstring.match(regex);
+		return {
+			key: "" + parts[1] + parts[2],
+			fString: fstring,
+			band: parts[1],
+			channel: parts[2],
+			frequency: parts[3]
+		}
+	},
 	findByFreq: function(frequency) {
 		var keyNames = Object.keys(this.frequencies);
 		for (var i in keyNames) {
 			if (this.frequencies[keyNames[i]] == frequency) {
-				return keyNames[i];
+				var fObj = this.getFObjbyKey(keyNames[i]);
+
+				return fObj;
 			}
 		}
-		return false;
+		return {
+			key: null,
+			fString: "n/a",
+			band: null,
+			channel: null,
+			frequency: frequency
+		};
 	},
 	buildSelect: function() {
 		var output = '';
@@ -1632,7 +1662,7 @@ var freq = {
 			} else if (this.frequencies[keyNames[i]] == 'n/a') {
 				output += '<option value="n/a">' + __('N/A') + '</option>';
 			} else {
-				output += '<option value="' + this.frequencies[keyNames[i]] + '">' + keyNames[i] + ' ' + this.frequencies[keyNames[i]] + '</option>';
+				output += '<option value="' + keyNames[i] + ':' + this.frequencies[keyNames[i]] + '">' + keyNames[i] + ' ' + this.frequencies[keyNames[i]] + '</option>';
 			}
 		}
 		return output;

--- a/src/server/templates/current.html
+++ b/src/server/templates/current.html
@@ -212,10 +212,14 @@
 		});
 
 		socket.on('frequency_data', function (msg) {
-			for (i = 0; i < msg.frequency.length; i++) {
-				$('#s_channel_' + i).val(msg.frequency[i]);
-				rotorhazard.nodes[i].frequency = msg.frequency[i];
-				freq.updateBlocks();
+			if (msg.fdata.length) {
+				for (var i in msg.fdata) {
+					var fObj = freq.getFObjbyFData(msg.fdata[i]);
+					rotorhazard.nodes[i].fObj = fObj;
+					$('#s_channel_' + i).val(fObj.frequency);
+					$('#f_table_' + i).val(fObj.fString);
+					freq.updateBlock(fObj, i);
+				}
 			}
 		});
 

--- a/src/server/templates/current.html
+++ b/src/server/templates/current.html
@@ -1,4 +1,4 @@
-{% extends "layout.html" %} {% block title %}Race{% endblock %}{% block head %}
+{% extends "layout.html" %} {% block title %}{{ __('Current') }}{% endblock %}{% block head %}
 <script type="text/javascript" charset="utf-8">
 	var data_dependencies = [
 		'all_languages',

--- a/src/server/templates/database.html
+++ b/src/server/templates/database.html
@@ -1,4 +1,4 @@
-{% extends "layout.html" %} {% block title %}Database{% endblock %} {% block content %}
+{% extends "layout.html" %} {% block title %}{{ __('Database') }}{% endblock %} {% block content %}
 <main class="page-database">
 <h2>{{ __('Pilots') }}</h2>
 <table class="table">

--- a/src/server/templates/decoder.html
+++ b/src/server/templates/decoder.html
@@ -7,7 +7,7 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<meta name="description" content="RotorHazard">
 	<meta name="google" content="notranslate">
-	<title>Decoder Settings</title>
+	<title>{{ __('Decoder Settings') }}</title>
 
 	<!-- Icons -->
 	<link rel="apple-touch-icon" sizes="180x180" href="/static/image/apple-touch-icon.png">

--- a/src/server/templates/decoder.html
+++ b/src/server/templates/decoder.html
@@ -281,11 +281,14 @@
 
 			/* Frequency Setup */
 			socket.on('frequency_data', function (msg) {
-				for (var i = 0; i < msg.frequency.length; i++) {
-					$('#s_channel_' + i).val(msg.frequency[i]);
-					rotorhazard.nodes[i].frequency = msg.frequency[i];
-					freq.updateSelects();
-					freq.updateBlocks();
+				if (msg.fdata.length) {
+					for (var i in msg.fdata) {
+						var fObj = freq.getFObjbyFData(msg.fdata[i]);
+						rotorhazard.nodes[i].fObj = fObj;
+						$('#s_channel_' + i).val(fObj.frequency);
+						$('#f_table_' + i).val(fObj.fString);
+						freq.updateBlock(fObj, i);
+					}
 				}
 			});
 
@@ -337,10 +340,23 @@
 			});
 
 			$('.frequency_table').change(function (event) {
-				if ($(this).val() != "n/a") {
-					var node = $(this).data('node');
-					var frequency = parseInt($(this).val());
-					$('#s_channel_' + node).val(frequency).trigger('change');
+				node = parseInt($(this).data('node'));
+				var fstring = $(this).val();
+				if (fstring != "n/a") {
+					// parse frequency string
+					fObj = freq.getFObjbyFString(fstring);
+
+					// update server
+					var data = {
+						node: node,
+						band: fObj.band,
+						channel: fObj.channel,
+						frequency: fObj.frequency
+					};
+					socket.emit('set_frequency', data);
+
+					// update local view
+					$('#s_channel_' + node).val(fObj.frequency);
 				}
 			});
 

--- a/src/server/templates/decoder.html
+++ b/src/server/templates/decoder.html
@@ -34,6 +34,7 @@
 	<script type="text/javascript" src="./static/socket.io-2.2.0/socket.io.min.js"></script>
 	<script type="text/javascript" src="./static/smoothie/smoothie.js"></script>
 	<script type="text/javascript" src="./static/magnific-1.1.0/magnific-inline-min.js"></script>
+	<script type="text/javascript" src="./static/svgasset.js?{{ serverInfo['release_version'] | urlencode }}"></script>
 	<script type="text/javascript" src="./static/rotorhazard.js?{{ serverInfo['release_version'] | urlencode }}"></script>
 
 	<!-- CSS -->
@@ -967,7 +968,7 @@
 	</main>
 
 	<footer>
-		<p>Powered by <a href="https://github.com/RotorHazard/RotorHazard/"><img src="../static/image/RotorHazard Logo.svg" alt="RotorHazard / FPV Race Timer" /></a> v{{ serverInfo['release_version'] }}</p>
+		<p>Powered by <a href="https://github.com/RotorHazard/RotorHazard/"><span class="rh-logo"></span></a> v{{ serverInfo['release_version'] }}</p>
 	</footer>
 </body>
 

--- a/src/server/templates/event.html
+++ b/src/server/templates/event.html
@@ -16,13 +16,20 @@
 			}
 		});
 
+		// set up node local store
+		for (var i = 0; i < {{ num_nodes }}; i++) {
+			rotorhazard.nodes[i] = new nodeModel();
+		}
+
 		socket.on('frequency_data', function (msg) {
-			for (var i in msg.frequency) {
-				if (typeof(rotorhazard.nodes[i]) === 'undefined') {
-					rotorhazard.nodes[i] = new nodeModel();
+			if (msg.fdata.length) {
+				for (var i in msg.fdata) {
+					var fObj = freq.getFObjbyFData(msg.fdata[i]);
+					rotorhazard.nodes[i].fObj = fObj;
+					$('#s_channel_' + i).val(fObj.frequency);
+					$('#f_table_' + i).val(fObj.fString);
+					freq.updateBlock(fObj, i);
 				}
-				rotorhazard.nodes[i].frequency = msg.frequency[i];
-				freq.updateBlocks();
 			}
 		});
 

--- a/src/server/templates/event.html
+++ b/src/server/templates/event.html
@@ -1,4 +1,4 @@
-{% extends "layout.html" %} {% block title %}Heats{% endblock %} {% block head %} {% endblock %} {% block content %}
+{% extends "layout.html" %} {% block title %}{{ __('Event') }}{% endblock %} {% block head %} {% endblock %} {% block content %}
 <script type="text/javascript" charset="utf-8">
 	var data_dependencies = [
 		'all_languages',

--- a/src/server/templates/hardwarelog.html
+++ b/src/server/templates/hardwarelog.html
@@ -1,4 +1,4 @@
-{% extends "layout.html" %} {% block title %}Server Log{% endblock %} {% block head %}
+{% extends "layout.html" %} {% block title %}{{ __('Server Log') }}{% endblock %} {% block head %}
 <script type="text/javascript" src="./static/Blob.js"></script>
 <script type="text/javascript" src="./static/FileSaver.min.js"></script>
 <script type="text/javascript" charset="utf-8">

--- a/src/server/templates/home.html
+++ b/src/server/templates/home.html
@@ -1,4 +1,4 @@
-{% extends "layout.html" %} {% block title %}Home{% endblock %} {% block head %} {% endblock %} {% block content %}
+{% extends "layout.html" %} {% block title %}{{ __('Home') }}{% endblock %} {% block head %} {% endblock %} {% block content %}
 <script type="text/javascript" charset="utf-8">
 	var data_dependencies = [
 		'all_languages',

--- a/src/server/templates/imdtabler.html
+++ b/src/server/templates/imdtabler.html
@@ -1,4 +1,4 @@
-{% extends "layout.html" %} {% block title %}IMDTabler{% endblock %} {% block head %} {% endblock %} {% block content %}
+{% extends "layout.html" %} {% block title %}{{ __('IMDTabler') }}{% endblock %} {% block head %} {% endblock %} {% block content %}
 <script type="text/javascript" charset="utf-8">
 	var data_dependencies = [
 		'all_languages',

--- a/src/server/templates/marshal.html
+++ b/src/server/templates/marshal.html
@@ -1,4 +1,4 @@
-{% extends "layout.html" %} {% block title %}Marshal Race Data{% endblock %}{% block head %}
+{% extends "layout.html" %} {% block title %}{{ __('Marshal Race Data') }}{% endblock %}{% block head %}
 
 <script type="text/javascript" charset="utf-8">
 	var data_dependencies = [

--- a/src/server/templates/results.html
+++ b/src/server/templates/results.html
@@ -1,4 +1,4 @@
-{% extends "layout.html" %} {% block title %}Results{% endblock %} {% block head %} {% endblock %} {% block content %}
+{% extends "layout.html" %} {% block title %}{{ __('Results') }}{% endblock %} {% block head %} {% endblock %} {% block content %}
 <script type="text/javascript" charset="utf-8">
 	var data_dependencies = [
 		'all_languages',

--- a/src/server/templates/run.html
+++ b/src/server/templates/run.html
@@ -352,10 +352,14 @@
 		});
 
 		socket.on('frequency_data', function (msg) {
-			for (i = 0; i < msg.frequency.length; i++) {
-				$('#s_channel_' + i).val(msg.frequency[i]);
-				rotorhazard.nodes[i].frequency = msg.frequency[i];
-				freq.updateBlocks();
+			if (msg.fdata.length) {
+				for (var i in msg.fdata) {
+					var fObj = freq.getFObjbyFData(msg.fdata[i]);
+					rotorhazard.nodes[i].fObj = fObj;
+					$('#s_channel_' + i).val(fObj.frequency);
+					$('#f_table_' + i).val(fObj.fString);
+					freq.updateBlock(fObj, i);
+				}
 			}
 		});
 

--- a/src/server/templates/run.html
+++ b/src/server/templates/run.html
@@ -1,4 +1,4 @@
-{% extends "layout.html" %} {% block title %}Run{% endblock %}{% block head %}
+{% extends "layout.html" %} {% block title %}{{ __('Run') }}{% endblock %}{% block head %}
 
 <script type="text/javascript" charset="utf-8">
 	var data_dependencies = [

--- a/src/server/templates/scanner.html
+++ b/src/server/templates/scanner.html
@@ -1,4 +1,4 @@
-{% extends "layout.html" %} {% block title %}Scan{% endblock %} {% block head %}
+{% extends "layout.html" %} {% block title %}{{ __('Scan') }}{% endblock %} {% block head %}
 
 <script type="text/javascript" src="./static/chart/Chart.min.js"></script>
 <script type="text/javascript" src="./static/scanner.js"></script>

--- a/src/server/templates/settings.html
+++ b/src/server/templates/settings.html
@@ -346,11 +346,14 @@
 
 		/* Frequency Setup */
 		socket.on('frequency_data', function (msg) {
-			for (var i = 0; i < msg.frequency.length; i++) {
-				$('#s_channel_' + i).val(msg.frequency[i]);
-				rotorhazard.nodes[i].frequency = msg.frequency[i];
-				freq.updateSelects();
-				freq.updateBlocks();
+			if (msg.fdata.length) {
+				for (var i in msg.fdata) {
+					var fObj = freq.getFObjbyFData(msg.fdata[i]);
+					rotorhazard.nodes[i].fObj = fObj;
+					$('#s_channel_' + i).val(fObj.frequency);
+					$('#f_table_' + i).val(fObj.fString);
+					freq.updateBlock(fObj, i);
+				}
 			}
 		});
 
@@ -557,6 +560,7 @@
 		});
 
 		$('.frequency_table').change(function (event) {
+			node = parseInt($(this).data('node'));
 			var fstring = $(this).val();
 			if (fstring != "n/a") {
 				// parse frequency string
@@ -564,7 +568,7 @@
 
 				// update server
 				var data = {
-					node: parseInt($(this).data('node')),
+					node: node,
 					band: fObj.band,
 					channel: fObj.channel,
 					frequency: fObj.frequency
@@ -572,7 +576,7 @@
 				socket.emit('set_frequency', data);
 
 				// update local view
-				$('#s_channel_' + node).val(frequency);
+				$('#s_channel_' + node).val(fObj.frequency);
 			}
 		});
 

--- a/src/server/templates/settings.html
+++ b/src/server/templates/settings.html
@@ -557,10 +557,22 @@
 		});
 
 		$('.frequency_table').change(function (event) {
-			if ($(this).val() != "n/a") {
-				var node = $(this).data('node');
-				var frequency = parseInt($(this).val());
-				$('#s_channel_' + node).val(frequency).trigger('change');
+			var fstring = $(this).val();
+			if (fstring != "n/a") {
+				// parse frequency string
+				fObj = freq.getFObjbyFString(fstring);
+
+				// update server
+				var data = {
+					node: parseInt($(this).data('node')),
+					band: fObj.band,
+					channel: fObj.channel,
+					frequency: fObj.frequency
+				};
+				socket.emit('set_frequency', data);
+
+				// update local view
+				$('#s_channel_' + node).val(frequency);
 			}
 		});
 
@@ -619,18 +631,17 @@
 
 		$('.set_frequency').change(function (event) {
 			show_imd_rating_dashes();
+
+			var fObj = freq.findByFreq($(this).val());
+			$('#f_table_' + $(this).data('node')).val(fObj.fString);
+
 			var data = {
 				node: parseInt($(this).data('node')),
-				frequency: parseInt($(this).val()),
+				band: fObj.band,
+				channel: fObj.channel,
+				frequency: fObj.frequency,
 			};
 			socket.emit('set_frequency', data);
-
-			var freqExists = $('#f_table_' + $(this).data('node') + ' option[value=' + $(this).val() + ']').length;
-			if (freqExists) {
-				$('#f_table_' + $(this).data('node')).val($(this).val());
-			} else {
-				$('#f_table_' + $(this).data('node')).val('n/a');
-			}
 		});
 
 		$('.set_enter_at_level').change(function (event) {

--- a/src/server/templates/settings.html
+++ b/src/server/templates/settings.html
@@ -1,4 +1,4 @@
-{% extends "layout.html" %} {% block title %}Settings{% endblock %} {% block head %}
+{% extends "layout.html" %} {% block title %}{{ __('Settings') }}{% endblock %} {% block head %}
 <script type="text/javascript" src="./static/Blob.js"></script>
 <script type="text/javascript" src="./static/FileSaver.min.js"></script>
 

--- a/src/server/templates/streamclass.html
+++ b/src/server/templates/streamclass.html
@@ -1,4 +1,4 @@
-{% extends "layout-basic.html" %} {% block title %}Stream: Class{% endblock %}{% block head %}
+{% extends "layout-basic.html" %} {% block title %}{{ __('Stream') }}: {{ __('Class') }}{% endblock %}{% block head %}
 <link rel="stylesheet" href="/static/stream.css?{{ serverInfo['release_version'] | urlencode }}"></link>
 
 <script type="text/javascript" charset="utf-8">

--- a/src/server/templates/streamheat.html
+++ b/src/server/templates/streamheat.html
@@ -1,4 +1,4 @@
-{% extends "layout-basic.html" %} {% block title %}Stream: Class{% endblock %}{% block head %}
+{% extends "layout-basic.html" %} {% block title %}{{ __('Stream') }}: {{ __('Heat') }}{% endblock %}{% block head %}
 <link rel="stylesheet" href="/static/stream.css?{{ serverInfo['release_version'] | urlencode }}"></link>
 
 <script type="text/javascript" charset="utf-8">

--- a/src/server/templates/streamheat.html
+++ b/src/server/templates/streamheat.html
@@ -32,12 +32,14 @@
 		});
 
 		socket.on('frequency_data', function (msg) {
-			for (var i in msg.frequency) {
-				if (typeof(rotorhazard.nodes[i]) === 'undefined') {
-					rotorhazard.nodes[i] = new nodeModel();
+			if (msg.fdata.length) {
+				for (var i in msg.fdata) {
+					var fObj = freq.getFObjbyFData(msg.fdata[i]);
+					rotorhazard.nodes[i].fObj = fObj;
+					$('#s_channel_' + i).val(fObj.frequency);
+					$('#f_table_' + i).val(fObj.fString);
+					freq.updateBlock(fObj, i);
 				}
-				rotorhazard.nodes[i].frequency = msg.frequency[i];
-				freq.updateBlocks();
 			}
 		});
 

--- a/src/server/templates/streamnode.html
+++ b/src/server/templates/streamnode.html
@@ -1,4 +1,4 @@
-{% extends "layout-basic.html" %} {% block title %}Stream: Node{% endblock %}{% block head %}
+{% extends "layout-basic.html" %} {% block title %}{{ __('Stream') }}: {{ __('Seat') }}{% endblock %}{% block head %}
 <link rel="stylesheet" href="/static/streamnode.css?{{ serverInfo['release_version'] | urlencode }}"></link>
 
 <script type="text/javascript" charset="utf-8">

--- a/src/server/templates/streamresults.html
+++ b/src/server/templates/streamresults.html
@@ -1,4 +1,4 @@
-{% extends "layout-basic.html" %} {% block title %}Stream: Current{% endblock %}{% block head %}
+{% extends "layout-basic.html" %} {% block title %}{{ __('Stream') }}: {{ __('Current') }}{% endblock %}{% block head %}
 <link rel="stylesheet" href="/static/stream.css?{{ serverInfo['release_version'] | urlencode }}"></link>
 
 <script type="text/javascript" charset="utf-8">

--- a/src/server/templates/streamresults.html
+++ b/src/server/templates/streamresults.html
@@ -5,7 +5,6 @@
 	var data_dependencies = [
 		'all_languages',
 		'language',
-		'frequency_data',
 		'pilot_data',
 		'race_format',
 		'leaderboard_cache',
@@ -152,14 +151,6 @@
 		});
 
 		socket.on('heartbeat', function (msg) {
-		});
-
-		socket.on('frequency_data', function (msg) {
-			for (i = 0; i < msg.frequency.length; i++) {
-				$('#s_channel_' + i).val(msg.frequency[i]);
-				rotorhazard.nodes[i].frequency = msg.frequency[i];
-				freq.updateBlocks();
-			}
 		});
 
 		socket.on('leaderboard', function (msg) {

--- a/src/server/templates/streams.html
+++ b/src/server/templates/streams.html
@@ -1,4 +1,4 @@
-{% extends "layout.html" %} {% block title %}Streams{% endblock %}{% block head %}
+{% extends "layout.html" %} {% block title %}{{ __('Streams') }}{% endblock %}{% block head %}
 
 <script type="text/javascript" charset="utf-8">
 	var data_dependencies = [

--- a/src/server/templates/updatenodes.html
+++ b/src/server/templates/updatenodes.html
@@ -1,4 +1,4 @@
-{% extends "layout.html" %} {% block title %}Firmware Update{% endblock %} {% block head %}
+{% extends "layout.html" %} {% block title %}{{ __('Firmware Update') }}{% endblock %} {% block head %}
 
 <script type="text/javascript" charset="utf-8">
 	var upd_msgs_text = "";

--- a/src/server/templates/viewdocs.html
+++ b/src/server/templates/viewdocs.html
@@ -1,4 +1,4 @@
-{% extends "layout.html" %} {% block title %}Docs{% endblock %} {% block head %}
+{% extends "layout.html" %} {% block title %}{{ __('Docs') }}{% endblock %} {% block head %}
 
 <script src="./static/showdown-1.9.1/showdown.min.js"></script>
 

--- a/src/server/templates/vrxstatus.html
+++ b/src/server/templates/vrxstatus.html
@@ -1,4 +1,4 @@
-{% extends "layout.html" %} {% block title %}VRx Status{% endblock %} {% block head %}
+{% extends "layout.html" %} {% block title %}{{ __('VRx Status') }}{% endblock %} {% block head %}
 <script type="text/javascript" charset="utf-8">
 	var data_dependencies = [
 		'all_languages',


### PR DESCRIPTION
Stores band and channel information in frequency objects to maintain differentiation on front-end. Avoids confusion when same frequency exists in multiple bands.

Frequency is still the primary key; band/channel info is only used if present and matches an existing defined band/channel/frequency .

Band/channel is not current sent to hardware, IMDTabler, or with LiveTime events.
RHNode.frequency is not affected.