### PR TITLE
Improved gevent.sleep/thread management

### DIFF
--- a/src/server/RHData.py
+++ b/src/server/RHData.py
@@ -2777,7 +2777,7 @@ class RHData():
 
         return race_meta, new_heat
 
-    def get_results_savedRaceMeta(self, savedRaceMeta_or_id):
+    def get_results_savedRaceMeta(self, savedRaceMeta_or_id, no_rebuild_flag=False):
         race = self.resolve_savedRaceMeta_from_savedRaceMeta_or_id(savedRaceMeta_or_id)
 
         if race is False:
@@ -2801,6 +2801,9 @@ class RHData():
             logger.error('Race {} cache has invalid status'.format(race.id))
             token = monotonic()
             self.clear_results_savedRaceMeta(race, token)
+
+        if no_rebuild_flag:
+            return None
 
         # cache rebuild
         logger.debug('Building Race {} (Heat {} Round {}) results'.format(race.id, race.heat_id, race.round_id))

--- a/src/server/RHUtils.py
+++ b/src/server/RHUtils.py
@@ -11,6 +11,7 @@ import glob
 import socket
 import random
 import functools
+import traceback
 import util.RH_GPIO as RH_GPIO
 
 logger = logging.getLogger(__name__)
@@ -390,3 +391,25 @@ def checkPythonVersion(majorVer, minorVer):
                         format(verStr, majorVer, minorVer))
     except Exception as ex:
         logger.debug("Error in 'checkRepPythonVersionStr': {}".format(ex))
+
+# Returns a debug traceback message indicated where the given function was called from, in the form:
+#   FILENAME.py line ###, in OUTER_FN_NAME
+def getFnTracebackMsgStr(fnNameStr):
+    try:
+        traceStr = str(traceback.format_stack())
+        ePos = traceStr.find(fnNameStr)  # find first occurrence of given function name in traceback
+        if ePos > 0:
+            traceStr = traceStr[:ePos]  # make end position right before function name
+            sPos = traceStr.rfind(".py")
+            if sPos < 0:
+                sPos = 0
+            while sPos > 0 and traceStr[sPos-1].isidentifier():  # find beginning of .py filename
+                sPos -= 1
+            traceStr = traceStr[sPos:ePos]
+            ePos = traceStr.find('\\n')
+            if ePos > 0:
+                traceStr = traceStr[:ePos]  # make end position right before linefeed
+            return traceStr.replace('", ', ' ').replace('\\n','').strip()  # tidy a bit
+        return "Unable to find given function name in traceback"
+    except Exception as ex:
+        return "Error parsing traceback in 'getFnTracebackMsgStr()':  {}".format(ex)

--- a/src/server/Results.py
+++ b/src/server/Results.py
@@ -409,7 +409,6 @@ def do_calc_leaderboard(racecontext, **params):
                                     break
                             if total_points:
                                 meta_points_flag = True
-                                logger.debug("Successfully completed points generation in 'calc_leaderboard()'")
                         else:
                             logger.warning("Cached results not available for points generation in 'calc_leaderboard()'")
                 do_gevent_sleep(0)

--- a/src/server/Results.py
+++ b/src/server/Results.py
@@ -396,20 +396,23 @@ def do_calc_leaderboard(racecontext, **params):
                         pilot_laps = []
                         if len(holeshot_laps):
                             for lap in selected_race_laps:
-                                if lap.pilot_id == pilot.id and \
-                                    lap.id not in holeshot_laps:
+                                if lap.pilot_id == pilot.id and lap.id not in holeshot_laps:
                                     pilot_laps.append(lap)
                         else:
                             pilot_laps = pilot_crossings
 
                     if not USE_ROUND:
