### PR TITLE
Fixed calling wrong query to get race format ID

### DIFF
--- a/src/server/RHData.py
+++ b/src/server/RHData.py
@@ -2109,7 +2109,7 @@ class RHData():
         if isinstance(raceFormat_or_id, Database.RaceFormat):
             return raceFormat_or_id
         else:
-            return self._Database.Pilot.query.get(raceFormat_or_id)
+            return self._Database.RaceFormat.query.get(raceFormat_or_id)
 
     def resolve_id_from_raceFormat_or_id(self, raceFormat_or_id):
         if isinstance(raceFormat_or_id, Database.RaceFormat):


### PR DESCRIPTION
Solving for issue [https://github.com/RotorHazard/RotorHazard/issues/735](url)

Looks like when retrieving the race format details from DB, the wrong query was being used "Pilot". Fixed to RaceFormat query to get the right ID and duplicate function works as per before. 