### PR TITLE
Bump minimum python version to 3.8

### DIFF
--- a/doc/Software Setup.md
+++ b/doc/Software Setup.md
@@ -95,7 +95,7 @@ Using a terminal window, install Python and the Python drivers for the GPIO:
 ```
 sudo apt install python3-dev libffi-dev python3-smbus build-essential python3-pip git scons swig python3-rpi.gpio
 ```
-The minimum version of Python supported is 3.7 Check the current default version of Python by entering the following command:
+The minimum version of Python supported is 3.8 Check the current default version of Python by entering the following command:
 ```
 python --version
 ```
@@ -326,7 +326,7 @@ cp -r RotorHazard.old/src/server/venv RotorHazard/src/server/
 ```
 The previous installation ends up in the 'RotorHazard.old' directory, which may be deleted or moved.
 
-For RotorHazard the minimum version of Python supported is 3.7. If your Python is older than this, you should upgrade using the steps in the "Install RotorHazard" section under "5. [Install Python](#python)."
+For RotorHazard the minimum version of Python supported is 3.8. If your Python is older than this, you should upgrade using the steps in the "Install RotorHazard" section under "5. [Install Python](#python)."
 
 The RotorHazard server dependencies should also be updated (be patient, this command may take a few minutes):
 ```
@@ -362,7 +362,7 @@ The RotorHazard server may be run on any computer with an operating system that 
 
 To install the RotorHazard server on these systems:
 
-1. If the computer does not already have Python installed, download and install Python from https://www.python.org/downloads . The minimum version of Python needed for RotorHazard is 3.7. To check if Python is installed and the version, open up a command prompt and enter ```python --version```
+1. If the computer does not already have Python installed, download and install Python from https://www.python.org/downloads . The minimum version of Python needed for RotorHazard is 3.8. To check if Python is installed and the version, open up a command prompt and enter ```python --version```
 
 1. From the RotorHazard [Releases page on github](https://github.com/RotorHazard/RotorHazard/releases), download the "Source code (zip)" file.
 

--- a/src/server/RHTimeFns.py
+++ b/src/server/RHTimeFns.py
@@ -1,5 +1,4 @@
 # RHTimeFns:  Helpers for datetime and timezone functions.
-#             Supports python 2 and python 3
 
 from datetime import datetime
 

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -4,8 +4,8 @@ SERVER_API = 41 # Server API version
 NODE_API_SUPPORTED = 18 # Minimum supported node version
 NODE_API_BEST = 35 # Most recent node API
 JSON_API = 3 # JSON API version
-MIN_PYTHON_MAJOR_VERSION = 3 # minimum python version (3.7)
-MIN_PYTHON_MINOR_VERSION = 7
+MIN_PYTHON_MAJOR_VERSION = 3 # minimum python version (3.8)
+MIN_PYTHON_MINOR_VERSION = 8
 
 # This must be the first import for the time being. It is
 # necessary to set up logging *before* anything else


### PR DESCRIPTION
Gevent no longer supports python 3.7 and older versions have a known critical vulnerability. 

Closes #804 .