### PR TITLE
Add new UI Markdown block element

### DIFF
--- a/doc/RHAPI.md
+++ b/doc/RHAPI.md
@@ -135,6 +135,22 @@ Register a Quickbutton and assign it to a UI panel. Returns all buttons as `list
 - `function` (callable): Function to run when button is pressed
 - `args` (any): Argument passed to `function` when called
 
+### Markdown
+
+Provides a simple interface to add a UI Markdown block to a panel.
+
+Markdow blocks are represented with the `Markdown` class, which has the following properties:
+- `panel` (string): `name` of panel where markdown will appear
+- `name` (string): Internal identifier for this markdown block
+- `desc` (string): Markdown-formatted text to display
+
+#### ui.register_markdown(panel, name, desc)
+
+Register a Markdown block and assign it to a UI panel.
+
+- `panel` (string): `name` of panel previously registered with `ui.register_panel`
+- `name` (string): Internal identifier for this markdown block
+- `desc` (string): Markdown-formatted text to display
 
 ### Pages
 

--- a/doc/RHAPI.md
+++ b/doc/RHAPI.md
@@ -140,6 +140,7 @@ Register a Quickbutton and assign it to a UI panel. Returns all buttons as `list
 Provides a simple interface to add a UI Markdown block to a panel.
 
 Markdow blocks are represented with the `Markdown` class, which has the following properties:
+
 - `panel` (string): `name` of panel where markdown will appear
 - `name` (string): Internal identifier for this markdown block
 - `desc` (string): Markdown-formatted text to display

--- a/src/server/RHAPI.py
+++ b/src/server/RHAPI.py
@@ -73,6 +73,10 @@ class UserInterfaceAPI():
     def register_quickbutton(self, panel, name, label, function, args=None):
         return self._racecontext.rhui.register_quickbutton(panel, name, label, function, args)
 
+    # Markdown
+    def register_markdown(self, panel, name, desc):
+        return self._racecontext.rhui.register_markdown(panel, name, desc)
+
     # Blueprint
     def blueprint_add(self, blueprint):
         return self._racecontext.rhui.add_blueprint(blueprint)

--- a/src/server/templates/format.html
+++ b/src/server/templates/format.html
@@ -1,6 +1,7 @@
 {% extends "layout.html" %} {% block title %}{{ __('Format') }}{% endblock %} {% block head %}
 <script type="text/javascript" src="./static/Blob.js"></script>
 <script type="text/javascript" src="./static/FileSaver.min.js"></script>
+<script type="text/javascript" src="{{ url_for('static', filename='showdown-1.9.1/showdown.min.js') }}"></script>
 
 <script type="text/javascript" charset="utf-8">
 	// TODO: UI for heat order
@@ -76,6 +77,15 @@
 			rotorhazard.nodes[i] = new nodeModel();
 		}
 
