### PR TITLE
Use InvokeFnQueue with 'pass_record_callback' and 'check_win_condition'

### DIFF
--- a/src/interface/BaseHardwareInterface.py
+++ b/src/interface/BaseHardwareInterface.py
@@ -114,7 +114,7 @@ class BaseHardwareInterface(object):
                 item = upd_list[0]
                 node = item[0]
                 if node.node_lap_id != -1 and callable(self.pass_record_callback):
-                    gevent.spawn(self.pass_record_callback, node, item[2], BaseHardwareInterface.LAP_SOURCE_REALTIME)  # (node, lap_time_absolute)
+                    self.pass_record_callback(node, item[2], BaseHardwareInterface.LAP_SOURCE_REALTIME)  # (node, lap_time_absolute)
                 node.node_lap_id = item[1]  # new_lap_id
 
             else:  # list contains multiple items; sort so processed in order by lap time
@@ -122,7 +122,7 @@ class BaseHardwareInterface(object):
                 for item in upd_list:
                     node = item[0]
                     if node.node_lap_id != -1 and callable(self.pass_record_callback):
-                        gevent.spawn(self.pass_record_callback, node, item[2], BaseHardwareInterface.LAP_SOURCE_REALTIME)  # (node, lap_time_absolute)
+                        self.pass_record_callback(node, item[2], BaseHardwareInterface.LAP_SOURCE_REALTIME)  # (node, lap_time_absolute)
                     node.node_lap_id = item[1]  # new_lap_id
 
     #
@@ -133,7 +133,7 @@ class BaseHardwareInterface(object):
         node = self.nodes[node_index]
         node.lap_timestamp = monotonic() - (ms_val / 1000.0)
         node.enter_at_timestamp = node.exit_at_timestamp = 0
-        gevent.spawn(self.pass_record_callback, node, node.lap_timestamp, BaseHardwareInterface.LAP_SOURCE_MANUAL)
+        self.pass_record_callback(node, node.lap_timestamp, BaseHardwareInterface.LAP_SOURCE_MANUAL)
 
     def set_race_status(self, race_status):
         self.race_status = race_status

--- a/src/server/util/InvokeFuncQueue.py
+++ b/src/server/util/InvokeFuncQueue.py
@@ -1,0 +1,61 @@
+# InvokeFuncQueue:  Operates an invoke-function queue
+
+# Invokes a function sequentially, via a GEvent queue.
+
+import gevent
+
+class InvokeFuncQueue:
+    """ Invokes a function sequentially, via a GEvent queue. """
+
+    def __init__(self, logger, maxQueueSize=20):
+        self.logger = logger
+        self.invokeFuncQueue = gevent.queue.Queue(maxsize=maxQueueSize)
+        self.invokeInProgressFlag = False
+        gevent.spawn(self.queueWorkerFn)
+
+    def put(self, funct, *args, **kwargs):
+        try:
+            self.invokeFuncQueue.put((funct, args, kwargs))
+        except:
+            self.logger.exception("InvokeFuncQueue 'put' error")
+
+    def queueWorkerFn(self):
+        while True:
+            try:
+                (funct, args, kwargs) = self.invokeFuncQueue.get()  # wait for next item in queue
+                try:
+                    self.invokeInProgressFlag = True
+                    funct(*args, **kwargs)
+                    self.invokeInProgressFlag = False
+                    gevent.sleep()
+                except (KeyboardInterrupt, SystemExit):
+                    self.invokeInProgressFlag = False
+                    raise
+                except Exception:
+                    self.invokeInProgressFlag = False
+                    self.logger.exception("InvokeFuncQueue error invoking function")
+                    gevent.sleep(1)
+            except KeyboardInterrupt:
+                self.invokeInProgressFlag = False
+                self.logger.info("InvokeFuncQueue worker thread terminated by keyboard interrupt")
+                raise
+            except SystemExit:
+                self.invokeInProgressFlag = False
+                raise
+            except Exception:
+                self.invokeInProgressFlag = False
+                self.logger.exception("InvokeFuncQueue error processing queue (aborting thread)")
+                break
+
+    # waits until no function invocation is in progress and the queue is empty
+    def waitForQueueEmpty(self):
+        try:
+            count = 0
+            while self.invokeInProgressFlag or (not self.invokeFuncQueue.empty()):
+                count += 1
+                if count > 300:
+                    self.logger.error("Timeout waiting for InvokeFuncQueue empty")
+                    return
+                gevent.sleep(0.01)
+        except Exception:
+            self.logger.exception("Error waiting for InvokeFuncQueue empty")


### PR DESCRIPTION
This addresses an issue where if a lap pass happens just before the race time expires the lap can end up not included in the set of laps used to determine the race winner.  (In the rare instance I saw this the lap pass was 33ms before the expiration.)

This happens because the calculate-leaderboard function has thread yields (via gevent.sleep) that allow the check-winner function "thread" to run before the pass-record function has completed.  The fix is to create and use an "invoke-function" queue that forces the functions to run sequentially.