### PR TITLE
Dependency cleanup

### DIFF
--- a/src/interface/BaseHardwareInterface.py
+++ b/src/interface/BaseHardwareInterface.py
@@ -1,6 +1,6 @@
 import gevent
 import logging
-from monotonic import monotonic
+from time import monotonic
 
 ENTER_AT_PEAK_MARGIN = 5 # closest that captured enter-at level can be to node peak RSSI
 CAP_ENTER_EXIT_AT_MILLIS = 3000  # number of ms for capture of enter/exit-at levels

--- a/src/interface/MockInterface.py
+++ b/src/interface/MockInterface.py
@@ -3,7 +3,7 @@
 import os
 import logging
 import gevent # For threads and timing
-from monotonic import monotonic # to capture read timing
+from time import monotonic # to capture read timing
 
 from Node import Node
 from BaseHardwareInterface import BaseHardwareInterface, PeakNadirHistory

--- a/src/interface/RHInterface.py
+++ b/src/interface/RHInterface.py
@@ -3,7 +3,7 @@
 import os
 import logging
 import gevent # For threads and timing
-from monotonic import monotonic # to capture read timing
+from time import monotonic # to capture read timing
 
 from Plugins import Plugins
 from BaseHardwareInterface import BaseHardwareInterface, PeakNadirHistory

--- a/src/interface/i2c_helper.py
+++ b/src/interface/i2c_helper.py
@@ -7,7 +7,7 @@ except:
 import gevent
 import os
 import logging
-from monotonic import monotonic
+from time import monotonic
 
 I2C_CHILL_TIME = float(os.environ.get('RH_I2C_SLEEP', '0.015')) # Delay after i2c read/write
 

--- a/src/interface/i2c_node.py
+++ b/src/interface/i2c_node.py
@@ -1,6 +1,6 @@
 '''RotorHazard I2C interface layer.'''
 import logging
-from monotonic import monotonic
+from time import monotonic
 
 from Node import Node
 from RHInterface import READ_ADDRESS, READ_REVISION_CODE, MAX_RETRY_COUNT, \

--- a/src/interface/serial_node.py
+++ b/src/interface/serial_node.py
@@ -3,7 +3,7 @@ import logging
 import serial # For serial comms
 import gevent
 import time
-from monotonic import monotonic
+from time import monotonic
 
 from Node import Node
 from RHInterface import READ_REVISION_CODE, READ_MULTINODE_COUNT, MAX_RETRY_COUNT, \

--- a/src/server/ClusterNodeSet.py
+++ b/src/server/ClusterNodeSet.py
@@ -4,7 +4,7 @@ import logging
 import gevent
 import json
 import socketio
-from monotonic import monotonic
+from time import monotonic
 import RHUtils
 from RHRace import RaceStatus
 from eventmanager import Evt

--- a/src/server/PageCache.py
+++ b/src/server/PageCache.py
@@ -9,7 +9,7 @@ if new data becomes available during the build process.
 '''
 
 import logging
-from monotonic import monotonic
+from time import monotonic
 from eventmanager import Evt
 import RHUtils
 import gevent

--- a/src/server/RHData.py
+++ b/src/server/RHData.py
@@ -16,7 +16,7 @@ import glob
 import RHUtils
 import Database
 import Results
-from monotonic import monotonic
+from time import monotonic
 from eventmanager import Evt
 from RHRace import RaceStatus, WinCondition, StagingTones
 from Database import ProgramMethod, HeatAdvanceType, HeatStatus

--- a/src/server/RHRace.py
+++ b/src/server/RHRace.py
@@ -10,7 +10,7 @@ import Config
 import random
 from datetime import datetime
 from flask import request
-from monotonic import monotonic
+from time import monotonic
 from eventmanager import Evt
 from util.InvokeFuncQueue import InvokeFuncQueue
 from RHUtils import catchLogExceptionsWrapper

--- a/src/server/Results.py
+++ b/src/server/Results.py
@@ -11,7 +11,7 @@ import gevent
 import RHUtils
 from RHUtils import catchLogExceptionsWrapper, cleanVarName
 import logging
-from monotonic import monotonic
+from time import monotonic
 from RHRace import RaceStatus, StartBehavior, WinCondition, WinStatus
 
 logger = logging.getLogger(__name__)

--- a/src/server/VRxControl.py
+++ b/src/server/VRxControl.py
@@ -4,7 +4,7 @@
 
 import logging
 from RHUtils import catchLogExceptionsWrapper
-from monotonic import monotonic
+from time import monotonic
 from eventmanager import Evt
 
 DEVICE_TIMEOUT = 30 # Consider devices if no response received within X seconds

--- a/src/server/eventmanager.py
+++ b/src/server/eventmanager.py
@@ -6,7 +6,7 @@ import logging
 import gevent
 import copy
 from RHUtils import catchLogExceptionsWrapper
-from monotonic import monotonic
+from time import monotonic
 
 logger = logging.getLogger(__name__)
 

--- a/src/server/plugins/rh_led_handler_character/__init__.py
+++ b/src/server/plugins/rh_led_handler_character/__init__.py
@@ -9,7 +9,7 @@ from eventmanager import Evt
 from led_event_manager import LEDEffect, LEDEvent, Color, ColorVal
 from RHRace import RaceStatus
 import gevent
-from monotonic import monotonic
+from time import monotonic
 
 logger = logging.getLogger(__name__)
 

--- a/src/server/plugins/rh_led_handler_strip/__init__.py
+++ b/src/server/plugins/rh_led_handler_strip/__init__.py
@@ -5,7 +5,7 @@ from led_event_manager import LEDEffect, LEDEvent, Color, ColorVal, ColorPattern
 import gevent
 import random
 import math
-from monotonic import monotonic
+from time import monotonic
 
 
 def leaderProxy(args):

--- a/src/server/reqsNonPi.txt
+++ b/src/server/reqsNonPi.txt
@@ -22,7 +22,5 @@ greenlet==3.0.*
 cffi==1.15.*
 
 # Other
-monotonic==1.5.*
 pyserial==3.4.*
-paho-mqtt==1.5.*
 requests==2.30.*

--- a/src/server/requirements.txt
+++ b/src/server/requirements.txt
@@ -22,9 +22,7 @@ greenlet==3.0.*
 cffi==1.15.*
 
 # Other
-monotonic==1.5.*
 pyserial==3.4.*
-paho-mqtt==1.5.*
 requests==2.30.*
 
 # Pi IO


### PR DESCRIPTION
- Migrate monotonic from independent module to `time` (its simply an alias now)
- Remove unused MQTT module

Builds on #814 