### PR TITLE
Updated sample path for fresh install lang

### DIFF
--- a/doc/de/Software Setup.md
+++ b/doc/de/Software Setup.md
@@ -295,7 +295,7 @@ So aktualisieren Sie eine vorhandene RotorHazard-Installation: Gehen Sie zur Sei
 
 ```
 cd ~
-wget https://codeload.github.com/RotorHazard/RotorHazard/zip/1.2.3 -O temp.zip
+wget https://codeload.github.com/RotorHazard/RotorHazard/zip/v1.2.3 -O temp.zip
 unzip temp.zip
 mv RotorHazard RotorHazard.old
 mv RotorHazard-1.2.3 RotorHazard

--- a/doc/es/Software Setup.md
+++ b/doc/es/Software Setup.md
@@ -42,7 +42,7 @@ Guarde y salga del archivo con Ctrl-X
 Instale el código RotorHazard en '/ home / pi /' en la Raspberry Pi de la siguiente manera: Vaya a [Latest Release page](https://github.com/RotorHazard/RotorHazard/releases/latest) para el proyecto y tenga en cuenta el código de versión. En los siguientes comandos, reemplace las dos apariciones de "1.2.3" con el código de la versión actual e ingrese los comandos:
 ```
 cd ~
-wget https://codeload.github.com/RotorHazard/RotorHazard/zip/1.2.3 -O temp.zip
+wget https://codeload.github.com/RotorHazard/RotorHazard/zip/v1.2.3 -O temp.zip
 unzip temp.zip
 mv RotorHazard-1.2.3 RotorHazard
 rm temp.zip

--- a/doc/pl/Software Setup.md
+++ b/doc/pl/Software Setup.md
@@ -42,7 +42,7 @@ Idź do strony [Latest Release page](https://github.com/RotorHazard/RotorHazard/
 „Ostatnie wydania” i zobacz jaka jest aktualna wersja kodu. W komendach poniżej zastąp znaki "1.2.3" aktualną wersję kodu i wpisz następujące komendy:
 ```
 cd ~
-wget https://codeload.github.com/RotorHazard/RotorHazard/zip/1.2.3 -O temp.zip
+wget https://codeload.github.com/RotorHazard/RotorHazard/zip/v1.2.3 -O temp.zip
 unzip temp.zip
 mv RotorHazard-1.2.3 RotorHazard
 rm temp.zip


### PR DESCRIPTION
Saw that the 'v' in the fresh install guide already existed in the english software.md file. This updates the other language notes. 