### PR TITLE
LED fixes and general improvments

### DIFF
--- a/src/server/ClusterNodeSet.py
+++ b/src/server/ClusterNodeSet.py
@@ -438,6 +438,7 @@ class ClusterNodeSet:
         self.recEventsSecondaries = []
         self.Events = eventmanager
 
+    def init_repeater(self):
         self.Events.on(Evt.ALL, 'cluster', self.event_repeater, priority=75, unique=True)
 
     def event_repeater(self, args):

--- a/src/server/eventmanager.py
+++ b/src/server/eventmanager.py
@@ -75,7 +75,7 @@ class EventManager:
                     args['_eventName'] = event
 
                 if handler['unique']:
-                    threadName = name + monotonic()
+                    threadName = name + str(monotonic())
                 else:
                     threadName = name
 
@@ -94,8 +94,6 @@ class EventManager:
                         'name': threadName,
                         'thread': greenlet
                         }
-                    
-                logger.debug(greenlet.minimal_ident)
 
 class Evt:
     # Special

--- a/src/server/eventmanager.py
+++ b/src/server/eventmanager.py
@@ -19,7 +19,10 @@ class EventManager:
     def __init__(self):
         pass
 
-    def on(self, event, name, handlerFn, defaultArgs={}, priority=200, unique=False):
+    def on(self, event, name, handlerFn, defaultArgs=None, priority=200, unique=False):
+        if defaultArgs == None:
+            defaultArgs = {}
+
         if event not in self.events:
             self.events[event] = {}
 

--- a/src/server/led_event_manager.py
+++ b/src/server/led_event_manager.py
@@ -17,6 +17,9 @@ import gevent
 from Results import CacheStatus
 from eventmanager import Evt
 from six.moves import UserDict
+import logging
+
+logger = logging.getLogger(__name__)
 
 class LEDEventManager:
     events = {}
@@ -189,7 +192,9 @@ class LEDEventManager:
         return hexToColor(color)
 
     def activateEffect(self, args):
-        args['handlerFn'](args)
+        result = args['handlerFn'](args)
+        if result == False:
+            logger.debug('LED effect %s produced no output', args['handlerFn'])
         if 'preventIdle' not in args or not args['preventIdle']:
             if 'time' in args:
                 time = args['time']

--- a/src/server/led_event_manager.py
+++ b/src/server/led_event_manager.py
@@ -204,9 +204,9 @@ class LEDEventManager:
             if time:
                 gevent.sleep(float(time))
 
-            self.activateIdle(args)
+            self.activateIdle()
 
-    def activateIdle(self, args):
+    def activateIdle(self):
         gevent.idle()
         event = None
         if self.RACE.race_status == RHRace.RaceStatus.DONE:

--- a/src/server/led_event_manager.py
+++ b/src/server/led_event_manager.py
@@ -353,6 +353,10 @@ class LEDEvent:
             "label": "Server Shutdown"
         },
         {
+            "event": Evt.CLUSTER_JOIN,
+            "label": "Joined Timer Cluster"
+        },
+        {
             "event": IDLE_READY,
             "label": "Idle: System Ready"
         },

--- a/src/server/led_handler_character.py
+++ b/src/server/led_handler_character.py
@@ -84,7 +84,7 @@ def printCharacter(args):
     else:
         return False
 
-    if 'color' in args:
+    if 'color' in args and 'color':
         color = convertColor(args['color'])
     else:
         color = convertColor(ColorVal.WHITE)
@@ -124,7 +124,7 @@ def scrollText(args):
     else:
         return False
 
-    if 'color' in args:
+    if 'color' in args and 'color':
         color = convertColor(args['color'])
     else:
         color = convertColor(ColorVal.WHITE)

--- a/src/server/led_handler_character.py
+++ b/src/server/led_handler_character.py
@@ -84,7 +84,7 @@ def printCharacter(args):
     else:
         return False
 
-    if 'color' in args and 'color':
+    if 'color' in args and args['color']:
         color = convertColor(args['color'])
     else:
         color = convertColor(ColorVal.WHITE)
@@ -124,7 +124,7 @@ def scrollText(args):
     else:
         return False
 
-    if 'color' in args and 'color':
+    if 'color' in args and args['color']:
         color = convertColor(args['color'])
     else:
         color = convertColor(ColorVal.WHITE)

