### PR TITLE
Add new UI link element

### DIFF
--- a/doc/RHAPI.md
+++ b/doc/RHAPI.md
@@ -135,6 +135,22 @@ Register a Quickbutton and assign it to a UI panel. Returns all buttons as `list
 - `function` (callable): Function to run when button is pressed
 - `args` (any): Argument passed to `function` when called
 
+### Links
+
+Provides a simple interface to add a UI link. Links appear on assigned UI panels in a list and will always be opened in a new tab.
+
+Links are represented with the `Link` class, which has the following properties:
+- `panel` (string): `name` of panel where link will appear
+- `name` (string): Text used for visible link label
+- `url` (string): URL to navigate to when link is clicked
+
+#### ui.register_link(panel, name, url)
+
+Register a Link and assign it to a UI panel. Returns all links as `list[Link]`.
+
+- `panel` (string): `name` of panel previously registered with `ui.register_panel`
+- `name` (string): Text used for visible link label
+- `url` (string): URL to navigate to when link is clicked
 
 ### Pages
 

--- a/src/server/RHAPI.py
+++ b/src/server/RHAPI.py
@@ -73,6 +73,10 @@ class UserInterfaceAPI():
     def register_quickbutton(self, panel, name, label, function, args=None):
         return self._racecontext.rhui.register_quickbutton(panel, name, label, function, args)
 
+    # Link
+    def register_link(self, panel, name, url):
+        return self._racecontext.rhui.register_link(panel, name, url)
+
     # Blueprint
     def blueprint_add(self, blueprint):
         return self._racecontext.rhui.add_blueprint(blueprint)

--- a/src/server/RHUI.py
+++ b/src/server/RHUI.py
@@ -80,6 +80,12 @@ class QuickButton():
     fn: callable
     args: dict
 
+@dataclass
+class Link():
+    panel: str
+    name: str
+    url: str
+
 class RHUI():
     # Language placeholder (Overwritten after module init)
     def __(self, *args):
@@ -99,6 +105,7 @@ class RHUI():
         self._ui_panels = []
         self._general_settings = []
         self._quickbuttons = []
+        self._links = []
 
     # Pilot Attributes
     def register_pilot_attribute(self, field:UIField):
@@ -239,6 +246,25 @@ class RHUI():
                     btn.fn(btn.args)
                     return
 
+    # link
+    def register_link(self, panel, name, url):
+        for idx, link in enumerate(self._links):
+            if link.name == name:
+                self._links[idx] = Link(panel, name, url)
+                logger.debug(F'Redefining link "{name}"')
+                break
+        else:
+            self._links.append(Link(panel, name, url))
+        return self._links
+
+    def get_panel_links(self, name):
+        payload = []
+        for link in self._links:
+            if link.panel == name:
+                payload.append(link)
+
+        return payload
+
     # Blueprints
     def add_blueprint(self, blueprint):
         self._app.register_blueprint(blueprint)
@@ -288,6 +314,13 @@ class RHUI():
                         'label': button.label,
                     })
 
+                links = []
+                for link in self.get_panel_links(panel.name):
+                    links.append({
+                        'name': link.name,
+                        'url': link.url,
+                    })
+
                 emit_payload['panels'].append({
                     'panel': {
                         'name': panel.name,
@@ -295,7 +328,8 @@ class RHUI():
                         'order': panel.order,
                     },
                     'settings': settings,
-                    'quickbuttons': buttons
+                    'quickbuttons': buttons,
+                    'links': links
                 })
 
         if ('nobroadcast' in params):

--- a/src/server/static/rh-ui.js
+++ b/src/server/static/rh-ui.js
@@ -126,6 +126,20 @@ var rhui = {
 		}
 		return btn_list_el
 	},
+	buildLinks: function(link_list) {
+		var link_list_el = $('<ul>');
+		for (var idx in link_list) {
+			link_el = $('<li>')
+				.append($('<a>')
+					.attr('href', link_list[idx].url)
+					.attr('target', '_blank')
+					.text(link_list[idx].name)
+				)
+
+			link_list_el.append(link_el)
+		}
+		return link_list_el
+	},
 	getFieldVal: function(element) {
 		var el = $(element);
 		var field = el.data('field');

--- a/src/server/templates/streams.html
+++ b/src/server/templates/streams.html
@@ -51,6 +51,7 @@
 					}
 					panel_content_el.append(form_el);
 					panel_content_el.append(rhui.buildQuickbuttons(panel.quickbuttons));
+					panel_content_el.append(rhui.buildLinks(panel.links));
 
 					panel_el.append(panel_header_el);
 					panel_el.append(panel_content_el);


### PR DESCRIPTION
Makes it possible to add URL links to a panel in the UI. This is very useful, for example, on the stream page, which gives plugins the opportunity to generate a list of links to OBS overlays.

Closes: #878

## Example
![image](https://github.com/RotorHazard/RotorHazard/assets/20448157/dfae9a28-e231-4c70-8f23-dfe313ec325e)
