### PR TITLE
Fixed race duration field toggle when no time limit

### DIFF
--- a/src/server/templates/format.html
+++ b/src/server/templates/format.html
@@ -1414,7 +1414,7 @@
 			format_id = $('#set_race_format').val();
 			var rf = rotorhazard.event.race_formats.find(obj => {return obj.id == format_id});
 
-			$('#format-race-duration-field').toggle(rf.unlimited_time == 0);
+			$('.format-race-duration-fields').toggle(rf.unlimited_time == 0);
 			$('#format-laps-to-win-field').toggle(rf.win_condition == 2);
 
 			var issues = []
@@ -2343,7 +2343,7 @@
 					<option value="1">{{ __('No Time Limit') }}</option>
 				</select>
 			</li>
-			<li id="format-race-duration-field">
+			<li class="format-race-duration-fields">
 				<div class="label-block">
 					<label for="set_fix_race_time">{{ __('Timer Duration (seconds)') }}</label>
 				</div>


### PR DESCRIPTION
Fix for issue [https://github.com/RotorHazard/RotorHazard/issues/769](https://github.com/RotorHazard/RotorHazard/issues/769)

Expected behaviour is when no time limit is selected in race condition, Time duration and Grace Period fields must be toggled off. If it is enabled and available, the value 0 is used which means the race immediately ends just after starting. 

The divs for both the fields were unmatched. Fix was to align the naming of both divs and tag them as classes. 

Tested and now RH starts up with the correct race format. Open Practice and First to 3 laps starts as expected. 