### PR TITLE
Fix %HEAT% token replacement in callout

### DIFF
--- a/src/server/templates/run.html
+++ b/src/server/templates/run.html
@@ -385,21 +385,19 @@
 				if (heat.class_id != 0) {
 					single_class = false;
 				}
+				if (heat.note) {
+					rotorhazard.heats[h].heatname = heat.note;
+				} else {
+					rotorhazard.heats[h].heatname = __('Heat') + ' ' + heat.heat_id;
+				}
 			}
 
 			// assemble optgroups
 			if (single_class) {
 				for (var h in msg.heats) {
 					var heat = msg.heats[h];
-
-					if (heat.note) {
-						var heatname = heat.note;
-					} else {
-						var heatname = __('Heat') + ' ' + heat.heat_id;
-					}
-
 					var opt = $('<option value="' + heat.heat_id + '" data-class="' + heat.class_id + '">');
-					opt.html(heatname);
+					opt.html(heat.heatname);
 					$('#set_current_heat').append(opt);
 				}
 			} else {
@@ -421,15 +419,9 @@
 					for (var h in heat_list) {
 						var heat = heat_list[h];
 
-						if (heat.note) {
-							var heatname = heat.note;
-						} else {
-							var heatname = __('Heat') + ' ' + heat.heat_id;
-						}
-
 						var opt = $('<option value="' + heat.heat_id + '" data-class="' + heat.class_id + '">');
 
-						opt.html(heatname);
+						opt.html(heat.heatname);
 						optgroup.append(opt)
 					}
 					$('#set_current_heat').append(optgroup);
@@ -1553,9 +1545,7 @@
 			var callout = $(this).siblings('.callout_text').val();
 
 			// %HEAT% : Current heat name
-			var heat = rotorhazard.heats[rotorhazard.current_heat];
-			var heatname = (heat.note ? heat.note : heat.heat_id);
-			callout = callout.replace('%HEAT%', heatname);
+			callout = callout.replace('%HEAT%', rotorhazard.heats[rotorhazard.current_heat].heatname);
 
 			// %PILOTS% : Current pilot names
 			var pilots = '';

--- a/src/server/templates/run.html
+++ b/src/server/templates/run.html
@@ -1553,7 +1553,9 @@
 			var callout = $(this).siblings('.callout_text').val();
 
 			// %HEAT% : Current heat name
-			callout = callout.replace('%HEAT%', rotorhazard.heats[rotorhazard.current_heat].heatname);
+			var heat = rotorhazard.heats[rotorhazard.current_heat];
+			var heatname = (heat.note ? heat.note : heat.heat_id);
+			callout = callout.replace('%HEAT%', heatname);
 
 			// %PILOTS% : Current pilot names
 			var pilots = '';


### PR DESCRIPTION
I noticed the broken callout when we upgraded from an old Delta5-based timer running RH 2.2.0 to a new S32_BPill-based build (awesome design, btw!) running 3.1.1

Fixes #606