### PR TITLE
Pilot sort not keeping the right setting [Fix]

### DIFF
--- a/src/server/templates/format.html
+++ b/src/server/templates/format.html
@@ -62,7 +62,7 @@
 		rotorhazard.saveData();
 		$('nav li').removeClass('admin-hide');
 
-		if ('{{ getOption('pilotSort') }}' == 'callsign') {
+		if ('{{ getConfig("UI", "pilotSort") }}' == 'callsign') {
 			$('#set_pilotSort').val('callsign');
 		}
 


### PR DESCRIPTION
When you switch from `Name` to `Callsign` with **Pilot Sort**, the list will update, but when you refresh the page it does not remember what you had previously set as a sorting.

This PR solves this problem and applies the correct syntax at the same time.