### PR TITLE
Add UI Panel open/close support

### DIFF
--- a/doc/RHAPI.md
+++ b/doc/RHAPI.md
@@ -98,6 +98,7 @@ Panels are represented with the `UIPanel` class, which has the following propert
 - `name` (string): Internal identifier for this panel
 - `label` (string): Text used as visible panel header
 - `page` (string): Page to add panel to
+- `open` (boolean): Whether panel is open or closed
 - `order` (int): Not yet implemented
 
 
@@ -111,6 +112,7 @@ Register a UI panel and assign it to a page. Returns all panels as `list[UIPanel
 - `name` (string): Internal identifier for this panel
 - `label` (string): Text used as visible panel header
 - `page` (string): Page to add panel to; one of "format", "settings"
+- `open` _optional_ (boolean): Whether panel is open or closed (default: `False`)
 - `order` _optional_ (int): Not yet implemented 
 
 ### Quickbuttons

--- a/doc/RHAPI.md
+++ b/doc/RHAPI.md
@@ -95,11 +95,12 @@ These methods are accessed via `RHAPI.ui`
 Add custom UI panels to RotorHazard's frontend pages. Panels may contain Options and Quickbuttons.
 
 Panels are represented with the `UIPanel` class, which has the following properties:
+
 - `name` (string): Internal identifier for this panel
 - `label` (string): Text used as visible panel header
 - `page` (string): Page to add panel to
-- `open` (boolean): Whether panel is open or closed
 - `order` (int): Not yet implemented
+- `open` (boolean): Whether panel is open or closed
 
 
 #### ui.panels
@@ -107,13 +108,14 @@ _Read only_
 The list of registered panels. Returns `List[UIPanel]`.
 
 #### ui.register_panel(name, label, page, order=0)
+
 Register a UI panel and assign it to a page. Returns all panels as `list[UIPanel]`.
 
 - `name` (string): Internal identifier for this panel
 - `label` (string): Text used as visible panel header
 - `page` (string): Page to add panel to; one of "format", "settings"
+- `order` _optional_ (int): Not yet implemented
 - `open` _optional_ (boolean): Whether panel is open or closed (default: `False`)
-- `order` _optional_ (int): Not yet implemented 
 
 ### Quickbuttons
 

--- a/src/server/RHAPI.py
+++ b/src/server/RHAPI.py
@@ -66,8 +66,8 @@ class UserInterfaceAPI():
     def panels(self):
         return self._racecontext.rhui.ui_panels
 
-    def register_panel(self, name, label, page, open = False, order=0):
-        return self._racecontext.rhui.register_ui_panel(name, label, page, open, order)
+    def register_panel(self, name, label, page, order=0, open = False):
+        return self._racecontext.rhui.register_ui_panel(name, label, page, order, open)
 
     # Quick button
     def register_quickbutton(self, panel, name, label, function, args=None):

--- a/src/server/RHAPI.py
+++ b/src/server/RHAPI.py
@@ -66,8 +66,8 @@ class UserInterfaceAPI():
     def panels(self):
         return self._racecontext.rhui.ui_panels
 
-    def register_panel(self, name, label, page, order=0):
-        return self._racecontext.rhui.register_ui_panel(name, label, page, order)
+    def register_panel(self, name, label, page, open = False, order=0):
+        return self._racecontext.rhui.register_ui_panel(name, label, page, open, order)
 
     # Quick button
     def register_quickbutton(self, panel, name, label, function, args=None):

--- a/src/server/RHUI.py
+++ b/src/server/RHUI.py
@@ -63,8 +63,8 @@ class UIPanel():
     name: str
     label: str
     page: str
-    open: bool = False
     order: int = 0
+    open: bool = False
 
 @dataclass
 class GeneralSetting():
@@ -184,14 +184,14 @@ class RHUI():
         return self._raceformat_attributes
 
     # UI Panels
-    def register_ui_panel(self, name, label, page, open = False, order=0):
+    def register_ui_panel(self, name, label, page, order=0, open = False,):
         for idx, panel in enumerate(self._ui_panels):
             if panel.name == name:
-                self._ui_panels[idx] = UIPanel(name, label, page, open, order)
+                self._ui_panels[idx] = UIPanel(name, label, page, order, open)
                 logger.debug(F'Redefining panel "{name}"')
                 break
         else:
-            self._ui_panels.append(UIPanel(name, label, page, open, order))
+            self._ui_panels.append(UIPanel(name, label, page, order, open))
         return self.ui_panels
 
     @property
@@ -330,8 +330,8 @@ class RHUI():
                     'panel': {
                         'name': panel.name,
                         'label': panel.label,
-                        'open': panel.open,
                         'order': panel.order,
+                        'open': panel.open,
                     },
                     'settings': settings,
                     'quickbuttons': buttons,

--- a/src/server/RHUI.py
+++ b/src/server/RHUI.py
@@ -63,6 +63,7 @@ class UIPanel():
     name: str
     label: str
     page: str
+    open: bool = False
     order: int = 0
 
 @dataclass
@@ -183,14 +184,14 @@ class RHUI():
         return self._raceformat_attributes
 
     # UI Panels
-    def register_ui_panel(self, name, label, page, order=0):
+    def register_ui_panel(self, name, label, page, open = False, order=0):
         for idx, panel in enumerate(self._ui_panels):
             if panel.name == name:
-                self._ui_panels[idx] = UIPanel(name, label, page, order)
+                self._ui_panels[idx] = UIPanel(name, label, page, open, order)
                 logger.debug(F'Redefining panel "{name}"')
                 break
         else:
-            self._ui_panels.append(UIPanel(name, label, page, order))
+            self._ui_panels.append(UIPanel(name, label, page, open, order))
         return self.ui_panels
 
     @property
@@ -329,6 +330,7 @@ class RHUI():
                     'panel': {
                         'name': panel.name,
                         'label': panel.label,
+                        'open': panel.open,
                         'order': panel.order,
                     },
                     'settings': settings,

--- a/src/server/templates/format.html
+++ b/src/server/templates/format.html
@@ -98,7 +98,15 @@
 					var panel_header_el = $('<div class="panel-header">');
 					panel_header_el.append('<h2><button class="no-style">' + panel.panel.label + '</button></h2>');
 					var panel_content_el = $('<div class="panel-content">');
-					panel_content_el.hide();
+
+					// panel open/close
+					if (panel.panel.open) {
+						panel_el.addClass('open');
+						panel_content_el.show();
+					} else {
+						panel_el.removeClass('open');
+						panel_content_el.hide();
+					}
 
 					// add markdown content
 					for (var md_idx in panel.markdowns) {

--- a/src/server/templates/marshal.html
+++ b/src/server/templates/marshal.html
@@ -53,7 +53,15 @@
 					var panel_header_el = $('<div class="panel-header">');
 					panel_header_el.append('<h2><button class="no-style">' + panel.panel.label + '</button></h2>');
 					var panel_content_el = $('<div class="panel-content">');
-					panel_content_el.hide();
+
+					// panel open/close
+					if (panel.panel.open) {
+						panel_el.addClass('open');
+						panel_content_el.show();
+					} else {
+						panel_el.removeClass('open');
+						panel_content_el.hide();
+					}
 
 					var form_el = $('<ol class="form">');
 

--- a/src/server/templates/run.html
+++ b/src/server/templates/run.html
@@ -264,7 +264,15 @@
 					var panel_header_el = $('<div class="panel-header">');
 					panel_header_el.append('<h2><button class="no-style">' + panel.panel.label + '</button></h2>');
 					var panel_content_el = $('<div class="panel-content">');
-					panel_content_el.hide();
+
+					// panel open/close
+					if (panel.panel.open) {
+						panel_el.addClass('open');
+						panel_content_el.show();
+					} else {
+						panel_el.removeClass('open');
+						panel_content_el.hide();
+					}
 
 					// add markdown content
 					for (var md_idx in panel.markdowns) {

--- a/src/server/templates/settings.html
+++ b/src/server/templates/settings.html
@@ -166,7 +166,15 @@
 					var panel_header_el = $('<div class="panel-header">');
 					panel_header_el.append('<h2><button class="no-style">' + panel.panel.label + '</button></h2>');
 					var panel_content_el = $('<div class="panel-content">');
-					panel_content_el.hide();
+
+					// panel open/close
+					if (panel.panel.open) {
+						panel_el.addClass('open');
+						panel_content_el.show();
+					} else {
+						panel_el.removeClass('open');
+						panel_content_el.hide();
+					}
 
 					// add markdown content
 					for (var md_idx in panel.markdowns) {

--- a/src/server/templates/streams.html
+++ b/src/server/templates/streams.html
@@ -41,7 +41,15 @@
 					var panel_header_el = $('<div class="panel-header">');
 					panel_header_el.append('<h2><button class="no-style">' + panel.panel.label + '</button></h2>');
 					var panel_content_el = $('<div class="panel-content">');
-					panel_content_el.hide();
+
+					// panel open/close
+					if (panel.panel.open) {
+						panel_el.addClass('open');
+						panel_content_el.show();
+					} else {
+						panel_el.removeClass('open');
+						panel_content_el.hide();
+					}
 
 					// add markdown content
 					for (var md_idx in panel.markdowns) {


### PR DESCRIPTION
This PR makes it possible to have custom UI panels open by default when you load a page. This is done via an `open` boolean parameter on the UIPanel class, can be optionally used by plugins and is set to `False` by default.