### PR TITLE
Improve frontend status displays

### DIFF
--- a/src/server/static/rotorhazard.css
+++ b/src/server/static/rotorhazard.css
@@ -775,6 +775,19 @@ main {
 	margin: 0 auto;
 }
 
+/* Socket status */
+
+.socket-warning {
+	text-align: center;
+	padding: 0.25rem;
+	border: solid 0.125em hsl(13.1, 64.6%, 37.6%);
+	background: hsl(8.2, 86.5%, 53.7%);
+	background: -moz-linear-gradient(top, hsl(8.2, 86.5%, 53.7%) 0%, hsl(13.1, 64.6%, 37.6%) 100%);
+	background: -webkit-linear-gradient(top, hsl(8.2, 86.5%, 53.7%) 0%,hsl(13.1, 64.6%, 37.6%) 100%);
+	background: linear-gradient(to bottom, hsl(8.2, 86.5%, 53.7%) 0%,hsl(13.1, 64.6%, 37.6%) 100%);
+	color: #fff;
+}
+
 /* Home */
 
 .page-home .header h1 {

--- a/src/server/static/rotorhazard.css
+++ b/src/server/static/rotorhazard.css
@@ -874,8 +874,8 @@ main.page-home {
 .timing-clock .warning {
 	position: absolute;
 	left: 0.25em;
-	line-height: 1.3;
-	display: none;
+	font-size: 1.2rem;
+	text-align: left;
 }
 
 #next-round {

--- a/src/server/static/rotorhazard.js
+++ b/src/server/static/rotorhazard.js
@@ -1597,6 +1597,16 @@ jQuery(document).ready(function($){
 		}
 	});
 
+	// display socket status
+	function socket_listener() {
+		if (socket.connected) {
+			$('.socket-warning').slideUp();
+		} else {
+			$('.socket-warning').slideDown();
+		}
+	}
+	setInterval(socket_listener, 1000);
+
 	// popup messaging
 	socket.on('priority_message', function (msg) {
 		push_message(msg.message, msg.interrupt);

--- a/src/server/static/rotorhazard.js
+++ b/src/server/static/rotorhazard.js
@@ -1362,6 +1362,9 @@ rotorhazard.timer.race.callbacks.step = function(timer){
 	}
 	$('.time-display').html(timer.renderHTML());
 }
+rotorhazard.timer.race.callbacks.stop = function(timer){
+	$('.time-display').html(timer.renderHTML());
+}
 rotorhazard.timer.race.callbacks.expire = function(timer){
 	// play expired tone
 	if (rotorhazard.use_mp3_tones) {

--- a/src/server/static/rotorhazard.js
+++ b/src/server/static/rotorhazard.js
@@ -16,9 +16,9 @@ const LEADER_FLAG_CHAR = 'L';
 const WINNER_FLAG_CHAR = 'W';
 
 // Display sync warning above (ms)
-const SYNC_WARNING_THRESHOLD_1 = 10
-const SYNC_WARNING_THRESHOLD_3 = 50
-const SYNC_WARNING_THRESHOLD_10 = 100
+const SYNC_WARNING_THRESHOLD_1 = 2
+const SYNC_WARNING_THRESHOLD_3 = 10
+const SYNC_WARNING_THRESHOLD_10 = 60
 
 var speakObjsQueue = [];
 var checkSpeakQueueFlag = true;

--- a/src/server/static/rotorhazard.js
+++ b/src/server/static/rotorhazard.js
@@ -15,6 +15,11 @@ const MAX_LOG_VOLUME = 1.0;
 const LEADER_FLAG_CHAR = 'L';
 const WINNER_FLAG_CHAR = 'W';
 
+// Display sync warning above (ms)
+const SYNC_WARNING_THRESHOLD_1 = 10
+const SYNC_WARNING_THRESHOLD_3 = 50
+const SYNC_WARNING_THRESHOLD_10 = 100
+
 var speakObjsQueue = [];
 var checkSpeakQueueFlag = true;
 var checkSpeakQueueCntr = 0;
@@ -1079,6 +1084,8 @@ var rotorhazard = {
 	pi_time_request: false,
 	server_time_differential: null,
 	server_time_differential_samples: [], // stored previously acquired offsets
+	has_server_sync: false,
+	sync_within: Infinity,
 	winner_declared_flag: false,
 
 	timer: {
@@ -1087,6 +1094,9 @@ var rotorhazard = {
 		stopAll: function() {
 			this.deferred.stop();
 			this.race.stop();
+		},
+		running: function() {
+			return (this.deferred.running || this.race.running);
 		}
 	},
 	saveData: function() {
@@ -1254,6 +1264,9 @@ rotorhazard.timer.deferred.callbacks.start = function(timer){
 	}
 }
 rotorhazard.timer.deferred.callbacks.step = function(timer){
+	if (rotorhazard.has_server_sync && timer.warn_until < window.performance.now()) {
+		$('.timing-clock .warning').hide();
+	}
 	if (rotorhazard.voice_race_timer != 0) {
 		if (timer.time_tenths < -36000 && !(timer.time_tenths % -36000)) { // 2+ hour callout
 			var hours = timer.time_tenths / -36000;
@@ -1287,6 +1300,14 @@ rotorhazard.timer.deferred.callbacks.expire = function(timer){
 	rotorhazard.timer.deferred.stop();
 	$('.time-display').html(__('Wait'));
 }
+rotorhazard.timer.deferred.callbacks.self_resync = function(timer){
+	// display resync warning
+	if (rotorhazard.has_server_sync) {
+		$('.timing-clock .warning .value').text(__('recovery'));
+	}
+	timer.warn_until = window.performance.now() + 3000;
+	$('.timing-clock .warning').show();
+}
 
 // race/staging timer callbacks
 rotorhazard.timer.race.phased_staging = true;
@@ -1297,7 +1318,7 @@ rotorhazard.timer.race.callbacks.start = function(timer){
 }
 
 rotorhazard.timer.race.callbacks.step = function(timer){
-	if (timer.warn_until < window.performance.now()) {
+	if (rotorhazard.has_server_sync && timer.warn_until < window.performance.now()) {
 		$('.timing-clock .warning').hide();
 	}
 	if (timer.time_tenths < 0) {
@@ -1377,6 +1398,9 @@ rotorhazard.timer.race.callbacks.expire = function(timer){
 }
 rotorhazard.timer.race.callbacks.self_resync = function(timer){
 	// display resync warning
+	if (rotorhazard.has_server_sync) {
+		$('.timing-clock .warning .value').text(__('recovery'));
+	}
 	timer.warn_until = window.performance.now() + 3000;
 	$('.timing-clock .warning').show();
 }

--- a/src/server/templates/layout-basic.html
+++ b/src/server/templates/layout-basic.html
@@ -63,6 +63,10 @@
 </head>
 
 <body>
+	<aside>
+		<div class="socket-warning" style="display:none">{{ __('Server connection lost') }}</div>
+	</aside>
+
 	<!--Child template content-->
 	{% block content %}{% endblock %}
 </body>

--- a/src/server/templates/layout.html
+++ b/src/server/templates/layout.html
@@ -103,6 +103,10 @@
 		</nav>
 	</header>
 
+	<aside>
+		<div class="socket-warning" style="display:none">{{ __('Server connection lost') }}</div>
+	</aside>
+
 	<!--Child template content-->
 	{% block content %}{% endblock %}
 

--- a/src/server/templates/run.html
+++ b/src/server/templates/run.html
@@ -365,6 +365,8 @@
 					$('body').removeClass('race-stopped');
 					$('body').addClass('race-new');
 					$('.timing-clock').removeClass('staging');
+					rotorhazard.timer.race.stop();
+					rotorhazard.timer.race.renderHTML();
 					if (resume_check) {
 						socket.emit('get_race_scheduled');
 					}

--- a/src/server/templates/run.html
+++ b/src/server/templates/run.html
@@ -109,7 +109,21 @@
 			for (var i in rotorhazard.server_time_differential_samples) {
 				a = Math.min(a, rotorhazard.server_time_differential_samples[i].response);
 			}
-			$('#server-lag').html('<p>Sync quality: within ' + a + 'ms (' + rotorhazard.server_time_differential_samples.length + '/' + max_samples + ' samples)</p>');
+			rotorhazard.sync_within = Math.ceil(a);
+
+			$('#server-lag').html('<p>Sync quality: within ' + rotorhazard.sync_within + 'ms (' + rotorhazard.server_time_differential_samples.length + '/' + max_samples + ' samples)</p>');
+
+			if (
+				(max_samples >= 10 && SYNC_WARNING_THRESHOLD_10 > rotorhazard.sync_within) ||
+				(max_samples >= 3 && SYNC_WARNING_THRESHOLD_3 > rotorhazard.sync_within) ||
+				SYNC_WARNING_THRESHOLD_1 > rotorhazard.sync_within) {
+				rotorhazard.has_server_sync = true;
+				if (!rotorhazard.timer.running()) {
+					$('.timing-clock .warning').hide();
+				}
+			} else {
+				$('.timing-clock .warning .value').text(rotorhazard.sync_within + 'ms');
+			}
 		});
 
 		socket.on('language', function (msg) {
@@ -2231,7 +2245,13 @@
 <div id="main_panel" class="panel">
 	<div class="panel-content full-width">
 		<div class="timer">
-			<div class="timing-clock"><div class="warning" title="Browser Sync Loss">&#9888;&#xFE0E;</div><div class="time-display">--:--</div></div>
+			<div class="timing-clock">
+				<div class="warning">
+					<div class="symbol">&#9888;&#xFE0E; {{ __('Sync') }}</div>
+					<div class="value">{{ __('Acquiring') }}</div>
+				</div>
+				<div class="time-display">--:--</div>
+			</div>
 		</div>
 
 		<!--Buttons for controlling the race-->


### PR DESCRIPTION
- Display alert when socket unavailable
- Reset timer after server issue
- Display poor browser sync warning
- Make browser sync recovery display more obvious

Calibration of sync alert thresholds is needed based on testing of real devices.