### PR TITLE
Improve time-format function names

### DIFF
--- a/src/server/ClusterNodeSet.py
+++ b/src/server/ClusterNodeSet.py
@@ -464,7 +464,7 @@ class SecondaryNode:
 
                                 split_time = round(split_ts - last_split_ts, 3)
                                 split_speed = round(self.distance / float(split_time), 2) if self.distance > 0.0 else None
-                                split_time_str = RHUtils.split_time_format(split_time, self._racecontext.serverconfig.get_item('UI', 'timeFormat'))
+                                split_time_str = RHUtils.format_split_time_to_str(split_time, self._racecontext.serverconfig.get_item('UI', 'timeFormat'))
                                 eventStr = self.info.get('event', 'runSplitEffect')
                                 effectStr = self.info.get('effect', None)
                                 logger.info('Split pass record: Node {}, pilot {}, lap {}, split {}, time={} {}, speed={}' \
@@ -500,7 +500,7 @@ class SecondaryNode:
                                 if last_split_ts and last_split_ts > 0.0:
                                     split_time = round(split_ts - last_split_ts, 3)
                                     split_speed = round(self.distance / float(split_time), 2)
-                                    split_time_str = RHUtils.split_time_format(split_time, self._racecontext.serverconfig.get_item('UI', 'timeFormat'))
+                                    split_time_str = RHUtils.format_split_time_to_str(split_time, self._racecontext.serverconfig.get_item('UI', 'timeFormat'))
                                     eventStr = self.info.get('event', 'runSplitEffect')
                                     effectStr = self.info.get('effect', None)
                                     logger.info('Split pass record (for speed): Node {}, pilot {}, lap {}, split {}, time={} {}, speed={}' \

--- a/src/server/RHAPI.py
+++ b/src/server/RHAPI.py
@@ -10,6 +10,7 @@ import json
 import inspect
 import copy
 import logging
+import RHUtils
 from RHUI import UIField, UIFieldType
 from eventmanager import Evt
 
@@ -44,6 +45,7 @@ class RHAPI():
         self.events = EventsAPI(self._racecontext)
         self.server = ServerAPI(self._racecontext)
         self.filters = FilterAPI(self._racecontext)
+        self.utils = UtilsAPI()
 
         self.__ = self.language.__ # shortcut access
 
@@ -1302,3 +1304,20 @@ class FilterAPI():
 
     def run(self, type, data):
         return self._racecontext.filters.run_filters(type, data)
+
+
+#
+# Utility Functions
+#
+class UtilsAPI():
+    # Convert milliseconds to 00:00.000
+    def format_time_to_str(self, millis, *args, **kwargs):
+        return RHUtils.format_time_to_str(millis, *args, **kwargs)
+
+    # Convert milliseconds to 00:00.000 with leading zeros removed
+    def format_split_time_to_str(self, millis, *args, **kwargs):
+        return RHUtils.format_time_to_str(millis, *args, **kwargs)
+
+    # Convert milliseconds to phonetic callout string
+    def format_phonetic_time_to_str(self, millis, *args, **kwargs):
+        return RHUtils.format_phonetic_time_to_str(millis, *args, **kwargs)

--- a/src/server/RHData.py
+++ b/src/server/RHData.py
@@ -3572,9 +3572,9 @@ def doReplace(rhapi, text, args, spoken_flag=False, delay_sec_holder=None):
         if '%SPLIT_' in text and type(args) == dict:
             # %SPLIT_TIME% : Split time for pilot
             if '%SPLIT_TIME%' in text:
-                text = text.replace('%SPLIT_TIME%', RHUtils.phonetictime_format(args.get('split_time'), \
+                text = text.replace('%SPLIT_TIME%', RHUtils.format_phonetic_time_to_str(args.get('split_time'), \
                                         rhapi.config.get_item('UI', 'timeFormatPhonetic')) if spoken_flag \
-                                            else RHUtils.split_time_format(args.get('split_time'), \
+                                            else RHUtils.format_split_time_to_str(args.get('split_time'), \
                                                                    rhapi.config.get_item('UI', 'timeFormat')))
             # %SPLIT_SPEED% : Split speed for pilot
             if '%SPLIT_SPEED%' in text:
@@ -3604,32 +3604,32 @@ def doReplace(rhapi, text, args, spoken_flag=False, delay_sec_holder=None):
                     text = text.replace('%LAP_COUNT%', str(result.get('laps')))
 
                     # %TOTAL_TIME% : Total time since start of race for pilot
-                    text = text.replace('%TOTAL_TIME%', RHUtils.phonetictime_format( \
+                    text = text.replace('%TOTAL_TIME%', RHUtils.format_phonetic_time_to_str( \
                         result.get('total_time_raw'), rhapi.config.get_item('UI', 'timeFormatPhonetic')) \
                         if spoken_flag else str(result.get('total_time', '')))
 
                     # %TOTAL_TIME_LAPS%: Total time since start of first lap for pilot
-                    text = text.replace('%TOTAL_TIME_LAPS%', RHUtils.phonetictime_format( \
+                    text = text.replace('%TOTAL_TIME_LAPS%', RHUtils.format_phonetic_time_to_str( \
                         result.get('total_time_laps_raw'), rhapi.config.get_item('UI', 'timeFormatPhonetic')) \
                         if spoken_flag else str(result.get('total_time_laps', '')))
 
                     # %LAST_LAP% : Last lap time for pilot
-                    text = text.replace('%LAST_LAP%', RHUtils.phonetictime_format( \
+                    text = text.replace('%LAST_LAP%', RHUtils.format_phonetic_time_to_str( \
                         result.get('last_lap_raw'), rhapi.config.get_item('UI', 'timeFormatPhonetic')) \
                         if spoken_flag else str(result.get('last_lap', '')))
 
                     # %AVERAGE_LAP% : Average lap time for pilot
-                    text = text.replace('%AVERAGE_LAP%', RHUtils.phonetictime_format( \
+                    text = text.replace('%AVERAGE_LAP%', RHUtils.format_phonetic_time_to_str( \
                         result.get('average_lap_raw'), rhapi.config.get_item('UI', 'timeFormatPhonetic')) \
                         if spoken_flag else str(result.get('average_lap', '')))
 
                     # %FASTEST_LAP% : Fastest lap time
-                    text = text.replace('%FASTEST_LAP%', RHUtils.phonetictime_format( \
+                    text = text.replace('%FASTEST_LAP%', RHUtils.format_phonetic_time_to_str( \
                         result.get('fastest_lap_raw'), rhapi.config.get_item('UI', 'timeFormatPhonetic')) \
                         if spoken_flag else str(result.get('fastest_lap', '')))
 
                     if '%TIME_BEHIND' in text:
-                        behind_str = RHUtils.phonetictime_format( \
+                        behind_str = RHUtils.format_phonetic_time_to_str( \
                             result.get('time_behind_raw', ''), rhapi.config.get_item('UI', 'timeFormatPhonetic')) \
                             if spoken_flag else str(result.get('time_behind', ''))
                         pos_bhind_str = ''
@@ -3656,7 +3656,7 @@ def doReplace(rhapi, text, args, spoken_flag=False, delay_sec_holder=None):
 
                     # %CONSECUTIVE% : Fastest consecutive laps for pilot
                     if result.get('consecutives_base') == int(rhapi.db.option('consecutivesCount', 3)):
-                        text = text.replace('%CONSECUTIVE%', RHUtils.phonetictime_format( \
+                        text = text.replace('%CONSECUTIVE%', RHUtils.format_phonetic_time_to_str( \
                             result.get('consecutives_raw'), rhapi.config.get_item('UI', 'timeFormatPhonetic')) \
                             if spoken_flag else str(result.get('consecutives', '')))
                     else:

--- a/src/server/RHRace.py
+++ b/src/server/RHRace.py
@@ -724,8 +724,8 @@ class RHRace():
                                 min_lap = self._racecontext.rhdata.get_optionInt("MinLapSec")
                                 min_lap_behavior = self._racecontext.serverconfig.get_item_int('TIMING', "MinLapBehavior")
 
-                            lap_time_fmtstr = RHUtils.time_format(lap_time, self._racecontext.serverconfig.get_item('UI', 'timeFormat'))
-                            lap_ts_fmtstr = RHUtils.time_format(lap_time_stamp, self._racecontext.serverconfig.get_item('UI', 'timeFormat'))
+                            lap_time_fmtstr = RHUtils.format_time_to_str(lap_time, self._racecontext.serverconfig.get_item('UI', 'timeFormat'))
+                            lap_ts_fmtstr = RHUtils.format_time_to_str(lap_time_stamp, self._racecontext.serverconfig.get_item('UI', 'timeFormat'))
                             pilot_obj = self._racecontext.rhdata.get_pilot(pilot_id)
                             if pilot_obj:
                                 pilot_namestr = pilot_obj.callsign
@@ -794,10 +794,10 @@ class RHRace():
 
                                 if logger.getEffectiveLevel() <= logging.DEBUG:  # if DEBUG msgs actually being logged
                                     late_str = " (late lap)" if lap_late_flag else ""
-                                    enter_fmtstr = RHUtils.time_format((node.enter_at_timestamp-self.start_time_monotonic)*1000, \
+                                    enter_fmtstr = RHUtils.format_time_to_str((node.enter_at_timestamp-self.start_time_monotonic)*1000, \
                                                                        self._racecontext.serverconfig.get_item('UI', 'timeFormat')) \
                                                    if node.enter_at_timestamp else "0"
-                                    exit_fmtstr = RHUtils.time_format((node.exit_at_timestamp-self.start_time_monotonic)*1000, \
+                                    exit_fmtstr = RHUtils.format_time_to_str((node.exit_at_timestamp-self.start_time_monotonic)*1000, \
                                                                       self._racecontext.serverconfig.get_item('UI', 'timeFormat')) \
                                                    if node.exit_at_timestamp else "0"
                                     logger.debug('Lap pass{}: Node={}, lap={}, lapTime={}, sinceStart={}, abs_ts={:.3f}, passtime={}, source={}, enter={}, exit={}, dur={:.0f}ms, pilot: {}' \
@@ -1020,10 +1020,10 @@ class RHRace():
 
             if db_next and db_last:
                 db_next.lap_time = db_next.lap_time_stamp - db_last.lap_time_stamp
-                db_next.lap_time_formatted = RHUtils.time_format(db_next.lap_time, self._racecontext.serverconfig.get_item('UI', 'timeFormat'))
+                db_next.lap_time_formatted = RHUtils.format_time_to_str(db_next.lap_time, self._racecontext.serverconfig.get_item('UI', 'timeFormat'))
             elif db_next:
                 db_next.lap_time = db_next.lap_time_stamp
-                db_next.lap_time_formatted = RHUtils.time_format(db_next.lap_time, self._racecontext.serverconfig.get_item('UI', 'timeFormat'))
+                db_next.lap_time_formatted = RHUtils.format_time_to_str(db_next.lap_time, self._racecontext.serverconfig.get_item('UI', 'timeFormat'))
 
             try:  # delete any split laps for deleted lap
                 lap_splits = self._racecontext.rhdata.get_lapSplits_by_lap(node_index, lap_number)
@@ -1080,7 +1080,7 @@ class RHRace():
                     if idx >= lap_index:
                         lap.lap_number = lap_number
                         lap.lap_time = lap.lap_time_stamp - last_lap_ts
-                        lap.lap_time_formatted = RHUtils.time_format(lap.lap_time, self._racecontext.serverconfig.get_item('UI', 'timeFormat'))
+                        lap.lap_time_formatted = RHUtils.format_time_to_str(lap.lap_time, self._racecontext.serverconfig.get_item('UI', 'timeFormat'))
                     last_lap_ts = lap.lap_time_stamp
                     lap_number += 1
 

--- a/src/server/RHUI.py
+++ b/src/server/RHUI.py
@@ -1152,7 +1152,7 @@ class RHUI():
     def emit_phonetic_data(self, pilot_id, lap_id, lap_time, team_name, team_laps, leader_flag=False, node_finished=False, node_index=None, **params):
         '''Emits phonetic data.'''
         raw_time = lap_time
-        phonetic_time = RHUtils.phonetictime_format(lap_time, self._racecontext.serverconfig.get_item('UI', 'timeFormatPhonetic'))
+        phonetic_time = RHUtils.format_phonetic_time_to_str(lap_time, self._racecontext.serverconfig.get_item('UI', 'timeFormatPhonetic'))
 
         emit_payload = {
             'lap': lap_id,
@@ -1260,7 +1260,7 @@ class RHUI():
             pilot = self._racecontext.rhdata.get_pilot(split_data.get('pilot_id', RHUtils.PILOT_ID_NONE))
             phonetic_name = (pilot.phonetic or pilot.callsign) if name_callout_flag and pilot else ''
             split_time = split_data.get('split_time')
-            phonetic_time = RHUtils.phonetictime_format(split_time, self._racecontext.serverconfig.get_item('UI', 'timeFormatPhonetic')) \
+            phonetic_time = RHUtils.format_phonetic_time_to_str(split_time, self._racecontext.serverconfig.get_item('UI', 'timeFormatPhonetic')) \
                             if (time_callout_flag and split_time) else None
             split_speed = split_data.get('split_speed')
             phonetic_speed = "{:.1f}".format(split_speed) if  (speed_callout_flag and split_speed) else None

--- a/src/server/RHUtils.py
+++ b/src/server/RHUtils.py
@@ -28,7 +28,7 @@ RHGPIO_S32ID_PIN = 25  # GPIO input is tied low on S32_BPill PCB
 Is_sys_raspberry_pi_flag = True  # set by 'idAndLogSystemInfo()'
 S32_BPill_board_flag = False  # set by 'idAndLogSystemInfo()'
 
-def time_format(millis, timeformat='{m}:{s}.{d}'):
+def format_time_to_str(millis, timeformat='{m}:{s}.{d}'):
     '''Convert milliseconds to 00:00.000'''
     if not isinstance(millis, (int, float)):
         return ''
@@ -45,7 +45,7 @@ def time_format(millis, timeformat='{m}:{s}.{d}'):
 
     return timeformat.format(m=str(minutes), s=str(seconds).zfill(2), d=str(milliseconds).zfill(3))
 
-def split_time_format(millis, timeformat='{m}:{s}.{d}'):
+def format_split_time_to_str(millis, timeformat='{m}:{s}.{d}'):
     '''Convert milliseconds to 00:00.000 with leading zeros removed'''
     if not isinstance(millis, (int, float)):
         return ''
@@ -55,8 +55,8 @@ def split_time_format(millis, timeformat='{m}:{s}.{d}'):
         s = s[p:]
     return s
 
-def phonetictime_format(millis, timeformat='{m} {s}.{d}'):
-    '''Convert milliseconds to phonetic'''
+def format_phonetic_time_to_str(millis, timeformat='{m} {s}.{d}'):
+    '''Convert milliseconds to phonetic callout string'''
     if not isinstance(millis, (int, float)):
         return ''
 
@@ -74,6 +74,22 @@ def phonetictime_format(millis, timeformat='{m} {s}.{d}'):
         return timeformat.format(m='', s=str(seconds), d=str(tenths))
     else:
         return timeformat.format(m=str(minutes), s=str(seconds).zfill(2), d=str(tenths))
+
+
+# Previous (now deprecated) versions of time-formatting functions:
+
+def time_format(millis, *args, **kwargs):
+    logger.warning("Deprecated function 'RHUtils.time_format()' function invoked; should use 'rhapi.utils.format_time_to_str()' instead")
+    return format_time_to_str(millis, *args, **kwargs)
+
+def split_time_format(millis, *args, **kwargs):
+    logger.warning("Deprecated function 'RHUtils.split_time_format()' function invoked; should use 'rhapi.utils.format_split_time_to_str()' instead")
+    return format_split_time_to_str(millis, *args, **kwargs)
+
+def phonetictime_format(millis, *args, **kwargs):
+    logger.warning("Deprecated function 'RHUtils.phonetictime_format()' function invoked; should use 'rhapi.utils.format_phonetic_time_to_str()' instead")
+    return format_phonetic_time_to_str(millis, *args, **kwargs)
+
 
 def getPythonVersionStr():
     return sys.version.split()[0]

--- a/src/server/Results.py
+++ b/src/server/Results.py
@@ -529,18 +529,18 @@ def format_leaderboard_times(racecontext, all_leaderboards):
     for key, leaderboard in all_leaderboards.items():
         if key != 'meta':
             for result_pilot in leaderboard:
-                result_pilot['total_time'] = RHUtils.time_format(result_pilot['total_time_raw'], time_format)
-                result_pilot['total_time_laps'] = RHUtils.time_format(result_pilot['total_time_laps_raw'], time_format)
-                result_pilot['average_lap'] = RHUtils.time_format(result_pilot['average_lap_raw'], time_format)
-                result_pilot['fastest_lap'] = RHUtils.time_format(result_pilot['fastest_lap_raw'], time_format)
+                result_pilot['total_time'] = RHUtils.format_time_to_str(result_pilot['total_time_raw'], time_format)
+                result_pilot['total_time_laps'] = RHUtils.format_time_to_str(result_pilot['total_time_laps_raw'], time_format)
+                result_pilot['average_lap'] = RHUtils.format_time_to_str(result_pilot['average_lap_raw'], time_format)
+                result_pilot['fastest_lap'] = RHUtils.format_time_to_str(result_pilot['fastest_lap_raw'], time_format)
                 if result_pilot.get('time_behind_raw'):
-                    result_pilot['time_behind'] = RHUtils.time_format(result_pilot['time_behind_raw'], time_format)
+                    result_pilot['time_behind'] = RHUtils.format_time_to_str(result_pilot['time_behind_raw'], time_format)
                 else:
                     result_pilot.pop('time_behind', None)
                     result_pilot.pop('time_behind_raw', None)
-                result_pilot['consecutives'] = RHUtils.time_format(result_pilot['consecutives_raw'], time_format)
+                result_pilot['consecutives'] = RHUtils.format_time_to_str(result_pilot['consecutives_raw'], time_format)
                 if result_pilot.get('last_lap_raw'):
-                    result_pilot['last_lap'] = RHUtils.time_format(result_pilot['last_lap_raw'], time_format)
+                    result_pilot['last_lap'] = RHUtils.format_time_to_str(result_pilot['last_lap_raw'], time_format)
 
     return all_leaderboards
 
@@ -655,7 +655,7 @@ def add_fastest_race_lap_meta(racecontext, all_leaderboards):
         else:
             pilot = racecontext.rhdata.get_pilot(leaderboard_by_fastest_lap[0]['pilot_id'])
             pilot_str = pilot.spoken_callsign if pilot else leaderboard_by_fastest_lap[0]['callsign']
-            phonetic_time = RHUtils.phonetictime_format(
+            phonetic_time = RHUtils.format_phonetic_time_to_str(
                 leaderboard_by_fastest_lap[0]['fastest_lap_raw'],
                 racecontext.serverconfig.get_item('UI', 'timeFormatPhonetic'))
             fastest_race_lap_data = {}
@@ -871,10 +871,10 @@ def calc_team_leaderboard(racecontext):
                 'average_lap_raw': average_lap_raw,
                 'average_fastest_lap_raw': average_fastest_lap_raw,
                 'average_consecutives_raw': average_consecutives_raw,
-                'total_time': RHUtils.time_format(teams[team]['total_time_raw'], time_format),
-                'average_lap': RHUtils.time_format(average_lap_raw, time_format),
-                'average_fastest_lap': RHUtils.time_format(average_fastest_lap_raw, time_format),
-                'average_consecutives': RHUtils.time_format(average_consecutives_raw, time_format),
+                'total_time': RHUtils.format_time_to_str(teams[team]['total_time_raw'], time_format),
+                'average_lap': RHUtils.format_time_to_str(average_lap_raw, time_format),
+                'average_fastest_lap': RHUtils.format_time_to_str(average_fastest_lap_raw, time_format),
+                'average_consecutives': RHUtils.format_time_to_str(average_consecutives_raw, time_format),
             })
 
         # sort race_time

--- a/src/server/plugins/rh_class_rank_best_x_rounds/__init__.py
+++ b/src/server/plugins/rh_class_rank_best_x_rounds/__init__.py
@@ -66,8 +66,8 @@ def rank_best_rounds(rhapi, race_class, args):
             new_pilot_result['total_time_laps_raw'] += race['total_time_laps_raw']
 
         timeFormat = rhapi.config.get_item('UI', 'timeFormat')
-        new_pilot_result['total_time'] = RHUtils.time_format(new_pilot_result['total_time_raw'], timeFormat)
-        new_pilot_result['total_time_laps'] = RHUtils.time_format(new_pilot_result['total_time_laps_raw'], timeFormat)
+        new_pilot_result['total_time'] = rhapi.utils.format_time_to_str(new_pilot_result['total_time_raw'], timeFormat)
+        new_pilot_result['total_time_laps'] = rhapi.utils.format_time_to_str(new_pilot_result['total_time_laps_raw'], timeFormat)
 
         leaderboard.append(new_pilot_result)
 

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -2010,7 +2010,7 @@ def on_resave_laps(data):
     for lap in laps:
         tmp_lap_time_formatted = lap['lap_time']
         if isinstance(lap['lap_time'], float):
-            tmp_lap_time_formatted = RHUtils.time_format(lap['lap_time'], RaceContext.serverconfig.get_item('UI', 'timeFormat'))
+            tmp_lap_time_formatted = RHUtils.format_time_to_str(lap['lap_time'], RaceContext.serverconfig.get_item('UI', 'timeFormat'))
 
         new_racedata['laps'].append({
             'lap_time_stamp': lap['lap_time_stamp'],


### PR DESCRIPTION
We need to improve the names on the 'time' functions in RHUtils, but there are external plugins using these functions.  We should:

- [x] Create API access to these functions (and probably other 'util' functions)

- [x] Make a helper for now that passes access through, but deprecate with a warning

- [x] Change access in builtin plugins to the proper API method