### PR TITLE
Add a way to set correct node to pilot on first heat

### DIFF
--- a/src/server/Database.py
+++ b/src/server/Database.py
@@ -72,7 +72,7 @@ class Pilot(Base):
         return "{} {}".format(__('Pilot'), id)
 
     def __repr__(self):
-        return '<Pilot %r>' % self.id
+        return '<Pilot %r %s>' % (self.id, self.display_name)
 
 class PilotAttribute(Base):
     __tablename__ = 'pilot_attribute'

--- a/src/server/heat_automation.py
+++ b/src/server/heat_automation.py
@@ -27,7 +27,7 @@ class HeatAutomator:
                 return 'safe'
 
             if calc_result['calc_success'] is True and calc_result['has_calc_pilots'] is False and not heat.auto_frequency:
-                # Heat has no calc issues, no dynamic slots, and auto-frequnecy is off
+                # Heat has no calc issues, no dynamic slots, and auto-frequency is off
                 return 'safe'
 
             adaptive = bool(self._racecontext.rhdata.get_optionInt('calibrationMode'))
@@ -180,7 +180,7 @@ class HeatAutomator:
                         'matches': []
                         })
 
-            # get frequency matches from pilots
+            # get band/frequency matches from pilots
             for slot in slots:
                 if slot.pilot_id:
                     used_frequencies_json = self._racecontext.rhdata.get_pilot(slot.pilot_id).used_frequencies
@@ -189,7 +189,7 @@ class HeatAutomator:
                         for node in available_seats:
                             end_idx = len(used_frequencies) - 1
                             for f_idx, pilot_freq in enumerate(used_frequencies):
