### PR TITLE
Fix race scheduling timer frontend

### DIFF
--- a/src/server/static/rotorhazard.js
+++ b/src/server/static/rotorhazard.js
@@ -1197,7 +1197,7 @@ rotorhazard.timer.deferred.callbacks.step = function(timer){
 			speak('<div>' + __l('Next race begins in') + ' 1 ' + __l('Hour') + '</div>', true);
 		} else if (timer.time_tenths == -18000) {
 			speak('<div>' + __l('Next race begins in') + ' 30 ' + __l('Minutes') + '</div>', true);
-		} else if (timer.time_tenths > -600 && timer.time_tenths <= 3000 && !(timer.time_tenths % 600)) { // 2–5 min callout
+		} else if (timer.time_tenths < -600 && timer.time_tenths >= -3000 && !(timer.time_tenths % 600)) { // 2–5 min callout
 			var minutes = timer.time_tenths / -600;
 			speak('<div>' + __l('Next race begins in') + ' ' + minutes + ' ' + __l('Minutes') + '</div>', true);
 		} else if (timer.time_tenths == -600) {

--- a/src/server/templates/current.html
+++ b/src/server/templates/current.html
@@ -154,7 +154,8 @@
 		socket.on('race_scheduled', function (msg) {
 			if (msg.scheduled) {
 				var deferred_start = msg.scheduled_at * 1000;  // convert seconds (pi) to millis (JS)
-				rotorhazard.timer.deferred.start(deferred_start, rotorhazard.pi_time_diff);
+				rotorhazard.timer.deferred.sync(deferred_start, rotorhazard.pi_time_diff);
+				rotorhazard.timer.deferred.start();
 			} else {
 				rotorhazard.timer.deferred.stop();
 			}

--- a/src/server/templates/run.html
+++ b/src/server/templates/run.html
@@ -206,7 +206,8 @@
 		socket.on('race_scheduled', function (msg) {
 			if (msg.scheduled) {
 				var deferred_start = msg.scheduled_at * 1000;  // convert seconds (pi) to millis (JS)
-				rotorhazard.timer.deferred.start(deferred_start, rotorhazard.pi_time_diff);
+				rotorhazard.timer.deferred.sync(deferred_start, rotorhazard.pi_time_diff);
+				rotorhazard.timer.deferred.start();
 			} else {
 				rotorhazard.timer.deferred.stop();
 			}

--- a/src/server/templates/streamresults.html
+++ b/src/server/templates/streamresults.html
@@ -98,7 +98,8 @@
 		socket.on('race_scheduled', function (msg) {
 			if (msg.scheduled) {
 				var deferred_start = msg.scheduled_at * 1000;  // convert seconds (pi) to millis (JS)
-				rotorhazard.timer.deferred.start(deferred_start, rotorhazard.pi_time_diff);
+				rotorhazard.timer.deferred.sync(deferred_start, rotorhazard.pi_time_diff);
+				rotorhazard.timer.deferred.start();
 			} else {
 				rotorhazard.timer.deferred.stop();
 			}


### PR DESCRIPTION
This PR closes #672.

In [line 846 of the `rotorhazard.js` file](https://github.com/RotorHazard/RotorHazard/blob/main/src/server/static/rotorhazard.js#L846), there's a condition that blocks the `deferred` timer to ever be synced because its `start` function only gets called with two arguments: `deferred_start` and `rotorhazard.pi_time_diff`.

I didn't want to change too much as to not break anything. Therefore I only added a sync line to anywhere that timer is started and removed the arguments from the `start` call.