### PR TITLE
Pi 5 support

### DIFF
--- a/doc/Real Time Clock.md
+++ b/doc/Real Time Clock.md
@@ -1,6 +1,8 @@
 # Real Time Clock
 
-The standard Raspberry Pi does not feature a real-time clock (RTC) -- when it has an internet connection the Pi will fetch the current date and time from an online server, but if an internet connection is not available when the Pi starts up, its date/time will be wrong.  (It will usually revert to the last date/time it was using, and go from there.)
+**Note:** These instructions are not compatible with the Raspberry Pi 5. The Pi 5 has an onboard real-time clock, so the recommended setup is to install a [backup battery](https://www.raspberrypi.com/documentation/computers/raspberry-pi-5.html#adding-a-backup-battery) onto the Pi 5 board (and not install an external RTC module). 
+
+The standard Raspberry Pi (before the Pi 5) does not feature a real-time clock (RTC) -- when it has an internet connection the Pi will fetch the current date and time from an online server, but if an internet connection is not available when the Pi starts up, its date/time will be wrong.  (It will usually revert to the last date/time it was using, and go from there.)
 
 Adding a real-time clock module addresses this problem.  The [DS3231](https://www.adafruit.com/product/3013) module is recommended, as it keeps very accurate time.  There are other, cheaper modules that will also do the job (albeit with less precision), such as the [PCF8523](https://www.adafruit.com/product/3295) and [DS1307](https://www.adafruit.com/product/3296).
 

--- a/doc/Software Setup.md
+++ b/doc/Software Setup.md
@@ -28,7 +28,7 @@ Note: Many of the setup commands below require that the Rasperry Pi has internet
 
 Install the Raspberry Pi OS, following the official instructions: https://www.raspberrypi.org/help
 
-The standard-recommended setup is to use a Raspberry Pi 3 or Pi 4 board, install the [Raspberry Pi OS](https://www.raspberrypi.org/software/operating-systems/#raspberry-pi-os-32-bit) (Desktop), and configure it with a user named "pi".
+The standard-recommended setup is to use a Raspberry Pi 3, Pi 4 or Pi 5 board, install the [Raspberry Pi OS](https://www.raspberrypi.org/software/operating-systems/#raspberry-pi-os-32-bit) (Desktop), and configure it with a user named "pi".
 
 Tip: Any time you intend to use a monitor (via HDMI) with the Raspberry Pi, connect it before powering up the Pi. Connecting the monitor after power up tends to not work (blank screen).
 
@@ -64,7 +64,7 @@ Add the following lines to the end of the file:
 dtparam=i2c_baudrate=75000
 dtoverlay=miniuart-bt
 ```
-If the Raspberry Pi in use is a Pi 3 model or older (not a Pi 4) then also add this line:
+If the Raspberry Pi in use is a Pi 3 model or older (not a Pi 4 or 5) then add this line:
 ```
 core_freq=250
 ```
@@ -72,7 +72,15 @@ core_freq=250
 ```
 dtoverlay=act-led,gpio=24
 dtparam=act_led_trigger=heartbeat
+```
+If the Raspberry Pi in use is a Pi 4 model or older (not a Pi 5) then add this line:
+```
 dtoverlay=gpio-shutdown,gpio_pin=18,debounce=5000
+```
+If the Raspberry Pi in use is a Pi 5 model then add these lines:
+```
+dtoverlay=uart0-pi5
+dtoverlay=i2c1-pi5
 ```
 Save and exit the editor (CTRL-X, Y, ENTER)
 
@@ -82,9 +90,11 @@ The first line sets the transfer rate on the I2C bus (which is used to communica
 
 The "dtoverlay=miniuart-bt" line moves the high performance UART from the Bluetooth device to the GPIO pins, which is needed for setups like the S32_BPill that use the serial port as the communications channel to the nodes.
 
-The "core_freq" line fixes a potential variable clock-rate issue, described [here](https://www.abelectronics.co.uk/kb/article/1089/i2c--smbus-and-raspbian-stretch-linux). If a Raspberry Pi 4 is being used, the "core_freq" line should be omitted (as per the Raspberry Pi documentation [here](https://www.raspberrypi.org/documentation/configuration/config-txt/overclocking.md)).
+The "core_freq" line fixes a potential variable clock-rate issue, described [here](https://www.abelectronics.co.uk/kb/article/1089/i2c--smbus-and-raspbian-stretch-linux). If a Raspberry Pi 4 or Pi 5 is being used, the "core_freq" line should be omitted (as per the Raspberry Pi documentation [here](https://www.raspberrypi.org/documentation/configuration/config-txt/overclocking.md)).
 
 For the S32_BPill setup, the "dtoverlay=act-led,gpio=24" and "dtparam=act_led_trigger=heartbeat" lines configure a Raspberry-Pi-heartbeat signal that the BPill processor monitors to track the status of the Pi. The "dtoverlay=gpio-shutdown..." line makes it so the shutdown button still operates if the RotorHazard server is not running.
+
+If the Raspberry Pi 5 is being used, the "dtoverlay=uart0-pi5" and "dtoverlay=i2c1-pi5" lines configure the devices to operate similar to how they do with the Pi 3 & 4. 
 
 
 ### 4. Perform System Update
@@ -102,7 +112,7 @@ sudo apt install python3-dev python3-venv libffi-dev python3-smbus build-essenti
 Enter the following commands to setup the Python virtual environment:
 ```
 cd ~
-python -m venv .venv
+python -m venv --system-site-packages .venv
 ```
 Configure the user shell to automatically activate the Python virtual environment by entering the command `nano .bashrc` to edit the ".bashrc" file and adding the following lines to the end of the file:
 ```
@@ -313,7 +323,7 @@ java -version
 ```
 If the response is "command not found" then Java needs to be installed.
 
-For the Raspberry Pi 3 or Pi 4, use the following command:
+For the Raspberry Pi 3 or newer, use the following command:
 ```
 sudo apt install default-jdk-headless
 ```
@@ -372,7 +382,7 @@ The RotorHazard server may be run on any computer with an operating system that 
 
 4. Open up a command prompt and navigate to the topmost RotorHazard directory.
 
-5. Create a Python virtual environment ('venv') by entering: ```python -m venv venv```
+5. Create a Python virtual environment ('venv') by entering: ```python -m venv --system-site-packages .venv```
 
 6. Activate the Python virtual environment ('venv'):
 

--- a/src/server/RHUtils.py
+++ b/src/server/RHUtils.py
@@ -90,9 +90,8 @@ def idAndLogSystemInfo():
     try:
         modelStr = None
         try:
-            fileHnd = open("/proc/device-tree/model", "r")
-            modelStr = fileHnd.read()
-            fileHnd.close()
+            with open("/proc/device-tree/model", 'r') as fileHnd:
+                modelStr = fileHnd.read()
         except:
             pass
         if modelStr and "raspberry pi" in modelStr.lower():
@@ -114,13 +113,18 @@ def is_sys_raspberry_pi():
 def is_S32_BPill_board():
     return S32_BPill_board_flag
 
+# Debug-test function for setting the S32_BPill-board-detected flag
 def set_S32_BPill_boardFlag():
     global S32_BPill_board_flag
     S32_BPill_board_flag = True
 
-# Return True if real hardware GPIO detected
+# Returns True if real hardware GPIO detected
 def is_real_hw_GPIO():
-    return RH_GPIO.is_real_RPi_GPIO()
+    return RH_GPIO.is_real_hw_GPIO()
+
+# Returns a string indicating the type of GPIO detected
+def get_GPIO_type_str():
+    return RH_GPIO.get_GPIO_type_str()
 
 # Returns "primary" IP address for local host.  Based on:
 #  https://stackoverflow.com/questions/166506/finding-local-ip-addresses-using-pythons-stdlib

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -36,6 +36,9 @@ _program_start_epoch_time = int((_prog_start_epoch1 + _prog_start_epoch2) * 500.
 logger.info('RotorHazard v{0}'.format(RELEASE_VERSION))
 
 # Normal importing resumes here
+import RHUtils  # need to import this early to get RH_GPIO initialized before gevent, etc
+from RHUtils import catchLogExceptionsWrapper
+
 import gevent.monkey
 gevent.monkey.patch_all()
 
@@ -57,8 +60,6 @@ import string
 import json
 
 import Config
-import RHUtils
-from RHUtils import catchLogExceptionsWrapper
 
 RHUtils.checkPythonVersion(MIN_PYTHON_MAJOR_VERSION, MIN_PYTHON_MINOR_VERSION)
 
@@ -601,8 +602,8 @@ def stop_background_threads():
             HEARTBEAT_THREAD.kill(block=True, timeout=0.5)
             HEARTBEAT_THREAD = None
         RaceContext.interface.stop()
-    except Exception:
-        logger.error("Error stopping background threads")
+    except:
+        logger.exception("Error stopping background threads")
 
 #
 # Socket IO Events
@@ -2952,12 +2953,12 @@ if (not RHUtils.is_S32_BPill_board()) and Config.GENERAL['FORCE_S32_BPILL_FLAG']
     logger.info("Set S32BPillBoardFlag in response to FORCE_S32_BPILL_FLAG in config")
 
 logger.debug("isRPi={}, isRealGPIO={}, isS32BPill={}".format(RHUtils.is_sys_raspberry_pi(), \
-                                                             RHUtils.is_real_hw_GPIO(), RHUtils.is_S32_BPill_board()))
+                                         RHUtils.get_GPIO_type_str(), RHUtils.is_S32_BPill_board()))
 if RHUtils.is_sys_raspberry_pi() and not RHUtils.is_real_hw_GPIO():
-    logger.warning("Unable to access real GPIO on Pi; try:  pip install RPi.GPIO")
+    logger.warning("Unable to access real GPIO on Pi; libraries may need to be installed")
     set_ui_message(
         'gpio',
-        __("Unable to access real GPIO on Pi. Try: <code>pip install RPi.GPIO</code>"),
+        __("Unable to access real GPIO on Pi libraries may need to be installed"),
         header='Warning',
         subclass='no-access'
         )

--- a/src/server/util/ButtonInputHandler.py
+++ b/src/server/util/ButtonInputHandler.py
@@ -65,6 +65,7 @@ class ButtonInputHandler:
             self.longPressReachedFlag = False
             self.lastInputLevel = RH_GPIO.UNKNOWN
             self.pressedStartTimeSecs = 0
+            RH_GPIO.close_channel(self.gpioPinNum)
 
     def isEnabled(self):
         return self.enabledFlag

--- a/src/server/util/RH_GPIO.py
+++ b/src/server/util/RH_GPIO.py
@@ -1,49 +1,66 @@
 # Utility class for Raspberry Pi GPIO functions
 
 import time
-import sys
-
-sys.path.append('util')  # needed at runtime to find FakeRPiGPIO module
 
 try:
-    import RPi.GPIO as GPIO
-    Real_RPi_GPIO_flag = True
+    import lgpio
+    import gpiozero
+    Real_GPIO_Zero_flag = True
+    Real_RPi_GPIO_flag = False
+    GPIO = {}
 except ImportError:
-    import FakeRPiGPIO as GPIO
-    Real_RPi_GPIO_flag = False
+    try:
+        import RPi.GPIO as GPIO
+        Real_GPIO_Zero_flag = False
+        Real_RPi_GPIO_flag = True
+    except ImportError:
+        Real_GPIO_Zero_flag = False
+        Real_RPi_GPIO_flag = False
+        GPIO = {}
 except:  # need extra exception catch for Travis CI tests
-    import FakeRPiGPIO as GPIO
+    Real_GPIO_Zero_flag = False
     Real_RPi_GPIO_flag = False
-# if RPi.GPIO not available then use FakeRiGPIO from https://github.com/sn4k3/FakeRPi
+    GPIO = {}
 
-# alias these GPIO constants so they can be referenced using RH_GPIO
-BOARD = GPIO.BOARD
-BCM = GPIO.BCM
-IN = GPIO.IN
-OUT = GPIO.OUT
-SPI = GPIO.SPI
-I2C = GPIO.I2C
-HARD_PWM = GPIO.HARD_PWM
-SERIAL = GPIO.SERIAL
-UNKNOWN = GPIO.UNKNOWN
-PUD_DOWN = GPIO.PUD_DOWN
-PUD_UP = GPIO.PUD_UP
-PUD_OFF = GPIO.PUD_OFF
-LOW = GPIO.LOW
-HIGH = GPIO.HIGH
-FALLING = GPIO.FALLING
-RISING = GPIO.RISING
-BOTH = GPIO.BOTH
+# setup these GPIO constants so they can be referenced using RH_GPIO
+BOARD = getattr(GPIO, "BOARD", 0)
+BCM =  getattr(GPIO, "BCM", 1)
+IN =  getattr(GPIO, "IN", 0)
+OUT =  getattr(GPIO, "OUT", 1)
+UNKNOWN =  getattr(GPIO, "UNKNOWN", -1)
+PUD_DOWN =  getattr(GPIO, "PUD_DOWN", 0)
+PUD_UP =  getattr(GPIO, "PUD_UP", 1)
+PUD_OFF =  getattr(GPIO, "PUD_OFF", -1)
+LOW =  getattr(GPIO, "LOW", 0)
+HIGH =  getattr(GPIO, "HIGH", 1)
+FALLING =  getattr(GPIO, "FALLING", 0)
+RISING =  getattr(GPIO, "RISING", 1)
+BOTH =  getattr(GPIO, "BOTH", 2)
 
+Input_devices_dict = {}
+Output_devices_dict = {}
 
-# Return True if real hardware GPIO detected
-def is_real_RPi_GPIO():
-    return Real_RPi_GPIO_flag
+# Returns True if real hardware GPIO detected
+def is_real_hw_GPIO():
+    return Real_GPIO_Zero_flag or Real_RPi_GPIO_flag
+
+# Returns a string indicating the type of GPIO detected
+def get_GPIO_type_str():
+    if Real_GPIO_Zero_flag:
+        return "True (GPIO Zero)"
+    if Real_RPi_GPIO_flag:
+        return "True (RPi.GPIO)"
+    return "False"
 
 # Returns True if given input pin is tied low (to GND)
 def check_input_tied_low(pin_id):
     ret_flag = False
-    if Real_RPi_GPIO_flag:
+    if Real_GPIO_Zero_flag:
+        input_dev = gpiozero.InputDevice(pin_id, pull_up=True)
+        time.sleep(0.05)
+        ret_flag = input_dev.is_active
+        input_dev.close()
+    elif Real_RPi_GPIO_flag:
         GPIO.setmode(GPIO.BCM)
         GPIO.setup(pin_id, GPIO.IN, pull_up_down=GPIO.PUD_UP)
         time.sleep(0.05)
@@ -53,8 +70,36 @@ def check_input_tied_low(pin_id):
 
 # Set up channel as an input or an output
 def setup(channel, mode, *args, **kwargs):
-    if Real_RPi_GPIO_flag:
+    if Real_GPIO_Zero_flag:
+        if mode == OUT:
+            if Output_devices_dict.get(channel):
+                Output_devices_dict[channel].close()
+                del Output_devices_dict[channel]
+            if Input_devices_dict.get(channel):
+                Input_devices_dict[channel].close()
+                del Input_devices_dict[channel]
+            Output_devices_dict[channel] = gpiozero.OutputDevice(channel)
+        else:
+            if Input_devices_dict.get(channel):
+                Input_devices_dict[channel].close()
+                del Input_devices_dict[channel]
+            if Output_devices_dict.get(channel):
+                Output_devices_dict[channel].close()
+                del Output_devices_dict[channel]
+            Input_devices_dict[channel] = gpiozero.InputDevice(channel, \
+                                              pull_up=(kwargs.get("pull_up_down")==PUD_UP))
+    elif Real_RPi_GPIO_flag:
         GPIO.setup(channel, mode, *args, **kwargs)
+
+# Performs cleanup action on the given channel
+def close_channel(channel):
+    if Real_GPIO_Zero_flag:
+        if Input_devices_dict.get(channel):
+            Input_devices_dict[channel].close()
+            del Input_devices_dict[channel]
+        if Output_devices_dict.get(channel):
+            Output_devices_dict[channel].close()
+            del Output_devices_dict[channel]
 
 # Set numbering mode for IO pins
 def setmode(mode):
@@ -63,12 +108,26 @@ def setmode(mode):
 
 # Read the value of a GPIO pin
 def input(channel):  #pylint: disable=redefined-builtin
-    if Real_RPi_GPIO_flag:
+    if Real_GPIO_Zero_flag:
+        input_dev = Input_devices_dict.get(channel)
+        if input_dev:
+            return LOW if input_dev.is_active else HIGH
+        return HIGH
+    elif Real_RPi_GPIO_flag:
         return GPIO.input(channel)
-    return LOW
+    return HIGH
 
 # Set output state of a GPIO pin
 def output(channel, state):
-    if Real_RPi_GPIO_flag:
+    if Real_GPIO_Zero_flag:
+        output_dev = Output_devices_dict.get(channel)
+        if output_dev:
+            if state == HIGH:
+                output_dev.on()
+            else:
+                output_dev.off()
+        else:
+            return UNKNOWN
+    elif Real_RPi_GPIO_flag:
         return GPIO.output(channel, state)
     return LOW


### PR DESCRIPTION
Implemented support for Raspberry Pi 5.  Node-code firmware should be updated to v1.1.5 (which fixes issue with buzzer sounding at startup).

Note that for setting up the Python virtual environment  ('venv') the command is now:
`python -m venv --system-site-packages .venv`

The "--system-site-packages" parameter is needed to copy over the newer version 'lgpio' library (v0.2.2.0).  Trying to install it later seems to result in an older (incompatible) 'lgpio' library getting installed.

Note also that for Pi 5 the "/boot/config.txt" file needs to contain the lines below (as noted in the Software Setup doc):
```
dtoverlay=uart0-pi5
dtoverlay=i2c1-pi5
```
