### PR TITLE
Add 'Lap order reversed' display setting

### DIFF
--- a/src/server/server.py
+++ b/src/server/server.py
@@ -3167,18 +3167,18 @@ def emit_race_formats(**params):
 
 def build_laps_list(active_race=RACE):
     current_laps = []
-    for node in range(active_race.num_nodes):
+    for node_idx in range(active_race.num_nodes):
         node_laps = []
         fastest_lap_time = float("inf")
         fastest_lap_index = None
         last_lap_id = -1
-        for idx, lap in enumerate(active_race.node_laps[node]):
+        for idx, lap in enumerate(active_race.node_laps[node_idx]):
             if (not lap['deleted']) or lap.get('late_lap', False):
                 if not lap.get('late_lap', False):
                     last_lap_id = lap_number = lap['lap_number']
                     if active_race.format and active_race.format.start_behavior == StartBehavior.FIRST_LAP:
                         lap_number += 1
-                    splits = get_splits(node, lap['lap_number'], True)
+                    splits = get_splits(node_idx, lap['lap_number'], True)
                     if lap['lap_time'] > 0 and idx > 0 and lap['lap_time'] < fastest_lap_time:
                         fastest_lap_time = lap['lap_time']
                         fastest_lap_index = idx
@@ -3196,7 +3196,7 @@ def build_laps_list(active_race=RACE):
                     'late_lap': lap.get('late_lap', False)
                 })
 
-        splits = get_splits(node, last_lap_id+1, False)
+        splits = get_splits(node_idx, last_lap_id+1, False)
         if splits:
             node_laps.append({
                 'lap_number': last_lap_id+1,
@@ -3205,8 +3205,8 @@ def build_laps_list(active_race=RACE):
                 'splits': splits
             })
 