--- a/src/server/led_handler_character.py
+++ b/src/server/led_handler_character.py
@@ -326,9 +326,9 @@ def discover(*args, **kwargs):
         "Text Scroll: Message",
         scrollText, {
             'manual': False,
-            'include': [Evt.MESSAGE_INTERRUPT, Evt.MESSAGE_STANDARD, Evt.STARTUP],
+            'include': [Evt.MESSAGE_INTERRUPT, Evt.MESSAGE_STANDARD, Evt.STARTUP, Evt.CLUSTER_JOIN],
             'exclude': [Evt.ALL],
-            'recommended': [Evt.MESSAGE_INTERRUPT, Evt.MESSAGE_STANDARD, Evt.STARTUP]
+            'recommended': [Evt.MESSAGE_INTERRUPT, Evt.MESSAGE_STANDARD, Evt.STARTUP, Evt.CLUSTER_JOIN]
         }, {
         'data': 'message',
         'time': 0

--- a/src/server/led_handler_graph.py
+++ b/src/server/led_handler_graph.py
@@ -20,6 +20,9 @@ def rssiGraph(args):
     else:
         return False
 
+    if len(INTERFACE.nodes) < 1:
+        return False
+
     panel = getPanelImg(strip, Config)
 
     if panel['width'] < len(INTERFACE.nodes):

--- a/src/server/led_handler_strip.py
+++ b/src/server/led_handler_strip.py
@@ -16,7 +16,7 @@ def leaderProxy(args):
         else:
             return False
 
-        if 'meta' in result and 'primary_leaderboard' in result['meta']: 
+        if result and 'meta' in result and 'primary_leaderboard' in result['meta']: 
             leaderboard = result[result['meta']['primary_leaderboard']]
         else:
             return False

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -1563,10 +1563,10 @@ def on_shutdown_pi():
     '''Shutdown the raspberry pi.'''
     if  INTERFACE.send_shutdown_started_message():
         gevent.sleep(0.25)  # give shutdown-started message a chance to transmit to node
-    Events.trigger(Evt.SHUTDOWN)
     CLUSTER.emit('shutdown_pi')
     emit_priority_message(__('Server has shut down.'), True)
     logger.info('Performing system shutdown')
+    Events.trigger(Evt.SHUTDOWN)
     stop_background_threads()
     gevent.sleep(0.5)
     gevent.spawn(SOCKET_IO.stop)  # shut down flask http server
@@ -1583,10 +1583,10 @@ def on_shutdown_pi():
 @catchLogExceptionsWrapper
 def on_reboot_pi():
     '''Reboot the raspberry pi.'''
-    Events.trigger(Evt.SHUTDOWN)
     CLUSTER.emit('reboot_pi')
     emit_priority_message(__('Server is rebooting.'), True)
     logger.info('Performing system reboot')
+    Events.trigger(Evt.SHUTDOWN)
     stop_background_threads()
     gevent.sleep(0.5)
     gevent.spawn(SOCKET_IO.stop)  # shut down flask http server
@@ -1603,10 +1603,10 @@ def on_reboot_pi():
 @catchLogExceptionsWrapper
 def on_kill_server():
     '''Shutdown this server.'''
-    Events.trigger(Evt.SHUTDOWN)
     CLUSTER.emit('kill_server')
     emit_priority_message(__('Server has stopped.'), True)
     logger.info('Killing RotorHazard server')
+    Events.trigger(Evt.SHUTDOWN)
     stop_background_threads()
     gevent.sleep(0.5)
     gevent.spawn(SOCKET_IO.stop)  # shut down flask http server

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -4782,6 +4782,9 @@ except:
         subclass='error'
         )
 
+if CLUSTER and CLUSTER.hasRecEventsSecondaries():
+    CLUSTER.init_repeater()
+
 if RACE.num_nodes > 0:
     logger.info('Number of nodes found: {0}'.format(RACE.num_nodes))
     # if I2C nodes then only report comm errors if > 1.0%

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -741,7 +741,10 @@ def on_cluster_event_trigger(data):
             RACE.race_status = RaceStatus.STAGING
             RACE.results = None
             if led_manager.isEnabled():
-                led_manager.setDisplayColorCache(evtArgs['race_node_colors'])
+                if 'race_node_colors' in evtArgs and isinstance(evtArgs['race_node_colors'], list):
+                    led_manager.setDisplayColorCache(evtArgs['race_node_colors'])
+                else:
+                    RHData.set_option('ledColorMode', 0)
         elif evtName == Evt.RACE_START:
             RACE.race_status = RaceStatus.RACING
         elif evtName == Evt.RACE_STOP:
@@ -1962,9 +1965,11 @@ def on_stage_race():
             'pi_starts_at_s': RACE.start_time_monotonic,
             'color': ColorVal.ORANGE,
         }
-        
+
         if led_manager.isEnabled():
-            eventPayload['race_node_colors'] = led_manager.getNodeColors(RACE.num_nodes) 
+            eventPayload['race_node_colors'] = led_manager.getNodeColors(RACE.num_nodes)
+        else: 
+            eventPayload['race_node_colors'] = None
 
         Events.trigger(Evt.RACE_STAGE, eventPayload)
 

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -760,7 +760,7 @@ def on_cluster_event_trigger(data):
 
     evtArgs.pop('RACE', None) # remove race if exists
 
-    if evtName != Evt.LED_SET_MANUAL:
+    if evtName not in [Evt.STARTUP, Evt.LED_SET_MANUAL]:
         Events.trigger(evtName, evtArgs)
     # special handling for LED Control via primary timer
     elif 'effect' in evtArgs and led_manager.isEnabled():

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -702,7 +702,9 @@ def on_join_cluster():
     setCurrentRaceFormat(SECONDARY_RACE_FORMAT)
     emit_race_format()
     logger.info("Joined cluster")
-    Events.trigger(Evt.CLUSTER_JOIN)
+    Events.trigger(Evt.CLUSTER_JOIN, {
+                'message': __('Joined cluster')
+                })
 
 @SOCKET_IO.on('join_cluster_ex')
 @catchLogExceptionsWrapper
@@ -715,7 +717,9 @@ def on_join_cluster_ex(data=None):
     if tmode == SecondaryNode.MIRROR_MODE:
         Server_is_mirror = True
     logger.info("Joined cluster" + ((" as '" + tmode + "' timer") if tmode else ""))
-    Events.trigger(Evt.CLUSTER_JOIN)
+    Events.trigger(Evt.CLUSTER_JOIN, {
+                'message': __('Joined cluster')
+                })
     emit_join_cluster_response()
 
 @SOCKET_IO.on('check_secondary_query')


### PR DESCRIPTION
Fix issues uncovered when primary timer has LEDs off but mirror has LEDs on.

* Allow effect assignment to cluster join
* Fix empty effect colors
* Improve checks for invalid color
* Fix graph when nodes = 0
* Fix results effects when no results exist yet
* Fix simultaneous effect triggering
* Prevent mirroring events unless needed
* Prevent mirroring server's startup
* Improve logging
* Move shutdown event trigger after sending shutdown message
* Cleanup unused arguments, potential default argument problem