### PR TITLE
Draft: Improve RainbowCycle loop and logging in ClusterNodeSet

### DIFF
--- a/src/server/ClusterNodeSet.py
+++ b/src/server/ClusterNodeSet.py
@@ -134,6 +134,7 @@ class SecondaryNode:
         self.start_connection()
 
     def start_connection(self):
+        logger.debug("Starting connection for secondary timer {}".format(self.id+1))
         self.startConnectTime = 0
         self.lastContactTime = -1
         self.firstContactTime = 0
@@ -151,11 +152,12 @@ class SecondaryNode:
             self.timeDiffMedianObj = RunningMedian(self.TIMEDIFF_MEDIAN_SIZE)
         self.timeDiffMedianMs = 0
         self.progStartEpoch = 0
-        gevent.spawn(self.secondary_worker_thread)
         self.runningFlag = True
+        gevent.spawn(self.secondary_worker_thread)
 
     def secondary_worker_thread(self):
         self.startConnectTime = monotonic()
+        logger.debug("Started worker thread for secondary timer {}".format(self.id+1))
         gevent.sleep(0.1)
         while self.runningFlag:
             try:
@@ -277,6 +279,7 @@ class SecondaryNode:
                     logger.exception("Exception in SecondaryNode worker thread for secondary {} (sio.conn={})".\
                                      format(self.id+1, self.sio.connected))
                     gevent.sleep(9)
+        logger.debug("Exiting worker thread for secondary timer {}".format(self.id+1))
 
     def emit(self, event, data = None):
         try:
@@ -699,11 +702,12 @@ class ClusterNodeSet:
                 del args['_eventName']
                 payload['evt_args'] = json.dumps(args, default=lambda _: '<not serializiable>')
                 self.emitEventTrigger(payload)
-        except Exception as ex:
-            logger.exception("Exception in 'Events.trigger()': " + ex)
+        except:
+            logger.exception("Exception in 'Events.trigger()'")
 
     def shutdown(self):
         for secondary in self.secondaries:
+            logger.debug("Setting 'runningFlag' to False on secondary timer {}".format(secondary.id+1))
             secondary.runningFlag = False
 
     def addSecondary(self, secondary):

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -583,6 +583,8 @@ def start_background_threads(forceFlag=False):
     if BACKGROUND_THREADS_ENABLED or forceFlag:
         BACKGROUND_THREADS_ENABLED = True
         RaceContext.interface.start()
+        if getattr(RaceContext.led_manager,"setEnabledFlag"):
+            RaceContext.led_manager.setEnabledFlag(True)
         global HEARTBEAT_THREAD
         if HEARTBEAT_THREAD is None:
             HEARTBEAT_THREAD = gevent.spawn(heartbeat_thread_function)
@@ -594,6 +596,8 @@ def stop_background_threads():
         stop_shutdown_button_thread()
         if RaceContext.cluster:
             RaceContext.cluster.shutdown()
+        if getattr(RaceContext.led_manager,"setEnabledFlag"):
+            RaceContext.led_manager.setEnabledFlag(False)
         global BACKGROUND_THREADS_ENABLED
         BACKGROUND_THREADS_ENABLED = False
         global HEARTBEAT_THREAD


### PR DESCRIPTION
When rh_led_handler_strip 'rainbowCycle()' was invoked it would end up in an infinite loop and would prevent the server shutdown from finishing.  This mod makes it exit the loop when another LED pattern is selected or a server shutdown is initiated.