### PR TITLE
Propose to First to X Laps race issue

### DIFF
--- a/doc/User Guide.md
+++ b/doc/User Guide.md
@@ -148,7 +148,7 @@ _Win Condition_ determines how the timer calls out the winner of the race, the i
 * __Most Laps in Fastest Time__: Pilots are judged by the number of laps completed and how long it took to complete them. If there is a tie for the number of laps completed, the pilot who completed those laps in a shorter amount of time will be ranked higher.
 * __Most Laps Only__: Scored only by the completed lap count. Pilots with the same lap count are tied. Use with "Fixed Time" mode for a race style before timing was reliable, or with "No Time Limit" mode to judge the greatest distance instead of shortest time.
 * __Most Laps Only with Overtime__: Similar to _Most Laps in Fastest Time_, but with a "sudden death" component. When the timer expires (or the race is stopped early), if a pilot has more laps than all the others then that pilot is the winner. If there is a tie for lap count when the timer expires, the first of the tied pilots across the line is the winner.
-* __First to X Laps__: The race continues until one pilot reaches the desired lap count. In this mode, the _Number of Laps to Win_ parameter is used. Typically used with the _No Time Limit_ race mode.
+* __First to X Laps__: The race continues until one pilot reaches the desired lap count when team racing is used. In this mode, the _Number of Laps to Win_ parameter is used. Typically used with the _No Time Limit_ race mode.
 * __Fastest Lap__: Ignores the race progress and considers only each pilot's single fastest lap.
 * __Fastest 3 Consecutive Laps__: Considers all laps a pilot has completed and uses the three consecutive laps with the fastest combined time.
 * __None__: Does not declare a winner under any circumstance. Heats generated from a class with this condition will be assigned randomly.

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -4300,6 +4300,7 @@ def pass_record_callback(node, lap_timestamp_absolute, source):
                                                INTERFACE.get_lap_source_str(source), pilot_namestr))
                             
                         if RACE.win_status == WinStatus.DECLARED and race_format.race_mode == 1 and RACE.format.win_condition == WinCondition.FIRST_TO_LAP_X:
+
                             lap_late_flag = True  # "late" lap pass after race winner declared (when no time limit)
                             if RACE.format.team_racing_mode and pilot_obj:
                                 t_str = ", Team " + pilot_obj.team
@@ -4333,8 +4334,8 @@ def pass_record_callback(node, lap_timestamp_absolute, source):
                             'lap_time': lap_time,
                             'lap_time_formatted': lap_time_fmtstr,
                             'source': source,
-                            'deleted': lap_late_flag,  # delete if lap pass is after race winner declared
-                            'late_lap': lap_late_flag
+                            'deleted':  lap_late_flag if race_format.team_racing_mode else node_finished_flag,  # delete if lap pass is after race winner declared on team racing or after node fineshed if else.
+                            'late_lap': lap_late_flag if race_format.team_racing_mode else node_finished_flag
                         }
                         RACE.node_laps[node.index].append(lap_data)
 


### PR DESCRIPTION
...
Currently, the race format "First to X Laps" sets "late lap" for everyone after a winner is declared.
Not what is required here, as we must allow other pilots to finish the X laps.
...

The solution I tested was not to set "late_lap" when not in Teams mode.

This is one possible solution for the First to X Laps
Closes #675 

