### PR TITLE
Stream node display misalignment

### DIFF
--- a/src/server/static/streamnode.css
+++ b/src/server/static/streamnode.css
@@ -103,7 +103,7 @@ body {
 	flex: 0 0 auto;
 }
 
-#current_laps {
+#current-laps {
 	position: absolute;
 	top: 4rem;
 	padding: 0.25rem 0.5rem;

--- a/src/server/static/streamnode.css
+++ b/src/server/static/streamnode.css
@@ -94,6 +94,7 @@ body {
 	flex: 1 1 auto;
 	margin-right: 1rem;
 	text-overflow: ellipsis;
+	overflow: hidden;
 	white-space: nowrap;
 	display: block;
 }

--- a/src/server/static/streamnode.css
+++ b/src/server/static/streamnode.css
@@ -94,7 +94,6 @@ body {
 	flex: 1 1 auto;
 	margin-right: 1rem;
 	text-overflow: ellipsis;
-	overflow: hidden;
 	white-space: nowrap;
 	display: block;
 }


### PR DESCRIPTION
Current laps were misaligned to the far left in the stream/node pages due to mismatching Id selectors between HTML & CSS. 
Quick rename fixed it. 

Additionally removed overflow:hidden from the callsign selector to prevent cropping of text. 

Requires cache to be cleared. 