### PR TITLE
Read / Verify Frequency Register following Freq Write

### DIFF
--- a/src/node/RssiNode.cpp
+++ b/src/node/RssiNode.cpp
@@ -1,6 +1,8 @@
 #include "config.h"
 #include "RssiNode.h"
 
+#define TSPI 10 //uS
+
 RssiNode RssiNode::rssiNodeArray[MULTI_RHNODE_MAX];
 uint8_t RssiNode::multiRssiNodeCount = 1;
 mtime_t RssiNode::lastRX5808BusTimeMs = 0;
@@ -76,6 +78,7 @@ void RssiNode::setRxModuleToFreq(uint16_t vtxFreq)
 
     // Get the hex value to send to the rx module
     uint16_t vtxHex = freqMhzToRegVal(vtxFreq);
+    uint16_t vtxHexSent = vtxHex; // keep vtxHex in vtxHexSent for reg read operation
 
     // Channel data from the lookup table, 20 bytes of register data are sent, but the
     // MSB 4 bits are zeros register address = 0x1, write, data0-15=vtxHex data15-19=0x0
@@ -112,6 +115,55 @@ void RssiNode::setRxModuleToFreq(uint16_t vtxFreq)
 
     digitalWrite(rx5808ClkPin, LOW);
     digitalWrite(rx5808DataPin, LOW);
+
+    // Start of Read Reg code :    
+    // Verify read HEX value in RX5808 module Frequency Register 0x01
+    uint16_t vtxHexVerify=0;
+    //  Modified copy of packet code in setRxModuleToFreq(), to read Register 0x01
+    //  20 bytes of register data are read, but the
+    //  MSB 4 bits are zeros
+    //  Data Packet is: register address (4-bits) = 0x1, read/write bit = 1 for read, data D0-D15 stored in vtxHexVerify, data15-19=0x0
+
+    delay(20); // IMPORTANT: Delay time for RX5808 VCOs and circuitry to settle after writing freq and before reading register 0x01 (20ms is optimal, can be longer but not shorter). Erroneous results will occur if delay is too short
+
+    rx5808SerialEnableHigh();
+    rx5808SerialEnableLow();
+
+    rx5808SerialSendBit1();  // Register 0x1
+    rx5808SerialSendBit0();
+    rx5808SerialSendBit0();
+    rx5808SerialSendBit0();
+
+    rx5808SerialSendBit0();  // Read register r/w
+    
+    //receive data D0-D15, and ignore D16-D19
+    pinMode(rx5808DataPin, INPUT_PULLUP);
+    for(i = 0; i < 20; i++){
+      delayMicroseconds(TSPI);
+      // only use D0-D15, ignore D16-D19
+      if (i < 16) {
+      if (digitalRead(rx5808DataPin)) {
+        bitWrite(vtxHexVerify,i,1);
+      }
+      else bitWrite(vtxHexVerify,i,0);       
+      }
+      if (i >= 16) digitalRead(rx5808DataPin);
+      digitalWrite(rx5808ClkPin,HIGH);
+      delayMicroseconds(TSPI);
+      digitalWrite(rx5808ClkPin,LOW);
+      delayMicroseconds(TSPI);
+    }
+ 
+    pinMode(rx5808DataPin, OUTPUT); // return status of Data pin after INPUT_PULLUP above
+    rx5808SerialEnableHigh();  // Finished clocking data in
+    delay(2);
+
+    digitalWrite(rx5808ClkPin, LOW);
+    digitalWrite(rx5808DataPin, LOW);    
+    
+    if (vtxHexVerify != vtxHexSent) {} // action to take if verify has failed (currently blank)
+    // vtxHexVerify contains the Register data read from Reg 0x01
+    // End of Read Reg Code
 
     recentSetFreqFlag = true;  // indicate need to wait RX5808_MIN_TUNETIME before reading RSSI
     lastRX5808BusTimeMs = lastSetFreqTimeMs = millis();  // mark time of last tune of RX5808 to freq


### PR DESCRIPTION
This PR includes some code to read the Freq Register 0x01 after a write frequency command.

The code is inserted towards the end of RssiNode.cpp's function : setRxModuleToFreq(uint16_t vtxFreq)

This code provides the value in Register #1 (stored in vtxHexVerify) following the Write Freq code. 

vtxHexVerify contains the Register data read from Reg 0x01, which can be compared with the original vrxHexSent value, for example: 

if (vtxHexVerify != vtxHexSent) {} // action to take if verify has failed (currently blank)

Note: it is important that a delay is inserted (see line 127) after the write freq command, before reading the register. This delay is to allow time for the RX5808 VCOs and circuitry to settle after writing freq and before reading register 0x01 (20ms is optimal. A delay of 20m is included, but it can be longer but not shorter. Erroneous results will occur if delay is too short.