-        if len(active_race.node_pilots) and active_race.node_pilots[node]:
-            pilot = RHData.get_pilot(active_race.node_pilots[node])
+        if len(active_race.node_pilots) and active_race.node_pilots[node_idx]:
+            pilot = RHData.get_pilot(active_race.node_pilots[node_idx])
             pilot_data = {
                 'id': pilot.id,
                 'name': pilot.name,
@@ -3218,7 +3218,8 @@ def build_laps_list(active_race=RACE):
         current_laps.append({
             'laps': node_laps,
             'fastest_lap_index': fastest_lap_index,
-            'pilot': pilot_data
+            'pilot': pilot_data,
+            'finished_flag': active_race.get_node_finished_flag(node_idx)
         })
     current_laps = {
         'node_index': current_laps
@@ -3240,12 +3241,12 @@ def emit_current_laps(**params):
     else:
         SOCKET_IO.emit('current_laps', emit_payload)
 
-def get_splits(node, lap_id, lapCompleted):
+def get_splits(node_idx, lap_id, lapCompleted):
     splits = []
     if CLUSTER:
         for secondary_index in range(len(CLUSTER.secondaries)):
             if CLUSTER.isSplitSecondaryAvailable(secondary_index):
-                split = RHData.get_lapSplit_by_params(node, lap_id, secondary_index)
+                split = RHData.get_lapSplit_by_params(node_idx, lap_id, secondary_index)
                 if split:
                     split_payload = {
                         'split_id': secondary_index,
@@ -4123,7 +4124,10 @@ def pass_record_callback(node, lap_timestamp_absolute, source):
                                                pilot_namestr))
                             if min_lap_behavior != 0:  # if behavior is 'Discard New Short Laps'
                                 lap_ok_flag = False
-                        elif RACE.win_status == WinStatus.DECLARED and (RACE.format.team_racing_mode or \
+
+                    if lap_ok_flag:
+
+                        if RACE.win_status == WinStatus.DECLARED and (RACE.format.team_racing_mode or \
                                                                         node_finished_flag):
                             lap_late_flag = True  # "late" lap pass (after race winner declared)
                             if RACE.format.team_racing_mode and pilot_obj:
@@ -4133,8 +4137,6 @@ def pass_record_callback(node, lap_timestamp_absolute, source):
                             logger.info('Ignoring lap after race winner declared: Node={}, lap={}, lapTime={}, sinceStart={}, source={}, pilot: {}{}' \
                                        .format(node.index+1, lap_number, lap_time_fmtstr, lap_ts_fmtstr, \
                                                INTERFACE.get_lap_source_str(source), pilot_namestr, t_str))
-
-                    if lap_ok_flag:
 
                         if logger.getEffectiveLevel() <= logging.DEBUG:  # if DEBUG msgs actually being logged
                             late_str = " (late lap)" if lap_late_flag else ""
@@ -4264,19 +4266,23 @@ def check_win_condition(**kwargs):
 
         if win_status_dict['status'] == WinStatus.DECLARED:
             # announce winner
+            win_data = win_status_dict['data']
             if race_format.team_racing_mode:
-                win_str = win_status_dict['data']['name']
+                win_str = win_data.get('name', '')
                 status_msg_str = __('Winner is') + ' ' + __('Team') + ' ' + win_str
                 log_msg_str = "Race status msg:  Winner is Team " + win_str
                 phonetic_str = status_msg_str
             else:
-                win_str = win_status_dict['data']['callsign']
+                win_str = win_data.get('callsign', '')
                 status_msg_str = __('Winner is') + ' ' + win_str
                 log_msg_str = "Race status msg:  Winner is " + win_str
-                win_phon_name = RHData.get_pilot(win_status_dict['data']['pilot_id']).phonetic
-                if len(win_phon_name) <= 0:  # if no phonetic then use callsign
-                    win_phon_name = win_status_dict['data']['callsign']
+                win_phon_name = RHData.get_pilot(win_data['pilot_id']).phonetic \
+                                if 'pilot_id' in win_data else None
+                if (not win_phon_name) or len(win_phon_name) <= 0:  # if no phonetic then use callsign
+                    win_phon_name = win_data.get('callsign', '')
                 phonetic_str = __('Winner is') + ' ' + win_phon_name
+                if 'node' in win_data:  # make sure winner node race status always set to 'finished'
+                    RACE.set_node_finished_flag(win_data['node'])
 
             # if racer lap was deleted then only output if win-status details changed
             if (not del_lap_flag) or RACE.win_status != previous_win_status or \
@@ -4287,8 +4293,9 @@ def check_win_condition(**kwargs):
                 Events.trigger(Evt.RACE_WIN, {
                     'win_status': win_status_dict,
                     'message': RACE.status_message,
-                    'node_index': win_status_dict['data']['node'] if 'node' in win_status_dict['data'] else None,
-                    'color': led_manager.getDisplayColor(win_status_dict['data']['node']) if 'node' in win_status_dict['data'] else None,
+                    'node_index': win_data.get('node', None),
+                    'color': led_manager.getDisplayColor(win_data['node']) \
+                                            if 'node' in win_data else None,
                     'results': RACE.results
                     })
 

--- a/src/server/static/rotorhazard.js
+++ b/src/server/static/rotorhazard.js
@@ -972,6 +972,7 @@ var rotorhazard = {
 	display_lap_id: false, //enables the display of the lap id
 	display_time_start: false, //shows the timestamp of the lap since the race was started
 	display_time_first_pass: false, //shows the timestamp of the lap since the first pass was recorded
+	display_laps_reversed: false, //shows race laps in reverse order
 
 	min_lap: 0, // minimum lap time
 	admin: false, // whether to show admin options in nav
@@ -1032,6 +1033,7 @@ var rotorhazard = {
 		localStorage['rotorhazard.display_lap_id'] = JSON.stringify(this.display_lap_id);
 		localStorage['rotorhazard.display_time_start'] = JSON.stringify(this.display_time_start);
 		localStorage['rotorhazard.display_time_first_pass'] = JSON.stringify(this.display_time_first_pass);
+		localStorage['rotorhazard.display_laps_reversed'] = JSON.stringify(this.display_laps_reversed);
 		return true;
 	},
 	restoreData: function(dataType) {
@@ -1125,6 +1127,9 @@ var rotorhazard = {
 			}
 			if (localStorage['rotorhazard.display_time_first_pass']) {
 				this.display_time_first_pass = JSON.parse(localStorage['rotorhazard.display_time_first_pass']);
+			}
+			if (localStorage['rotorhazard.display_laps_reversed']) {
+				this.display_laps_reversed = JSON.parse(localStorage['rotorhazard.display_laps_reversed']);
 			}
 			return true;
 		}

--- a/src/server/templates/current.html
+++ b/src/server/templates/current.html
@@ -117,6 +117,9 @@
 			rotorhazard.nodes[i] = new nodeModel();
 		}
 
+		var current_laps = {};
+		var current_laps_reversed = false;
+
 		// populate voice controls
 		$('#voice-calls').val(parseInt(rotorhazard.primaryPilot));
 
@@ -139,6 +142,7 @@
 		$('#display_lap_id').prop("checked", rotorhazard.display_lap_id);
 		$('#display_time_start').prop("checked", rotorhazard.display_time_start);
 		$('#display_time_first_pass').prop("checked", rotorhazard.display_time_first_pass);
+		$('#display_laps_reversed').prop("checked", rotorhazard.display_laps_reversed);
 		$('#beep_race_leader_lap').prop("checked", rotorhazard.beep_race_leader_lap);
 		$('#beep_race_winner_declared').prop("checked", rotorhazard.beep_race_winner_declared);
 		$('#use_mp3_tones').prop("checked", rotorhazard.use_mp3_tones);
@@ -235,71 +239,131 @@
 		});
 
 		function show_current_laps() {
-			$.each(current_laps.node_index, function (i, node_index) { // i is loop num, node_index is json object
-				$('#recent .callsign_' + i).html(node_index.pilot && 'callsign' in node_index.pilot ? node_index.pilot.callsign : __('-None-'));
+			$.each(current_laps.node_index, function (i, curnode_data) { // i is loop num, curnode_data is json object
+				$('#recent .callsign_' + i).html(curnode_data.pilot && 'callsign' in curnode_data.pilot ? curnode_data.pilot.callsign : __('-None-'));
 				$('#current_laps_' + i + ' tbody > tr').remove();
 
-				$.each(node_index.laps, function (j, lap) { // j is loop num, lap is json object
-					var $tr = $('<tr>');
-					var lap_num = lap.lap_number;
-					if (lap_num == 0) {
-						$tr.addClass('lap_0');
+				if(rotorhazard.display_laps_reversed) {
+					if(!current_laps_reversed) {
+						curnode_data.laps.reverse();
 					}
+				}
+				else if(current_laps_reversed) {
+					curnode_data.laps.reverse();
+				}
 
-					var local_colspan = 2;
-					if(rotorhazard.display_lap_id) {
-						local_colspan = 1;
-						if(lap_num < 0) {
-							lap_num = ' ';
-						}
-						$tr.append(
-							$('<td class="display_lap_number">').text(lap_num)
-						);
-					}
-					$time_td = $('<td colspan="'+local_colspan+'">').text(lap.lap_time + ' ');
-					$local_prepend = $('<span class="from_start">');
-
-					if(rotorhazard.display_time_first_pass) {
-						$local_prepend.text(formatTimeMillis(lap.lap_time_stamp - node_index.laps[0].lap_time_stamp, {{ getOption('timeFormat')|tojson }}));
-						if(rotorhazard.display_time_start){
-							$local_prepend.append(" / ");
-						}
-					}
-
-					if(rotorhazard.display_time_start){
-						$local_prepend.append(formatTimeMillis(lap.lap_time_stamp, {{ getOption('timeFormat')|tojson }}));
-					}
-					$time_td.prepend($local_prepend);
-					$tr.append($time_td);
-
-					if (j && lap.lap_raw < (rotorhazard.min_lap * 1000)) {
-						$tr.addClass('min-lap-warning');
-					}
-					if (!rotorhazard.race_formats.race_mode && lap.lap_time_stamp > (rotorhazard.race_formats.race_time_sec * 1000)) {
-						$tr.addClass('after-time-expired');
-					}
-					$tr.appendTo('#current_laps_' + i);
-
-					$.each(lap.splits, function(k, split) {
-						var split_display = split.split_time + ' ';
-						if (split.split_speed) {
-							split_display += '(' + split.split_speed + ')';
-						}
-						var split_tr = $('<tr>');
-						split_tr.addClass('lap_split');
-						if (rotorhazard.display_lap_id) {
-							var split_id = 'split ';
-							if (lap.splits.length > 1) {
-								split_id += (k+1);
+				$.each(curnode_data.laps, function (j, lap) { // j is loop num, lap is json object
+					if(!lap.late_lap) {
+						if(lap.splits) {
+							if(rotorhazard.display_laps_reversed) {
+								if(!current_laps_reversed && lap.splits.length > 1) {
+									lap.splits.laps.reverse();
+								}
+								$.each(lap.splits, function(k, split) {
+									if (j > 0 || (split.split_time && split.split_time != '-') ||
+													split.split_speed) {  // don't show last split if empty
+										var split_display = split.split_time + ' ';
+										if (split.split_speed) {
+											split_display += '(' + split.split_speed + ')';
+										}
+										var split_tr = $('<tr>');
+										split_tr.addClass('lap_split');
+										if (rotorhazard.display_lap_id) {
+											var split_id = 'split ';
+											if (lap.splits.length > 1) {
+												split_id += (k+1);
+											}
+											split_tr.append($('<td>').text(split_id));
+										}
+										var split_time_td = $('<td colspan="'+local_colspan+'">').text(split_display);
+										split_tr.append(split_time_td);
+										split_tr.appendTo('#current_laps_' + i);
+									}
+								});
 							}
-							split_tr.append($('<td>').text(split_id));
+							else if(current_laps_reversed && lap.splits.length > 1) {
+								lap.splits.laps.reverse();
+							}
 						}
-						var split_time_td = $('<td colspan="'+local_colspan+'">').text(split_display);
-						split_tr.append(split_time_td);
-						split_tr.appendTo('#current_laps_' + i);
-					});
+	
+						var $tr = $('<tr>');
+						var lap_num = lap.lap_number;
+						if (lap_num == 0) {
+							$tr.addClass('lap_0');
+						}
+	
+						var local_colspan = 2;
+						if(rotorhazard.display_lap_id) {
+							local_colspan = 1;
+							if(lap_num < 0) {
+								lap_num = ' ';
+							}
+							$tr.append(
+								$('<td class="display_lap_number">').text(lap_num)
+							);
+						}
+						$time_td = $('<td colspan="'+local_colspan+'">').text(lap.lap_time + ' ');
+						$local_prepend = $('<span class="from_start">');
+	
+						if(rotorhazard.display_time_first_pass) {
+							if(rotorhazard.display_laps_reversed) {
+								if(curnode_data.laps.length > 0) {
+									ts_val = lap.lap_time_stamp - curnode_data.laps[curnode_data.laps.length-1].lap_time_stamp;
+								}
+								else {
+									ts_val = 0;
+								}
+							}
+							else {
+								ts_val = lap.lap_time_stamp - curnode_data.laps[0].lap_time_stamp;
+							}
+							$local_prepend.text(formatTimeMillis(ts_val, {{ getOption('timeFormat')|tojson }}));
+							if(rotorhazard.display_time_start){
+								$local_prepend.append(" / ");
+							}
+						}
+	
+						if(rotorhazard.display_time_start){
+							$local_prepend.append(formatTimeMillis(lap.lap_time_stamp, {{ getOption('timeFormat')|tojson }}));
+						}
+						$time_td.prepend($local_prepend);
+						$tr.append($time_td);
+	
+						if (lap.lap_number && lap.lap_raw < (rotorhazard.min_lap * 1000)) {
+							$tr.addClass('min-lap-warning');
+						}
+						if (!rotorhazard.race_formats.race_mode && lap.lap_time_stamp > (rotorhazard.race_formats.race_time_sec * 1000)) {
+							$tr.addClass('after-time-expired');
+						}
+						$tr.appendTo('#current_laps_' + i);
+	
+						if(!rotorhazard.display_laps_reversed) {
+							$.each(lap.splits, function(k, split) {
+								if (j < curnode_data.laps.length-1 || (split.split_time && split.split_time != '-') ||
+																	split.split_speed) {  // don't show last split if empty
+									var split_display = split.split_time + ' ';
+									if (split.split_speed) {
+										split_display += '(' + split.split_speed + ')';
+									}
+									var split_tr = $('<tr>');
+									split_tr.addClass('lap_split');
+									if (rotorhazard.display_lap_id) {
+										var split_id = 'split ';
+										if (lap.splits.length > 1) {
+											split_id += (k+1);
+										}
+										split_tr.append($('<td>').text(split_id));
+									}
+									var split_time_td = $('<td colspan="'+local_colspan+'">').text(split_display);
+									split_tr.append(split_time_td);
+									split_tr.appendTo('#current_laps_' + i);
+								}
+							});
+						}
+					}
 				});
 			});
+			current_laps_reversed = rotorhazard.display_laps_reversed;
 		}
 
 		socket.on('leaderboard', function (msg) {
@@ -561,6 +625,12 @@
 			show_current_laps();
 		});
 
+		$('#display_laps_reversed').change(function (event) {
+			rotorhazard.display_laps_reversed = $(this).prop('checked');
+			rotorhazard.saveData();
+			show_current_laps();
+		});
+
 		socket.on('race_format', function (msg) {
 			rotorhazard.race_formats = msg;
 		});
@@ -789,9 +859,10 @@
 					{{ __('Lap Information') }}
 				</div>
 				<ul>
-					<li><label><input type="checkbox" id="display_lap_id"> {{ __('Lap Number') }}</label></li>
+					<li><label><input type="checkbox" id="display_lap_id"> {{ __('Lap number') }}</label></li>
 					<li><label><input type="checkbox" id="display_time_start"> {{ __('Time since start') }}</label></li>
 					<li><label><input type="checkbox" id="display_time_first_pass"> {{ __('Time since first pass') }}</label></li>
+					<li><label><input type="checkbox" id="display_laps_reversed"> {{ __('Lap order reversed') }}</label></li>
 				</ul>
 			</li>
 		</ol>

--- a/src/server/templates/run.html
+++ b/src/server/templates/run.html
@@ -127,6 +127,7 @@
 
 		var heartbeatCounter = 0;
 		var current_laps = {};
+		var current_laps_reversed = false;
 
 		// set admin flag
 		rotorhazard.admin = true;
@@ -167,6 +168,7 @@
 		$('#display_lap_id').prop("checked", rotorhazard.display_lap_id);
 		$('#display_time_start').prop("checked", rotorhazard.display_time_start);
 		$('#display_time_first_pass').prop("checked", rotorhazard.display_time_first_pass);
+		$('#display_laps_reversed').prop("checked", rotorhazard.display_laps_reversed);
 
 		if ('{{ getOption('ledBrightness') }}' != 'False') {
 			$('#set_led_brightness').val(brightness_logsl.position( {{ getOption('ledBrightness') }} ));
@@ -490,14 +492,58 @@
 
 		socket.on('current_laps', function (msg) {
 			current_laps = msg.current;
+			current_laps_reversed = false;
 			show_current_laps();
 		});
 
 		function show_current_laps() {
-			$.each(current_laps.node_index, function (i, node_index) { // i is loop num, node_index is json object
+			$.each(current_laps.node_index, function (i, curnode_data) { // i is loop num, curnode_data is json object
 				$('#current_laps_' + i + ' tbody > tr').remove();
 
-				$.each(node_index.laps, function (j, lap) { // j is loop num, lap_id is json object
+				if(rotorhazard.display_laps_reversed) {
+					if(!current_laps_reversed) {
+						curnode_data.laps.reverse();
+					}
+				}
+				else if(current_laps_reversed) {
+					curnode_data.laps.reverse();
+				}
+
+				$.each(curnode_data.laps, function (j, lap) { // j is loop num, lap_id is json object
+					if(lap.splits) {
+						if(rotorhazard.display_laps_reversed) {
+							if(!current_laps_reversed && lap.splits.length > 1) {
+								lap.splits.laps.reverse();
+							}
+							$.each(lap.splits, function(k, split) {
+								if ((!curnode_data.finished_flag) || j > 0 ||
+												(split.split_time && split.split_time != '-') ||
+												split.split_speed) {  // don't show last split if empty and pilot finished
+									var split_display = split.split_time + ' ';
+									if (split.split_speed) {
+										split_display += '(' + split.split_speed + ')';
+									}
+									var split_tr = $('<tr>');
+									split_tr.addClass('lap_split');
+									if (rotorhazard.display_lap_id) {
+										var split_id = 'split ';
+										if (lap.splits.length > 1) {
+											split_id += (k+1);
+										}
+										split_tr.append($('<td>').text(split_id));
+									}
+									var split_time_td = $('<td colspan="'+local_colspan+'">').text(split_display);
+									split_tr.append(split_time_td);
+									split_tr.appendTo('#current_laps_' + i);
+								}
+							});
+						}
+						else if(current_laps_reversed && lap.splits.length > 1) {
+							lap.splits.laps.reverse();
+						}
+					}
+
+
 					var tr = $('<tr>');
 					var lap_num = lap.lap_number;
 					if (lap_num == 0) {
@@ -524,7 +570,18 @@
 					local_prepend = $('<span class="from_start">');
 
 					if(rotorhazard.display_time_first_pass) {
-						local_prepend.text(formatTimeMillis(lap.lap_time_stamp - node_index.laps[0].lap_time_stamp, {{ getOption('timeFormat')|tojson }}));
+						if(rotorhazard.display_laps_reversed) {
+							if(curnode_data.laps.length > 0) {
+								ts_val = lap.lap_time_stamp - curnode_data.laps[curnode_data.laps.length-1].lap_time_stamp;
+							}
+							else {
+								ts_val = 0;
+							}
+						}
+						else {
+							ts_val = lap.lap_time_stamp - curnode_data.laps[0].lap_time_stamp;
+						}
+						local_prepend.text(formatTimeMillis(ts_val, {{ getOption('timeFormat')|tojson }}));
 						if(rotorhazard.display_time_start){
 							local_prepend.append(" / ");
 						}
@@ -545,26 +602,33 @@
 					}
 					tr.appendTo('#current_laps_' + i);
 
-					$.each(lap.splits, function(k, split) {
-						var split_display = split.split_time + ' ';
-						if (split.split_speed) {
-							split_display += '(' + split.split_speed + ')';
-						}
-						var split_tr = $('<tr>');
-						split_tr.addClass('lap_split');
-						if (rotorhazard.display_lap_id) {
-							var split_id = 'split ';
-							if (lap.splits.length > 1) {
-								split_id += (k+1);
+					if(!rotorhazard.display_laps_reversed) {
+						$.each(lap.splits, function(k, split) {
+							if ((!curnode_data.finished_flag) || j < curnode_data.laps.length-1 ||
+													(split.split_time && split.split_time != '-') ||
+													split.split_speed) {  // don't show last split if empty and pilot finished
+								var split_display = split.split_time + ' ';
+								if (split.split_speed) {
+									split_display += '(' + split.split_speed + ')';
+								}
+								var split_tr = $('<tr>');
+								split_tr.addClass('lap_split');
+								if (rotorhazard.display_lap_id) {
+									var split_id = 'split ';
+									if (lap.splits.length > 1) {
+										split_id += (k+1);
+									}
+									split_tr.append($('<td>').text(split_id));
+								}
+								var split_time_td = $('<td colspan="'+local_colspan+'">').text(split_display);
+								split_tr.append(split_time_td);
+								split_tr.appendTo('#current_laps_' + i);
 							}
-							split_tr.append($('<td>').text(split_id));
-						}
-						var split_time_td = $('<td colspan="'+local_colspan+'">').text(split_display);
-						split_tr.append(split_time_td);
-						split_tr.appendTo('#current_laps_' + i);
-					});
+						});
+					}
 				});
 			});
+			current_laps_reversed = rotorhazard.display_laps_reversed;
 		}
 
 		socket.on('leaderboard', function (msg) {
@@ -1088,6 +1152,12 @@
 
 		$('#display_time_first_pass').change(function (event) {
 			rotorhazard.display_time_first_pass = $(this).prop('checked');
+			rotorhazard.saveData();
+			show_current_laps();
+		});
+
+		$('#display_laps_reversed').change(function (event) {
+			rotorhazard.display_laps_reversed = $(this).prop('checked');
 			rotorhazard.saveData();
 			show_current_laps();
 		});
@@ -2259,9 +2329,10 @@
 					{{ __('Lap Information') }}
 				</div>
 				<ul>
-					<li><label><input type="checkbox" id="display_lap_id"> {{ __('Lap Number') }}</label></li>
+					<li><label><input type="checkbox" id="display_lap_id"> {{ __('Lap number') }}</label></li>
 					<li><label><input type="checkbox" id="display_time_start"> {{ __('Time since start') }}</label></li>
 					<li><label><input type="checkbox" id="display_time_first_pass"> {{ __('Time since first pass') }}</label></li>
+					<li><label><input type="checkbox" id="display_laps_reversed"> {{ __('Lap order reversed') }}</label></li>
 				</ul>
 			</li>
 


### PR DESCRIPTION
Adds 'Lap order reversed' display setting checkbox to 'Run' and 'Current' pages

Also:
  Don't show "late" laps on 'Current' page
  On 'Current' page: Don't show final split-lap entry if empty
  On 'Run' page: Don't show final split-lap entry if empty and pilot finished