### PR TITLE
Eliminate dependency "six"

### DIFF
--- a/src/interface/Plugins.py
+++ b/src/interface/Plugins.py
@@ -3,7 +3,7 @@
 import logging
 import importlib
 import pkgutil
-from six.moves import UserList
+from collections import UserList
 
 logger = logging.getLogger(__name__)
 

--- a/src/server/RHData.py
+++ b/src/server/RHData.py
@@ -15,7 +15,6 @@ import json
 import glob
 import RHUtils
 import random
-from six import unichr
 import Database
 import Results
 from monotonic import monotonic
@@ -25,7 +24,7 @@ from Database import ProgramMethod, HeatAdvanceType, HeatStatus
 
 class RHData():
     _OptionsCache = {} # Local Python cache for global settings
-    TEAM_NAMES_LIST = [str(unichr(i)) for i in range(65, 91)]  # list of 'A' to 'Z' strings
+    TEAM_NAMES_LIST = [str(chr(i)) for i in range(65, 91)]  # list of 'A' to 'Z' strings
 
     def __init__(self, DBObj, Events, RaceContext, SERVER_API, DB_FILE_NAME, DB_BKP_DIR_NAME):
         self._Database = DBObj

--- a/src/server/led_event_manager.py
+++ b/src/server/led_event_manager.py
@@ -16,7 +16,7 @@ import RHUtils
 from RHUtils import catchLogExceptionsWrapper, cleanVarName
 import gevent
 from eventmanager import Evt
-from six.moves import UserDict
+from collections import UserDict
 import logging
 
 logger = logging.getLogger(__name__)

--- a/src/server/reqsNonPi.txt
+++ b/src/server/reqsNonPi.txt
@@ -10,7 +10,6 @@ Flask-SocketIO==5.3.*
 python-socketio==5.8.*
 python-engineio==4.4.*
 websocket-client==1.5.*
-six==1.14.*
 
 # Database
 flask_sqlalchemy==2.4.*

--- a/src/server/requirements.txt
+++ b/src/server/requirements.txt
@@ -10,7 +10,6 @@ Flask-SocketIO==5.3.*
 python-socketio==5.8.*
 python-engineio==4.4.*
 websocket-client==1.5.*
-six==1.14.*
 
 # Database
 flask_sqlalchemy==2.4.*

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -45,7 +45,6 @@ import subprocess
 import importlib
 # import copy
 from functools import wraps
-from six import string_types
 
 from flask import Flask, send_file, request, Response, session, templating, redirect, abort, copy_current_request_context
 from flask_socketio import SocketIO, emit
@@ -860,7 +859,7 @@ def on_set_frequency(data):
     '''Set node frequency.'''
     if RaceContext.cluster:
         RaceContext.cluster.emitToSplits('set_frequency', data)
-    if isinstance(data, string_types): # LiveTime compatibility
+    if isinstance(data, str): # LiveTime compatibility
         data = json.loads(data)
     node_index = data['node']
     frequency = int(data['frequency'])
@@ -4294,7 +4293,7 @@ def check_requirements():
     try:
         import importlib.metadata  # @UnusedImport pylint: disable=redefined-outer-name
         chk_list = [['Flask==','flask'], ['Flask-SocketIO==','flask_socketio'], \
-                    ['Flask_SocketIO==','flask_socketio'], ['six==','six'], \
+                    ['Flask_SocketIO==','flask_socketio'], \
                     ['flask_sqlalchemy==','flask_sqlalchemy'], ['gevent==','gevent'], \
                     ['gevent-websocket==','gevent-websocket'], ['monotonic==','monotonic'], \
                     ['requests==','requests']]
@@ -4442,7 +4441,7 @@ hasMirrors = False
 secondary = None
 try:
     for sec_idx, secondary_info in enumerate(Config.GENERAL['SECONDARIES']):
-        if isinstance(secondary_info, string_types):
+        if isinstance(secondary_info, str):
             secondary_info = {'address': secondary_info, 'mode': SecondaryNode.SPLIT_MODE}
         if 'address' not in secondary_info:
             raise RuntimeError("Secondary 'address' item not specified")


### PR DESCRIPTION
We don't support py2 anymore, so we have no need for a 2/3 compatibility dependency.