### PR TITLE
Added auto-refresh if server data fails to load

### DIFF
--- a/src/server/templates/current.html
+++ b/src/server/templates/current.html
@@ -36,6 +36,7 @@
 	}
 
 	$(document).ready(function () {
+		var page_data_loaded_flag = false;
 		// get pi time
 		rotorhazard.pi_time_request = window.performance.now();
 		socket.emit('get_pi_time');
@@ -229,6 +230,7 @@
 		});
 
 		socket.on('frequency_data', function (msg) {
+			page_data_loaded_flag = true;
 			if (msg.fdata.length) {
 				for (var i in msg.fdata) {
 					var fObj = freq.getFObjbyFData(msg.fdata[i]);
@@ -508,6 +510,7 @@
 		})
 
 		socket.on('current_heat', function (msg) {
+			page_data_loaded_flag = true;
 			for (var idx in msg.heatNodes) {
 				hn = msg.heatNodes[idx];
 				cs = $('#next-race .callsign_' + idx)
@@ -534,6 +537,7 @@
 		});
 
 		socket.on('pilot_data', function (msg) {
+			page_data_loaded_flag = true;
 			msg.pilots.sort(function(a, b){
 				if (a.name < b.name)
 					return -1;
@@ -707,6 +711,13 @@
 		$('#use_mp3_tones').change(function (event) {
 			rotorhazard.use_mp3_tones = $(this).prop('checked');
 		});
+
+		setTimeout(function(reload_page) {
+			if (!page_data_loaded_flag) {
+				location.reload();  // if data fails to load from server then do a page refresh
+			}
+		}, 5000);
+
 	});
 
 </script>

--- a/src/server/templates/run.html
+++ b/src/server/templates/run.html
@@ -48,6 +48,7 @@
 	}
 
 	$(document).ready(function () {
+		var page_data_loaded_flag = false;
 		// get pi time
 		rotorhazard.pi_time_request = window.performance.now();
 		socket.emit('get_pi_time');
@@ -373,6 +374,7 @@
 		});
 
 		socket.on('frequency_data', function (msg) {
+			page_data_loaded_flag = true;
 			if (msg.fdata.length) {
 				for (var i in msg.fdata) {
 					var fObj = freq.getFObjbyFData(msg.fdata[i]);
@@ -1387,6 +1389,7 @@
 		})
 
 		socket.on('format_data', function (msg) {
+			page_data_loaded_flag = true;
 			rotorhazard.event.race_formats = msg.formats;
 			update_race_formats();
 		});
@@ -1712,6 +1715,7 @@
 
 		/* Pilots */
 		socket.on('pilot_data', function (msg) {
+			page_data_loaded_flag = true;
 			rotorhazard.pilot_data = msg.pilots;
 		});
 
@@ -2191,6 +2195,13 @@
 					break;
 			}
 		});
+
+		setTimeout(function(reload_page) {
+			if (!page_data_loaded_flag) {
+				location.reload();  // if data fails to load from server then do a page refresh
+			}
+		}, 3000);
+
 	});
 
 </script>


### PR DESCRIPTION
Every once in a while the Run and the Current page will get stuck in the "Loading..." state when being rendered.  Not sure about the root cause but the initial emits from the server to the browser don't make it though.  This adds an auto refresh after a few seconds if the data did not load.