### PR TITLE
Make the backup folder present by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@
 
 # RH Database and backups
 *.db
-db_bkp
 
 # Local system configuration
 /src/server/config.json


### PR DESCRIPTION
This change makes the database backup folder present in the GitHub repo, but will still ignore new .db files. 

Perhaps we should also document somewhere where you can find database backups because until now it was a mystery to me that backups were apparently found in this folder.