### PR TITLE
Plugin support for generating heat slots seeded by class rank

### DIFF
--- a/doc/Plugins.md
+++ b/doc/Plugins.md
@@ -202,7 +202,7 @@ A `HeatPlan` object uses the following format:
 A `HeatPlanSlot` object uses the following format:
     - `method` (SeedMethod): Method used for seeding
     - `seed_rank` (int): Rank to seed from
-    - `seed_index` _optional_ (int): Index of heat within the plan list to seed from, when `method` is `HEAT_INDEX`
+    - `seed_index` _optional_ (int): Index of heat within the plan list to seed from, when `method` is `HEAT_INDEX` or `CLASS_INDEX`
 
 ##### Seeding methods
 Heat slots can be seeded either directly from
@@ -210,6 +210,7 @@ Heat slots can be seeded either directly from
 
 - `INPUT`: The slot is seeded from the `seed_rank` position in the input class ranking
 - `HEAT_INDEX`: The slot is seeded from the `seed_rank` position in the heat specified by `seed_index`
+- `CLASS_INDEX`: The slot is seeded from the `seed_rank` position in the class specified by `seed_index`
 
 The following heat plan is a double-advance ladder. Pilots ranked 3rd through 6th from the input class are seeded into the first heat. Then, the 1st and 2nd place from that heat advance to the second heat where they join the 1st and 2nd place from the input class.
 ```

--- a/src/server/HeatGenerator.py
+++ b/src/server/HeatGenerator.py
@@ -19,6 +19,7 @@ logger = logging.getLogger(__name__)
 class SeedMethod(Enum):
     INPUT = 0
     HEAT_INDEX = 1
+    CLASS_INDEX = 2
 
 @dataclass
 class HeatPlanSlot():
@@ -146,6 +147,11 @@ class HeatGeneratorManager():
                     elif seed_slot.method == SeedMethod.HEAT_INDEX:
                         data['method'] = ProgramMethod.HEAT_RESULT
                         data['seed_heat_id'] = heat_id_mapping[seed_slot.seed_index]
+
+                    elif seed_slot.method == SeedMethod.CLASS_INDEX:
+                        data['method'] = ProgramMethod.CLASS_RESULT
+                        data['seed_class_id'] = seed_slot.seed_index
+
                     else:
                         logger.error("Not a supported seed method: {}".format(seed_slot.method))
                         return False


### PR DESCRIPTION
This PR allows plugin developers to generate heat slots which are seeded by class rank using the heat generator. This gives them the same functionality which can currently only be done via the UI, but now it can be done programmatically with a plugin.