-                                if node['frq']['f'] == pilot_freq['f']:
+                                if node['frq']['f'] == pilot_freq['f'] and node['frq']['b'] == pilot_freq['b']:
                                     node['matches'].append({
                                             'slot': slot,
                                             'band': pilot_freq['b'],
@@ -229,10 +229,18 @@ class HeatAutomator:
                                                 eliminated_matches[slot_idx]['slot'].node_index = available_seats[n_idx]['idx']
                                                 available_seats[n_idx] = None
                                                 break
+                                    elif eliminated_matches[slot_idx] \
+                                    and eliminated_matches[slot_idx]['band'] == 'O' \
+                                    and eliminated_matches[slot_idx]['priority'] == True:
+                                        for n_idx, node in enumerate(available_seats):
+                                            if node['frq']['b'] == 'O':
+                                                eliminated_matches[slot_idx]['slot'].node_index = available_seats[n_idx]['idx']
+                                                available_seats[n_idx] = None
+                                                break
                                     else:
                                         # else explicity avoid D-band
                                         for n_idx, node in enumerate(available_seats):
-                                            if node['frq']['b'] != 'D':
+                                            if node['frq']['b'] not in ['D', 'O']:
                                                 eliminated_matches[slot_idx]['slot'].node_index = available_seats[n_idx]['idx']
                                                 available_seats[n_idx] = None
                                                 break
@@ -250,12 +258,39 @@ class HeatAutomator:
                                 
                             eliminated_matches = [x for x in eliminated_matches if x is not None]
                         else:
-                            # place pilots with no history into first available slots
+                            # place pilots with no history into best available seats
                             for slot in slots:
+                                prefered_band = self._racecontext.rhdata.get_pilot_attribute_value(slot.pilot_id, 'prefered_band')
                                 if slot.node_index is None and slot.pilot_id:
                                     if len(available_seats):
-                                        slot.node_index = available_seats[0]['idx']
-                                        del(available_seats[0])
+                                        logger.info(f'ARNAUD pilot pref = {prefered_band}')
+                                        if prefered_band == 'dji':
+                                            for n_idx, node in enumerate(available_seats):
+                                                if node['frq']['b'] == 'D':
+                                                    slot.node_index = available_seats[n_idx]['idx']
+                                                    tmp_freq = node['frq']['f']
+                                                    # It's usually not a good idea to delete from a loop
+                                                    # but because break the line after, it's safe
+                                                    del(available_seats[n_idx])
+                                                    break
+                                        elif prefered_band == 'dji_o3':
+                                            for n_idx, node in enumerate(available_seats):
+                                                if node['frq']['b'] == 'O':
+                                                    slot.node_index = available_seats[n_idx]['idx']
+                                                    tmp_freq = node['frq']['f']
+                                                    del(available_seats[n_idx])
+                                                    break
+                                        else:
+                                            # Explicitely avoid D/O band
+                                            for n_idx, node in enumerate(available_seats):
+                                                if node['frq']['b'] not in ['D', 'O']:
+                                                    slot.node_index = available_seats[n_idx]['idx']
+                                                    tmp_freq = node['frq']['f']
+                                                    del(available_seats[n_idx])
+                                                    break
+
+                                        # keep only seats that are not close the the ones we choose
+                                        available_seats = [x for x in available_seats if x['frq']['f'] not in range(tmp_freq - 10, tmp_freq + 10)]
                                     else:
                                         logger.warning("Dropping pilot {}; No remaining available nodes for slot {}".format(slot.pilot_id, slot))
                             break

--- a/src/server/plugins/rh_dji_pilots/__init__.py
+++ b/src/server/plugins/rh_dji_pilots/__init__.py
@@ -1,0 +1,28 @@
+''' Pilot Prefered Band Selector '''
+
+import logging
+from eventmanager import Evt
+from RHUI import UIField, UIFieldType, UIFieldSelectOption
+
+logger = logging.getLogger(__name__)
+
+class PilotPreferedBandSelector():
+    def __init__(self, rhapi):
+        self._rhapi = rhapi
+        self.enabled = True
+
+    def initialize(self, _args):
+        logger.info('Initializing Pilot Prefered Band Selector')
+        options=[
+            UIFieldSelectOption('raceband', "RACEBAND"),
+            UIFieldSelectOption('dji', "DJI"),
+            UIFieldSelectOption('dji_o3', "DJI_O3"),
+        ]
+        self._rhapi.fields.register_pilot_attribute(
+            UIField('prefered_band', "Prefered Band", UIFieldType.SELECT,
+                    options=options, value='raceband'))
+
+def initialize(rhapi):
+    s = PilotPreferedBandSelector(rhapi)
+    rhapi.events.on(Evt.STARTUP, s.initialize)
+

--- a/src/server/plugins/rh_dji_pilots/manifest.json
+++ b/src/server/plugins/rh_dji_pilots/manifest.json
@@ -1,0 +1,13 @@
+{
+    "name": "DJI pilot frequency selector",
+    "author": "Arnaud Morin",
+    "author_uri": "https://github.com/arnaudmorin",
+    "description": "Allows setting a prefered frequency band (like D or O) on RotorHazard to help selecting best node",
+    "info_uri": "https://github.com/arnaudmorin",
+    "license": "APACHE 2.0",
+    "license_uri": "https://www.apache.org/licenses/LICENSE-2.0",
+    "version": "0.1.0",
+    "required_rhapi_version": "1.0",
+    "update_uri": null,
+    "text_domain": null
+}

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -898,6 +898,10 @@ def on_set_frequency_preset(data):
             bands = ['R', 'R', 'R', 'R']
             channels = [1, 3, 6, 7]
             freqs = [5658, 5732, 5843, 5880]
+        elif data['preset'] == 'RB-4-DO67':
+            bands = ['R', 'R', 'R', 'R', 'D', 'D', 'O', 'O']
+            channels = [1, 3, 6, 7, 6, 7, 6, 7]
+            freqs = [5658, 5732, 5843, 5880, 5880, 5914, 5876, 5912]
         elif data['preset'] == 'RB-8':
             bands = ['R', 'R', 'R', 'R', 'R', 'R', 'R', 'R']
             channels = [1, 2, 3, 4, 5, 6, 7, 8]

--- a/src/server/templates/decoder.html
+++ b/src/server/templates/decoder.html
@@ -744,6 +744,7 @@
 					<button class="set_frequency_preset" data-preset="IMD5C">{{ __('IMD5C') }}</button>
 					<button class="set_frequency_preset" data-preset="IMD6C">{{ __('IMD6C') }}</button>
 					<button class="set_frequency_preset" data-preset="RB-8">{{ __('Raceband 8') }}</button>
+			                <button class="set_frequency_preset" data-preset="RB-4-DO67">{{ __('R1367 D67 O67') }}</button>
 				</div>
 
 				<div class="node-list">

--- a/src/server/templates/settings.html
+++ b/src/server/templates/settings.html
@@ -1639,6 +1639,7 @@
 			<button class="set_frequency_preset" data-preset="IMD5C">{{ __('IMD5C') }}</button>
 			<button class="set_frequency_preset" data-preset="IMD6C">{{ __('IMD6C') }}</button>
 			<button class="set_frequency_preset" data-preset="RB-8">{{ __('Raceband 8') }}</button>
+			<button class="set_frequency_preset" data-preset="RB-4-DO67">{{ __('R1367 D67 O67') }}</button>
 		</div>
 
 		<div class="node-list">


### PR DESCRIPTION
During races, we do not only have R-band pilots.
Most of the time, few DJI/O3 pilots are also there.

So far, managing such pilots was painful as it needed a manual change either in nodes settings or heat pilot seats in order to have correct DJI pilots configured on correct nodes.

With this new plugin and associated patches, DJI pilots are automatically assigned to a D or O band node if available.

This is mostly useful on first heat, when no history has been recorded yet. On subsequent heats, the current algorithm would reuse the previous frequencies.

This commit is also introducing a new configuration for 8 nodes RH with:
- R1367 + D67 + O67

D67 and O67 are configured for DJI/DJI O3 pilots.

Note that:
- when D6 or O6 is select, R7 and O6 or D6 are then discarded
- when D7 or O7 is select, O7 or D7 are then discarded.

Fix bug GH-468