### PR TITLE
Fix timer function parameter typo

### DIFF
--- a/src/server/static/rotorhazard.js
+++ b/src/server/static/rotorhazard.js
@@ -871,18 +871,18 @@ function timerModel() {
 		this.running = true;
 	}
 
-	this.sync = function(remote_time_zero, local_remote_diiferential, remote_time_start) {
+	this.sync = function(remote_time_zero, local_remote_differential, remote_time_start) {
 		// set local timer based on remote and calculated differential
 		// only valid with both components
-		if (local_remote_diiferential) {
+		if (local_remote_differential) {
 			if (remote_time_start) {
-				this.local_start_time = remote_time_start - local_remote_diiferential;
+				this.local_start_time = remote_time_start - local_remote_differential;
 			} else {
 				this.local_start_time = null;
 			}
 
 			if (remote_time_zero) {
-				this.local_zero_time = remote_time_zero - local_remote_diiferential;
+				this.local_zero_time = remote_time_zero - local_remote_differential;
 			} else {
 				this.local_zero_time = null;
 			}


### PR DESCRIPTION
During the development of #673 I stumbled across this parameter name typo. This is just a minor refactoring.
I wasn't sure if to add it to my other PR so I decided to open a new one instead and don't mix things that are only very loosely related.