### PR TITLE
Update requirements.txt

### DIFF
--- a/src/server/requirements.txt
+++ b/src/server/requirements.txt
@@ -7,9 +7,9 @@ python-engineio==3.11.*
 python-socketio==4.4.*
 six==1.14.*
 Werkzeug==1.0.*
-gevent==20.6.*
+gevent==20.12.*
 gevent-websocket==0.10.*
-greenlet==0.4.16
+greenlet==0.4.17
 flask_sqlalchemy==2.4.*
 SQLAlchemy==1.3.*
 monotonic==1.5.*


### PR DESCRIPTION
Minor changes to declared versions of gevent and greenlet due to compatibility with 64 bit Raspbian. Did fresh install of 64bit Raspbian. Could't install gevent in previous 20.6 version. I checked and this is the minimal version that doesn't cause issues (and is downloadable). Greenlet had to be updated to due to compatibility with never greenlet. I also tested it on 32bit Raspberry Pi OS. Still works after those changes. Note: not related to python3.10 compatibility reported issue. 