-                        results = rhDataObj.get_results_savedRaceMeta(race)
-                        for line in results[results['meta']['primary_leaderboard']]:
-                            if line['pilot_id'] == pilot.id: 
-                                total_points += line['points']
-                                break
-                        if total_points:
-                            meta_points_flag = True 
+                        results = rhDataObj.get_results_savedRaceMeta(race, no_rebuild_flag=True)
+                        if results:
+                            for line in results[results['meta']['primary_leaderboard']]:
+                                if line['pilot_id'] == pilot.id:
+                                    total_points += line['points']
+                                    break
+                            if total_points:
+                                meta_points_flag = True
+                                logger.debug("Successfully completed points generation in 'calc_leaderboard()'")
+                        else:
+                            logger.warning("Cached results not available for points generation in 'calc_leaderboard()'")
 
                 if race_starts > 0:
                     leaderboard.append({

--- a/src/server/Results.py
+++ b/src/server/Results.py
@@ -116,6 +116,11 @@ class RacePointsMethod():
 
 @catchLogExceptionsWrapper
 def build_atomic_results(rhDataObj, params):
+    dbg_trace_str = ""
+    if logger.getEffectiveLevel() <= logging.DEBUG:  # if DEBUG msgs actually being logged
+        dbg_trace_str = RHUtils.getFnTracebackMsgStr("build_atomic_results")
+        logger.debug("Entered 'build_atomic_results()', called from: {}".format(dbg_trace_str))
+        dbg_trace_str = " (called from: {})".format(dbg_trace_str)
     APP.app_context().push()
     token = monotonic()
     timing = {
@@ -174,32 +179,40 @@ def build_atomic_results(rhDataObj, params):
     do_gevent_sleep()
     timing['event'] = monotonic()
     rhDataObj.get_results_event()
-    logger.debug('Event results built in {}s'.format(monotonic() - timing['event']))
-
-    logger.debug('Built result caches in {0}'.format(monotonic() - timing['start']))
+    if logger.getEffectiveLevel() <= logging.DEBUG:  # if DEBUG msgs actually being logged
+        logger.debug('Event results built in {}s'.format(monotonic() - timing['event']))
+        logger.debug('Built result caches in {0}'.format(monotonic() - timing['start']))
+        logger.debug("Exiting 'build_atomic_results()'{}".format(dbg_trace_str))
 
 def calc_leaderboard(racecontext, **params):
+    dbg_trace_str = ""
+    if logger.getEffectiveLevel() <= logging.DEBUG:  # if DEBUG msgs actually being logged
+        dbg_trace_str = RHUtils.getFnTracebackMsgStr("calc_leaderboard")
+        logger.debug("Entered 'calc_leaderboard()', called from: {}".format(dbg_trace_str))
+        dbg_trace_str = " (called from: {})".format(dbg_trace_str)
     global in_calc_leaderboard_fn_flag
     if in_calc_leaderboard_fn_flag:
-        logger.info("Waiting for previous invocation of 'calc_leaderboard()' to finish")
+        logger.info("Waiting for previous invocation of 'calc_leaderboard()' to finish{}".format(dbg_trace_str))
         wait_count = 0
         while True:
             gevent.sleep(0.05)
             if not in_calc_leaderboard_fn_flag:
-                logger.info("Previous invocation of 'calc_leaderboard()' finished; continuing")
+                logger.info("Previous invocation of 'calc_leaderboard()' finished; continuing{}".format(dbg_trace_str))
                 break
             wait_count += 1
             if wait_count > 6000:
-                logger.error("Timeout waiting for previous invocation of 'calc_leaderboard()' to finish")
+                logger.error("Timeout waiting for previous invocation of 'calc_leaderboard()' to finish{}".format(dbg_trace_str))
                 break
     in_calc_leaderboard_fn_flag = True
     try:
-        lb_result = do_calc_leaderboard(racecontext, **params)
+        lb_result = _do_calc_leaderboard(racecontext, **params)
     finally:
         in_calc_leaderboard_fn_flag = False
+    if logger.getEffectiveLevel() <= logging.DEBUG:  # if DEBUG msgs actually being logged
+        logger.debug("Exiting 'calc_leaderboard()'{}".format(dbg_trace_str))
     return lb_result
 
-def do_calc_leaderboard(racecontext, **params):
+def _do_calc_leaderboard(racecontext, **params):
     rhDataObj = racecontext.rhdata
     ''' Generates leaderboards '''
     meta_points_flag = False

--- a/src/server/util/InvokeFuncQueue.py
+++ b/src/server/util/InvokeFuncQueue.py
@@ -27,7 +27,7 @@ class InvokeFuncQueue:
                     self.invokeInProgressFlag = True
                     funct(*args, **kwargs)
                     self.invokeInProgressFlag = False
-                    gevent.sleep()
+                    gevent.sleep(0.001)
                 except (KeyboardInterrupt, SystemExit):
                     self.invokeInProgressFlag = False
                     raise


### PR DESCRIPTION
Changed instances of "gevent.sleep()" to "gevent.sleep(0.001)" (to prevent other threads from being blocked while 'calc_leaderboard()' runs).

Put in check to prevent 'calc_leaderboard()' function from being reentered while running.