### PR TITLE
Update Software Setup.md

### DIFF
--- a/doc/Software Setup.md
+++ b/doc/Software Setup.md
@@ -294,8 +294,9 @@ sudo iptables -A PREROUTING -t nat -p tcp --dport 8080 -j REDIRECT --to-ports 80
 sudo iptables-save
 sudo apt-get install iptables-persistent
 ```
-After running these commands, RotorHazard will be available from both ports 80 and 5000. When available by port 80, you may leave the port off when accessing the server: `http://127.0.0.1`
-Note: Services that would be normally available on default port 80, now will be available on port 8080.
+After running these commands, RotorHazard will be available from both ports 80 and 5000. When available by port 80, you may leave the port off when accessing the server, i.e.: `http://127.0.0.1`
+
+Note: The second *iptables* command will forward port 8080 to 80, so services that would normally be available on port 80 will instead be available on port 8080. If port 80 services are not present or if other services are using port 8080, this *iptables* command may be omitted.
 <br/>
 
 ----------------------------------------------------------------------------

--- a/doc/Software Setup.md
+++ b/doc/Software Setup.md
@@ -295,6 +295,7 @@ sudo iptables-save
 sudo apt-get install iptables-persistent
 ```
 After running these commands, RotorHazard will be available from both ports 80 and 5000. When available by port 80, you may leave the port off when accessing the server: `http://127.0.0.1`
+Note: Services that would be normally available on default port 80, now will be available on port 8080.
 <br/>
 
 ----------------------------------------------------------------------------

--- a/doc/Software Setup.md
+++ b/doc/Software Setup.md
@@ -290,6 +290,7 @@ By default, HTTP uses port 80. Other values will require that the port be includ
 
 ```
 sudo iptables -A PREROUTING -t nat -p tcp --dport 80 -j REDIRECT --to-ports 5000
+sudo iptables -A PREROUTING -t nat -p tcp --dport 8080 -j REDIRECT --to-ports 80
 sudo iptables-save
 sudo apt-get install iptables-persistent
 ```


### PR DESCRIPTION
Port 8080 added as a fallback port for services previously available on port 80, so user still reach them.
Helpful for example when RaspAP as an AccessPoint manager is being used and admin page is available
on port 80 normally.