### PR TITLE
Discard laps with confirmation

### DIFF
--- a/src/server/language.json
+++ b/src/server/language.json
@@ -490,6 +490,7 @@
 			"Discard New Short Laps": "Descartar Vueltas Erróneas",
 			"Display settings apply to this device only.": "La configuración de visualización solo se aplica a este dispositivo.",
 			"Display Settings": "Configuración de Pantalla",
+			"Do you want to discard laps?": "¿Quieres descartar las vueltas?",
 			"Documentation": "Documentación",
 			"Download Logs": "Descargar Logs",
 			"Duplicate Format": "Duplicar Formato",

--- a/src/server/templates/run.html
+++ b/src/server/templates/run.html
@@ -1073,12 +1073,14 @@
 
 		$('button#discard_laps').click(function (event) {
 			if(!$(this).prop('disabled')) {
-				$('button#start_race').prop('disabled', true);
-				$('button#stop_race').prop('disabled', true);
-				$('button#save_laps').prop('disabled', true);
-				$('button#discard_laps').prop('disabled', true);
-				$('.time-display').html('--:--');
-				socket.emit('discard_laps');
+				if (confirm(__('Do you want to discard laps?'))) {
+					$('button#start_race').prop('disabled', true);
+					$('button#stop_race').prop('disabled', true);
+					$('button#save_laps').prop('disabled', true);
+					$('button#discard_laps').prop('disabled', true);
+					$('.time-display').html('--:--');
+					socket.emit('discard_laps');
+				}
 			}
 		});
 


### PR DESCRIPTION
The idea of this PR is to add an extra protection step after a run to avoid discard laps by mistake.

It is missing translations for now.

![image](https://github.com/RotorHazard/RotorHazard/assets/7817064/1b63dedc-ff19-4502-8a05-9b09effd55da)