+		// set up markdown converter
+		var panel_converter = new showdown.Converter({
+			ghCodeBlocks: true,
+			ghCompatibleHeaderId: true,
+			literalMidWordUnderscores: true,
+			simpleLineBreaks: true,
+			headerLevelStart: 3
+		});
+
 		socket.on('ui', function (msg) {
 			if (msg.page == 'format') {
 				$('#custom-ui').empty();
@@ -89,6 +99,14 @@
 					panel_header_el.append('<h2><button class="no-style">' + panel.panel.label + '</button></h2>');
 					var panel_content_el = $('<div class="panel-content">');
 					panel_content_el.hide();
+
+					// add markdown content
+					for (var md_idx in panel.markdowns) {
+						md_content = panel.markdowns[md_idx].desc;
+						md_output = panel_converter.makeHtml(md_content);
+						panel_content_el.append('<div class="ui-md-el">')
+							.html(md_output);
+					}
 
 					var form_el = $('<ol class="form">');
 

--- a/src/server/templates/format.html
+++ b/src/server/templates/format.html
@@ -104,8 +104,8 @@
 					for (var md_idx in panel.markdowns) {
 						md_content = panel.markdowns[md_idx].desc;
 						md_output = panel_converter.makeHtml(md_content);
-						panel_content_el.append('<div class="ui-md-el">')
-							.html(md_output);
+						md_element = $('<div class="ui-md-el">').html(md_output);
+						panel_content_el.append(md_element);
 					}
 
 					var form_el = $('<ol class="form">');

--- a/src/server/templates/run.html
+++ b/src/server/templates/run.html
@@ -1,6 +1,7 @@
 {% extends "layout.html" %} {% block title %}{{ __('Run') }}{% endblock %}{% block head %}
 <script type="text/javascript" src="./static/Blob.js"></script>
 <script type="text/javascript" src="./static/FileSaver.min.js"></script>
+<script type="text/javascript" src="{{ url_for('static', filename='showdown-1.9.1/showdown.min.js') }}"></script>
 
 <script type="text/javascript" charset="utf-8">
 	var data_dependencies = [
@@ -242,6 +243,15 @@
 			$('.rssi-graph').prop('hidden', true);
 		}
 
+		// set up markdown converter
+		var panel_converter = new showdown.Converter({
+			ghCodeBlocks: true,
+			ghCompatibleHeaderId: true,
+			literalMidWordUnderscores: true,
+			simpleLineBreaks: true,
+			headerLevelStart: 3
+		});
+
 		socket.on('ui', function (msg) {
 			if (msg.page == 'run') {
 				$('#custom-ui').empty();
@@ -255,6 +265,14 @@
 					panel_header_el.append('<h2><button class="no-style">' + panel.panel.label + '</button></h2>');
 					var panel_content_el = $('<div class="panel-content">');
 					panel_content_el.hide();
+
+					// add markdown content
+					for (var md_idx in panel.markdowns) {
+						md_content = panel.markdowns[md_idx].desc;
+						md_output = panel_converter.makeHtml(md_content);
+						panel_content_el.append('<div class="ui-md-el">')
+							.html(md_output);
+					}
 
 					var form_el = $('<ol class="form">');
 

--- a/src/server/templates/run.html
+++ b/src/server/templates/run.html
@@ -270,8 +270,8 @@
 					for (var md_idx in panel.markdowns) {
 						md_content = panel.markdowns[md_idx].desc;
 						md_output = panel_converter.makeHtml(md_content);
-						panel_content_el.append('<div class="ui-md-el">')
-							.html(md_output);
+						md_element = $('<div class="ui-md-el">').html(md_output);
+						panel_content_el.append(md_element);
 					}
 
 					var form_el = $('<ol class="form">');

--- a/src/server/templates/settings.html
+++ b/src/server/templates/settings.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %} {% block title %}{{ __('Settings') }}{% endblock %} {% block head %}
 <script type="text/javascript" src="./static/Blob.js"></script>
 <script type="text/javascript" src="./static/FileSaver.min.js"></script>
-<script src="./static/showdown-1.9.1/showdown.min.js"></script>
+<script type="text/javascript" src="{{ url_for('static', filename='showdown-1.9.1/showdown.min.js') }}"></script>
 
 <script type="text/javascript" charset="utf-8">
 	var data_dependencies = [
@@ -168,6 +168,7 @@
 					var panel_content_el = $('<div class="panel-content">');
 					panel_content_el.hide();
 
+					// add markdown content
 					for (var md_idx in panel.markdowns) {
 						md_content = panel.markdowns[md_idx].desc;
 						md_output = panel_converter.makeHtml(md_content);

--- a/src/server/templates/settings.html
+++ b/src/server/templates/settings.html
@@ -1,6 +1,7 @@
 {% extends "layout.html" %} {% block title %}{{ __('Settings') }}{% endblock %} {% block head %}
 <script type="text/javascript" src="./static/Blob.js"></script>
 <script type="text/javascript" src="./static/FileSaver.min.js"></script>
+<script src="./static/showdown-1.9.1/showdown.min.js"></script>
 
 <script type="text/javascript" charset="utf-8">
 	var data_dependencies = [
@@ -144,6 +145,15 @@
 			rotorhazard.nodes[i].setup(rotorhazard.nodes[i].canvas);
 		}
 
+		// set up markdown converter
+		var panel_converter = new showdown.Converter({
+			ghCodeBlocks: true,
+			ghCompatibleHeaderId: true,
+			literalMidWordUnderscores: true,
+			simpleLineBreaks: true,
+			headerLevelStart: 3
+		});
+
 		socket.on('ui', function (msg) {
 			if (msg.page == 'settings') {
 				$('#custom-ui').empty();
@@ -157,6 +167,13 @@
 					panel_header_el.append('<h2><button class="no-style">' + panel.panel.label + '</button></h2>');
 					var panel_content_el = $('<div class="panel-content">');
 					panel_content_el.hide();
+
+					for (var md_idx in panel.markdowns) {
+						md_content = panel.markdowns[md_idx].desc;
+						md_output = panel_converter.makeHtml(md_content);
+						panel_content_el.append('<div class="ui-md-el">')
+							.html(md_output);
+					}
 
 					var form_el = $('<ol class="form">');
 

--- a/src/server/templates/settings.html
+++ b/src/server/templates/settings.html
@@ -172,8 +172,8 @@
 					for (var md_idx in panel.markdowns) {
 						md_content = panel.markdowns[md_idx].desc;
 						md_output = panel_converter.makeHtml(md_content);
-						panel_content_el.append('<div class="ui-md-el">')
-							.html(md_output);
+						md_element = $('<div class="ui-md-el">').html(md_output);
+						panel_content_el.append(md_element);
 					}
 
 					var form_el = $('<ol class="form">');

--- a/src/server/templates/streams.html
+++ b/src/server/templates/streams.html
@@ -1,4 +1,5 @@
 {% extends "layout.html" %} {% block title %}{{ __('Streams') }}{% endblock %}{% block head %}
+<script type="text/javascript" src="{{ url_for('static', filename='showdown-1.9.1/showdown.min.js') }}"></script>
 
 <script type="text/javascript" charset="utf-8">
 	var data_dependencies = [
@@ -13,6 +14,15 @@
 	];
 
 	$(document).ready(function () {
+		// set up markdown converter
+		var panel_converter = new showdown.Converter({
+			ghCodeBlocks: true,
+			ghCompatibleHeaderId: true,
+			literalMidWordUnderscores: true,
+			simpleLineBreaks: true,
+			headerLevelStart: 3
+		});
+
 		socket.on('language', function (msg) {
 			if (msg.language) {
 				rotorhazard.interface_language = msg.language;
@@ -32,6 +42,14 @@
 					panel_header_el.append('<h2><button class="no-style">' + panel.panel.label + '</button></h2>');
 					var panel_content_el = $('<div class="panel-content">');
 					panel_content_el.hide();
+
+					// add markdown content
+					for (var md_idx in panel.markdowns) {
+						md_content = panel.markdowns[md_idx].desc;
+						md_output = panel_converter.makeHtml(md_content);
+						panel_content_el.append('<div class="ui-md-el">')
+							.html(md_output);
+					}
 
 					var form_el = $('<ol class="form">');
 

--- a/src/server/templates/streams.html
+++ b/src/server/templates/streams.html
@@ -47,8 +47,8 @@
 					for (var md_idx in panel.markdowns) {
 						md_content = panel.markdowns[md_idx].desc;
 						md_output = panel_converter.makeHtml(md_content);
-						panel_content_el.append('<div class="ui-md-el">')
-							.html(md_output);
+						md_element = $('<div class="ui-md-el">').html(md_output);
+						panel_content_el.append(md_element);
 					}
 
 					var form_el = $('<ol class="form">');


### PR DESCRIPTION
Makes it possible (for plugins) to add Markdown blocks to a panel in the UI. This is very useful, for example, on the stream page, which gives plugins the opportunity to generate a list of links to OBS overlays. Or to add extra textual explanation to a panel styled in markdown.

For now I've added support for the pages: `streams`, `settings`, `run`, `format`

This may eliminate the need for a separate UI link element (#904)
Closes: #878

![image](https://github.com/RotorHazard/RotorHazard/assets/20448157/66284d9f-b3ea-4b63-b29f-3c8dec0eba29)
