### PR TITLE
Add margin to elements in pilot form

### DIFF
--- a/src/server/static/rotorhazard.css
+++ b/src/server/static/rotorhazard.css
@@ -2002,9 +2002,15 @@ td.speak {
 	width: 2.2em;
 }
 
-.phonetic {
+.pilot-info-inline {
 	display: flex;
 	justify-content: space-between;
+	margin-top: 0.25em;
+	margin-bottom: 0.25em;
+}
+
+.pilot-info-inline button, .delete_pilot{
+	margin-left: 0.25em;
 }
 
 .pilot-team {

--- a/src/server/static/rotorhazard.css
+++ b/src/server/static/rotorhazard.css
@@ -2005,11 +2005,14 @@ td.speak {
 .pilot-info-inline {
 	display: flex;
 	justify-content: space-between;
-	margin-top: 0.25em;
 	margin-bottom: 0.25em;
 }
 
-.pilot-info-inline button, .delete_pilot{
+.pilot-info-inline:not(:first-of-type) {
+	margin-top: 0.25em;
+}
+
+.pilot-info-inline button, .delete_pilot {
 	margin-left: 0.25em;
 }
 

--- a/src/server/templates/format.html
+++ b/src/server/templates/format.html
@@ -1014,12 +1014,12 @@
 					if (pilot.pilot_id != 0) {
 						var el = $('<li data-id="' + pilot.pilot_id + '">');
 						el.append('<label for="name_' + pilot.pilot_id + '" class="screen-reader-text">' + __('Name') + '</label>');
-						var pilot_name = $('<div class="pilot-info-inline">')	
-							pilot_name.append('<input type="text" class="set_pilot_name" id="name_' + pilot.pilot_id + '" data-pilot_id="' + pilot.pilot_id + '" value="' + pilot.name + '" placeholder="' + __('Name') +'">');
-							if ('color' in pilot) {
-								pilot_name.append('<label for="color_' + pilot.pilot_id + '" class="screen-reader-text">' + __('Color') + '</label>');
-								pilot_name.append('<button class="set_pilot_color color-picker" id="color_' + pilot.pilot_id + '" data-pilot_id="' + pilot.pilot_id + '" data-color="' + pilot.color + '" style="background-color:' + pilot.color + '">');
-							}
+						var pilot_name = $('<div class="pilot-info-inline">');
+						pilot_name.append('<input type="text" class="set_pilot_name" id="name_' + pilot.pilot_id + '" data-pilot_id="' + pilot.pilot_id + '" value="' + pilot.name + '" placeholder="' + __('Name') +'">');
+						if ('color' in pilot) {
+							pilot_name.append('<label for="color_' + pilot.pilot_id + '" class="screen-reader-text">' + __('Color') + '</label>');
+							pilot_name.append('<button class="set_pilot_color color-picker" id="color_' + pilot.pilot_id + '" data-pilot_id="' + pilot.pilot_id + '" data-color="' + pilot.color + '" style="background-color:' + pilot.color + '">');
+						}
 						el.append(pilot_name);
 						el.append('<label for="callsign_' + pilot.pilot_id + '" class="screen-reader-text">' + __('Callsign') + '</label>');
 						el.append('<input type="text" class="callsign set_pilot_callsign" id="callsign_' + pilot.pilot_id + '" data-pilot_id="' + pilot.pilot_id + '" value="' + pilot.callsign + '" placeholder="' + __('Callsign') +'">');
@@ -1029,6 +1029,10 @@
 						phonetic.append('<button class="speak_pilot" data-pilot_id="' + pilot.pilot_id + '">&#9658;&#65038; <span class="screen-reader-text">' + __('Play') + '</span></button>');
 						el.append(phonetic);
 						el.append('<div class="pilot-team"><label for="set_pilot_team_' + pilot.pilot_id + '">' + __('Team') + '</label><select class="set_pilot_team" id="set_pilot_team_' + pilot.pilot_id + '" data-pilot_id="' + pilot.pilot_id + '">' + pilot.team_options + '</select></div>');
+
+						if (!pilot.locked) {
+							el.append('<button class="delete_pilot btn-danger" data-id="' + pilot.pilot_id + '" title="Delete Pilot ' + pilot.callsign + '">&#215; </button>');
+						}
 
 						for (var attr_idx in rotorhazard.event.pilot_attributes) {
 							var pilot_attr = rotorhazard.event.pilot_attributes[attr_idx];
@@ -1041,10 +1045,6 @@
 
 							el.append(attr_label);
 							el.append(attr_field);
-						}
-
-						if (!pilot.locked) {
-							el.append('<button class="delete_pilot btn-danger" data-id="' + pilot.pilot_id + '" title="Delete Pilot ' + pilot.callsign + '">&#10006; </button>');
 						}
 
 						el.appendTo($('.pilots'));

--- a/src/server/templates/format.html
+++ b/src/server/templates/format.html
@@ -1014,15 +1014,17 @@
 					if (pilot.pilot_id != 0) {
 						var el = $('<li data-id="' + pilot.pilot_id + '">');
 						el.append('<label for="name_' + pilot.pilot_id + '" class="screen-reader-text">' + __('Name') + '</label>');
-						el.append('<input type="text" class="set_pilot_name" id="name_' + pilot.pilot_id + '" data-pilot_id="' + pilot.pilot_id + '" value="' + pilot.name + '" placeholder="' + __('Name') +'">');
-						if ('color' in pilot) {
-							el.append('<label for="color_' + pilot.pilot_id + '" class="screen-reader-text">' + __('Color') + '</label>');
-							el.append('<button class="set_pilot_color color-picker" id="color_' + pilot.pilot_id + '" data-pilot_id="' + pilot.pilot_id + '" data-color="' + pilot.color + '" style="background-color:' + pilot.color + '">');
-						}
+						var pilot_name = $('<div class="pilot-info-inline">')	
+							pilot_name.append('<input type="text" class="set_pilot_name" id="name_' + pilot.pilot_id + '" data-pilot_id="' + pilot.pilot_id + '" value="' + pilot.name + '" placeholder="' + __('Name') +'">');
+							if ('color' in pilot) {
+								pilot_name.append('<label for="color_' + pilot.pilot_id + '" class="screen-reader-text">' + __('Color') + '</label>');
+								pilot_name.append('<button class="set_pilot_color color-picker" id="color_' + pilot.pilot_id + '" data-pilot_id="' + pilot.pilot_id + '" data-color="' + pilot.color + '" style="background-color:' + pilot.color + '">');
+							}
+						el.append(pilot_name);
 						el.append('<label for="callsign_' + pilot.pilot_id + '" class="screen-reader-text">' + __('Callsign') + '</label>');
 						el.append('<input type="text" class="callsign set_pilot_callsign" id="callsign_' + pilot.pilot_id + '" data-pilot_id="' + pilot.pilot_id + '" value="' + pilot.callsign + '" placeholder="' + __('Callsign') +'">');
 						el.append('<label for="phonetic_' + pilot.pilot_id + '" class="screen-reader-text">' + __('Phonetic') +'</label>');
-						var phonetic = $('<div class="phonetic">');
+						var phonetic = $('<div class="pilot-info-inline">');
 						phonetic.append('<input type="text" class="set_pilot_phonetic" id="phonetic_' + pilot.pilot_id + '" data-pilot_id="' + pilot.pilot_id + '" value="' + pilot.phonetic + '" placeholder="' + __('Phonetic') + '">');
 						phonetic.append('<button class="speak_pilot" data-pilot_id="' + pilot.pilot_id + '">&#9658;&#65038; <span class="screen-reader-text">' + __('Play') + '</span></button>');
 						el.append(phonetic);
@@ -1042,7 +1044,7 @@
 						}
 
 						if (!pilot.locked) {
-							el.append('<button class="delete_pilot btn-danger" data-id="' + pilot.pilot_id + '" title="Delete Pilot ' + pilot.callsign + '">&#215;</button>');
+							el.append('<button class="delete_pilot btn-danger" data-id="' + pilot.pilot_id + '" title="Delete Pilot ' + pilot.callsign + '">&#10006; </button>');
 						}
 
 						el.appendTo($('.pilots'));


### PR DESCRIPTION
Introducing margins to the element inside the Pilots section of the Format page. Solution adds spacing to the pilot name, callsign inputs and respective buttons giving the form a pleasant look and allowing users to search for pilots easily when the list is long. 

Change includes:

- Renaming 1 of the DIVs to better suit purpose. "pilot-info-inline" class is tagged to a div used to nest pilot information input and button.
- Introducing margins in the CSS file for the above mention class.
- Chanced unicode for close button to better suit overall theme. 

**BEFORE**:
<img width="1201" alt="Screenshot 2023-05-10 at 10 58 09 AM" src="https://github.com/RotorHazard/RotorHazard/assets/17153870/c4f3285d-6760-491c-b0a7-64369ba6f249">

**AFTER**:
<img width="1156" alt="Screenshot 2023-05-10 at 10 56 38 AM" src="https://github.com/RotorHazard/RotorHazard/assets/17153870/2bf8afb1-0a09-41d2-8b96-77474b715738">
