### PR TITLE
Single race heats / grouped round mode

### DIFF
--- a/src/server/Database.py
+++ b/src/server/Database.py
@@ -130,18 +130,18 @@ class Heat(Base):
         if self.name:
             output = self.name
             if self.class_id and race_class.round_type == RoundType.GROUPED:
-                output = "{}: {} {}".format(output, __('Round'), (self.group_id + 1))
+                output = f"{__('Round')} {self.group_id + 1}: {output}"
 
         else:
-            if self.class_id:
+            if self.class_id and race_class.name:
                 output = RHUtils.uniqueName(race_class.display_name, [rc.name for rc in racecontext.rhdata.get_heats()])
                 racecontext.rhdata.alter_heat({
                     'heat': self.id,
                     'name': output
                 })
                 return self.display_name
-            else:
-                output = "{} {}".format(__('Heat'), str(self.id))
+
+            output = "{} {}".format(__('Heat'), str(self.id))
 
         return output
 

--- a/src/server/Database.py
+++ b/src/server/Database.py
@@ -93,7 +93,7 @@ class Heat(Base):
     order = DB.Column(DB.Integer, nullable=True)
     status = DB.Column(DB.Integer, nullable=False)
     auto_frequency = DB.Column(DB.Boolean, nullable=False)
-    group_id = DB.Column(DB.Integer, nullable=True)
+    group_id = DB.Column(DB.Integer, nullable=False)
     active = DB.Column(DB.Boolean, nullable=False, default=True)
 
     # DEPRECATED: compatibility for 'note' property / renamed to 'name'

--- a/src/server/Database.py
+++ b/src/server/Database.py
@@ -93,6 +93,7 @@ class Heat(Base):
     order = DB.Column(DB.Integer, nullable=True)
     status = DB.Column(DB.Integer, nullable=False)
     auto_frequency = DB.Column(DB.Boolean, nullable=False)
+    group_id = DB.Column(DB.Integer, nullable=True)
     active = DB.Column(DB.Boolean, nullable=False, default=True)
 
     # DEPRECATED: compatibility for 'note' property / renamed to 'name'
@@ -177,6 +178,7 @@ class RaceClass(Base):
     _rank_status = DB.Column('rankStatus', DB.String(16), nullable=False)
     rounds = DB.Column(DB.Integer, nullable=False)
     heat_advance_type = DB.Column('heatAdvanceType', DB.Integer, nullable=False)
+    round_type = DB.Column('roundType', DB.Integer, nullable=False)
     order = DB.Column(DB.Integer, nullable=True)
     active = DB.Column(DB.Boolean, nullable=False, default=True)
 
@@ -226,6 +228,10 @@ class HeatAdvanceType:
     NONE = 0
     NEXT_HEAT = 1
     NEXT_ROUND = 2
+
+class RoundType:
+    RACES_PER_HEAT = 0
+    GROUPED = 1
 
 class RaceClassAttribute(Base):
     __tablename__ = 'race_class_attribute'

--- a/src/server/PageCache.py
+++ b/src/server/PageCache.py
@@ -114,7 +114,13 @@ class PageCache:
             self.set_buildToken(monotonic())
 
             heats = {}
-            for heat in self._racecontext.rhdata.get_heats():
+            all_heats = self._racecontext.rhdata.get_heats()
+            all_heats = sorted(all_heats, key = lambda h: (
+                h.class_id,
+                h.group_id,
+                h.order,
+            ))
+            for heat in all_heats:
                 if self._racecontext.rhdata.savedRaceMetas_has_heat(heat.id):
                     rounds = []
                     for race in self._racecontext.rhdata.get_savedRaceMetas_by_heat(heat.id):    
@@ -166,9 +172,18 @@ class PageCache:
 
             gevent.sleep(0.001)
             heats_by_class = {}
-            heats_by_class[RHUtils.CLASS_ID_NONE] = [heat.id for heat in self._racecontext.rhdata.get_heats_by_class(RHUtils.CLASS_ID_NONE)]
+            heats_by_class[RHUtils.CLASS_ID_NONE] = self._racecontext.rhdata.get_heats_by_class(RHUtils.CLASS_ID_NONE)
             for race_class in self._racecontext.rhdata.get_raceClasses():
-                heats_by_class[race_class.id] = [heat.id for heat in self._racecontext.rhdata.get_heats_by_class(race_class.id)]
+                heats_by_class[race_class.id] = self._racecontext.rhdata.get_heats_by_class(race_class.id)
+
+            heat_ids_by_class = {}
+            for idx, race_class in heats_by_class.items():
+                race_class = sorted(race_class, key=lambda h: (
+                    h.class_id,
+                    h.group_id,
+                    h.order,
+                ))
+                heat_ids_by_class[idx] = [heat.id for heat in race_class]
 
             timing['by_class'] = monotonic()
 
@@ -197,7 +212,7 @@ class PageCache:
 
             payload = {
                 'heats': heats,
-                'heats_by_class': heats_by_class,
+                'heats_by_class': heat_ids_by_class,
                 'classes': current_classes,
                 'event_leaderboard': results,
                 'consecutives_count': self._racecontext.rhdata.get_optionInt('consecutivesCount', 3)

--- a/src/server/RHData.py
+++ b/src/server/RHData.py
@@ -1037,6 +1037,7 @@ class RHData():
             }),
             order=None,
             status=HeatStatus.PLANNED,
+            group_id=0,
             auto_frequency=False
             )
 
@@ -1048,7 +1049,7 @@ class RHData():
             if 'auto_frequency' in init:
                 new_heat.auto_frequency = init['auto_frequency']
             if 'group_id' in init:
-                new_heat.class_id = init['group_id']
+                new_heat.group_id = init['group_id']
 
             defaultMethod = init['defaultMethod'] if 'defaultMethod' in init else ProgramMethod.ASSIGN
         else:

--- a/src/server/RHData.py
+++ b/src/server/RHData.py
@@ -1434,7 +1434,7 @@ class RHData():
 
             if current_class.heat_advance_type == HeatAdvanceType.NEXT_ROUND:
                 if regen_heat:
-                    return regen_heat
+                    return regen_heat.id
 
             heats = self.get_heats_by_class(current_heat.class_id)
             heats = [h for h in heats if h.active]

--- a/src/server/RHData.py
+++ b/src/server/RHData.py
@@ -2885,12 +2885,24 @@ class RHData():
             race.round_id = round_counter
             round_counter += 1
 
+        if old_heat_races and old_class:
+            if old_class.round_type == RoundType.GROUPED:
+                old_heat.active = False
+            else:
+                old_heat.active = True
+
         new_heat_races = Database.SavedRaceMeta.query.filter_by(heat_id=new_heat_id) \
             .order_by(Database.SavedRaceMeta.start_time_formatted).all()
         round_counter = 1
         for race in new_heat_races:
             race.round_id = round_counter
             round_counter += 1
+
+        if new_heat_races and new_class:
+            if new_class.round_type == RoundType.GROUPED:
+                new_heat.active = False
+            else:
+                new_heat.active = True
 
         self.commit()
 

--- a/src/server/RHRace.py
+++ b/src/server/RHRace.py
@@ -614,12 +614,13 @@ class RHRace():
 
             self.discard_laps(saved=True) # Also clear the current laps
 
+            regen_heat = False
             if heat.class_id:
                 raceclass = self._racecontext.rhdata.get_raceClass(heat.class_id)
                 if raceclass.round_type == RoundType.GROUPED:
                     if heat.group_id + 1 < raceclass.rounds:
                         # Regenerate to new heat + group
-                        self._racecontext.rhdata.duplicate_heat(heat, new_heat_name=heat.name, group_id=heat.group_id + 1)
+                        regen_heat = self._racecontext.rhdata.duplicate_heat(heat, new_heat_name=heat.name, group_id=heat.group_id + 1)
 
                     # Deactivate current heat
                     self._racecontext.rhdata.alter_heat({
@@ -629,7 +630,8 @@ class RHRace():
 
                     self._racecontext.rhui.emit_heat_data()
 
-            next_heat = self._racecontext.rhdata.get_next_heat_id(heat)
+            next_heat = self._racecontext.rhdata.get_next_heat_id(heat, regen_heat)
+
             if next_heat is not heat.id:
                 self.set_heat(next_heat)
 

--- a/src/server/RHRace.py
+++ b/src/server/RHRace.py
@@ -617,8 +617,9 @@ class RHRace():
             if heat.class_id:
                 raceclass = self._racecontext.rhdata.get_raceClass(heat.class_id)
                 if raceclass.round_type == RoundType.GROUPED:
-                    # Regenerate to new heat + group
-                    self._racecontext.rhdata.duplicate_heat(heat, new_heat_name=heat.name, group_id=heat.group_id + 1)
+                    if heat.group_id + 1 < raceclass.rounds:
+                        # Regenerate to new heat + group
+                        self._racecontext.rhdata.duplicate_heat(heat, new_heat_name=heat.name, group_id=heat.group_id + 1)
 
                     # Deactivate current heat
                     self._racecontext.rhdata.alter_heat({

--- a/src/server/RHRace.py
+++ b/src/server/RHRace.py
@@ -618,7 +618,7 @@ class RHRace():
             if heat.class_id:
                 raceclass = self._racecontext.rhdata.get_raceClass(heat.class_id)
                 if raceclass.round_type == RoundType.GROUPED:
-                    if heat.group_id + 1 < raceclass.rounds:
+                    if raceclass.rounds == 0 or heat.group_id + 1 < raceclass.rounds:
                         # Regenerate to new heat + group
                         regen_heat = self._racecontext.rhdata.duplicate_heat(heat, new_heat_name=heat.name, group_id=heat.group_id + 1)
 

--- a/src/server/RHUI.py
+++ b/src/server/RHUI.py
@@ -851,8 +851,8 @@ class RHUI():
         for heat in self._racecontext.rhdata.get_heats():
             current_heat = {}
             current_heat['id'] = heat.id
-            current_heat['name'] = heat.name
             current_heat['displayname'] = heat.display_name
+            current_heat['name'] = heat.name
             current_heat['class_id'] = heat.class_id
             current_heat['group_id'] = heat.group_id
             current_heat['order'] = heat.order

--- a/src/server/RHUI.py
+++ b/src/server/RHUI.py
@@ -849,6 +849,7 @@ class RHUI():
             current_heat['name'] = heat.name
             current_heat['displayname'] = heat.display_name
             current_heat['class_id'] = heat.class_id
+            current_heat['group_id'] = heat.group_id
             current_heat['order'] = heat.order
             current_heat['status'] = heat.status
             current_heat['auto_frequency'] = heat.auto_frequency
@@ -911,6 +912,7 @@ class RHUI():
             current_class['ranksettings'] = json.loads(race_class.rank_settings) if race_class.rank_settings else None
             current_class['rounds'] = race_class.rounds
             current_class['heat_advance_type'] = race_class.heat_advance_type
+            current_class['round_type'] = race_class.round_type
             current_class['order'] = race_class.order
             current_class['locked'] = self._racecontext.rhdata.savedRaceMetas_has_raceClass(race_class.id)
             current_classes.append(current_class)

--- a/src/server/RHUI.py
+++ b/src/server/RHUI.py
@@ -753,7 +753,6 @@ class RHUI():
                         })
                     rounds[race.round_id] = {
                         'race_id': race.id,
-                        'class_id': race.class_id,
                         'format_id': race.format_id,
                         'start_time': race.start_time,
                         'start_time_formatted': race.start_time_formatted,
@@ -761,9 +760,13 @@ class RHUI():
                     }
                 heats[heat.id] = {
                     'heat_id': heat.id,
+                    'class_id': heat.class_id,
                     'displayname': heat.display_name,
                     'rounds': rounds,
                 }
+                if heat.class_id:
+                    race_class = self._racecontext.rhdata.get_raceClass(heat.class_id)
+                    heats[heat.id]['round_type'] = race_class.round_type
 
         emit_payload = {
             'heats': heats,

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -1,6 +1,6 @@
 '''RotorHazard server script'''
 RELEASE_VERSION = "4.2.0-dev.1" # Public release version code
-SERVER_API = 44 # Server API version
+SERVER_API = 45 # Server API version
 NODE_API_SUPPORTED = 18 # Minimum supported node version
 NODE_API_BEST = 35 # Most recent node API
 JSON_API = 3 # JSON API version

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -1143,7 +1143,7 @@ def on_alter_race_class(data):
         RaceContext.rhui.emit_priority_message(message, False)
 
     RaceContext.rhui.emit_class_data(noself=True)
-    if 'class_name' in data or 'round_type' in data:
+    if 'class_name' in data or 'round_type' in data or 'rounds' in data:
         RaceContext.rhui.emit_heat_data() # Update class names in heat displays
     if 'class_format' in data:
         RaceContext.rhui.emit_current_heat(noself=True) # in case race operator is a different client, update locked format dropdown

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -1134,13 +1134,14 @@ def on_alter_race_class(data):
     if ('class_format' in data or \
         'class_name' in data or \
         'win_condition' in data or \
+        'round_type' in data or \
         'rank_settings' in data) and len(altered_race_list):
         RaceContext.rhui.emit_result_data() # live update rounds page
         message = __('Alterations made to race class: {0}').format(race_class.display_name)
         RaceContext.rhui.emit_priority_message(message, False)
 
     RaceContext.rhui.emit_class_data(noself=True)
-    if 'class_name' in data:
+    if 'class_name' in data or 'round_type' in data:
         RaceContext.rhui.emit_heat_data() # Update class names in heat displays
     if 'class_format' in data:
         RaceContext.rhui.emit_current_heat(noself=True) # in case race operator is a different client, update locked format dropdown

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -199,6 +199,8 @@ RaceContext.pagecache = PageCache.PageCache(RaceContext, Events) # For storing p
 RaceContext.language = Language.Language(RaceContext) # initialize language
 __ = RaceContext.language.__ # Shortcut to translation function
 Database.__ = __ # Pass language to Database module
+Database.racecontext = RaceContext # Pass racecontext to Database module
+
 RaceContext.race = RHRace.RHRace(RaceContext) # Current race variables
 RaceContext.rhui = RHUI.RHUI(APP, SOCKET_IO, RaceContext, Events) # User Interface Manager
 RaceContext.rhui.__ = RaceContext.language.__ # Pass translation shortcut

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -1049,7 +1049,12 @@ def on_set_scan(data):
 def on_add_heat(data=None):
     '''Adds the next available heat number to the database.'''
     if data and 'class' in data:
-        RaceContext.rhdata.add_heat(init={'class_id': data['class']})
+        init = {
+            'class_id': data['class']
+        }
+        if 'group' in data:
+            init['group_id'] = data['group']
+        RaceContext.rhdata.add_heat(init=init)
     else:
         RaceContext.rhdata.add_heat()
     RaceContext.rhui.emit_heat_data()

--- a/src/server/static/rotorhazard.css
+++ b/src/server/static/rotorhazard.css
@@ -1658,7 +1658,7 @@ main.page-home {
 
 	.race_classes .set_race_class_description {
 		grid-column: 1;
-		grid-row: 2 / span 4;
+		grid-row: 2 / span 5;
 		height: 100%;
 	}
 
@@ -1670,6 +1670,11 @@ main.page-home {
 	.race_classes .field-ranking {
 		grid-column: 2;
 		grid-row: 3;
+	}
+
+	.race_classes .field-round-type {
+		grid-column: 2;
+		grid-row: 4;
 	}
 
 	.race_classes .field {
@@ -1691,17 +1696,17 @@ main.page-home {
 
 	.race_classes .field-rounds {
 		grid-column: 2;
-		grid-row: 4;
+		grid-row: 5;
 	}
 
 	.race_classes .field-advance {
 		grid-column: 2;
-		grid-row: 5;
+		grid-row: 6;
 	}
 
 	.race_classes .heats {
 		grid-column: 1 / -1;
-		grid-row: 6;
+		grid-row: 7;
 	}
 }
 

--- a/src/server/static/rotorhazard.css
+++ b/src/server/static/rotorhazard.css
@@ -1704,7 +1704,8 @@ main.page-home {
 		grid-row: 6;
 	}
 
-	.race_classes .heats {
+	.race_classes .heats,
+	.race_classes .groups {
 		grid-column: 1 / -1;
 		grid-row: 7;
 	}

--- a/src/server/templates/format.html
+++ b/src/server/templates/format.html
@@ -410,7 +410,9 @@
 						var selectbox = $('<select class="set_race_class_heat_advance" id="class_heat_advance_' + race_class.id + '" data-class_id="' + race_class.id + '">')
 						selectbox.append('<option value="1">' + __('Always') + '</option>');
 						selectbox.append('<option value="2">' + __('After All Rounds') + '</option>');
-						selectbox.append('<option value="0">' + __('Never') + '</option>');
+						if (race_class.round_type != 1) {
+							selectbox.append('<option value="0">' + __('Never') + '</option>');
+						}
 
 						selectbox.val(race_class.heat_advance_type);
 						field.append(selectbox);
@@ -444,6 +446,13 @@
 								heats_el.append('<li class="new_heat_container"><button class="add_heat" data-id="' + race_class.id + '" data-group="' + i + '">' + __('Add Heat') + '</button></li>');
 								groups_el.append(heats_el);
 							}
+							if (!heats_by_group.length) {
+								groups_el.append('<p>' + __('Round') + ' 1</p>');
+								var heats_el = $('<ol class="heats">');
+								heats_el.append('<li class="new_heat_container"><button class="add_heat" data-id="' + race_class.id + '" data-group="0">' + __('Add Heat') + '</button></li>');
+								groups_el.append(heats_el);
+							}
+
 							el.append(groups_el);
 
 						} else {

--- a/src/server/templates/format.html
+++ b/src/server/templates/format.html
@@ -615,6 +615,7 @@
 			if (race_class) {
 				race_class.round_type = data.round_type;
 			}
+			display_classes();
 		});
 
 		$(document).on("change", '.set_race_class_rounds', function (event) {

--- a/src/server/templates/format.html
+++ b/src/server/templates/format.html
@@ -388,6 +388,15 @@
 						field.append(settingsbtn)
 						el.append(field);
 
+						var field = $('<div class="field field-round-type">');
+						field.append('<label for="class_round_type_' + race_class.id + '">' + __('Round Type') + '</label>');
+						var selectbox = $('<select class="set_race_class_round_type" id="class_round_type_' + race_class.id + '" data-class_id="' + race_class.id + '">')
+						selectbox.append('<option value="0">' + __('Races per heat') + '</option>');
+						selectbox.append('<option value="1">' + __('Fixed Groups') + '</option>');
+						selectbox.val(race_class.round_type);
+						field.append(selectbox);
+						el.append(field);
+
 						var field = $('<div class="field field-rounds">');
 						field.append('<label for="race_class_rounds-' + race_class.id + '">' + __('Rounds') + '</label>');
 						var input = $('<input type="number" id="race_class_rounds-' + race_class.id + '" class="set_race_class_rounds" data-class_id="' + race_class.id + '" step="1" min="0">');
@@ -562,6 +571,19 @@
 				} else {
 					settingsbtn.prop('hidden', true);
 				}
+			}
+		});
+
+		$(document).on("change", '.set_race_class_round_type', function (event) {
+			var data = {
+				class_id: parseInt($(this).data('class_id')),
+				round_type: parseInt($(this).val()),
+			};
+			socket.emit('alter_race_class', data);
+
+			var race_class = rotorhazard.event.classes.find(obj => {return obj.id == data.class_id});
+			if (race_class) {
+				race_class.round_type = data.round_type;
 			}
 		});
 

--- a/src/server/templates/format.html
+++ b/src/server/templates/format.html
@@ -728,7 +728,7 @@
 			var header = $('<h4>Heat ' + heat.id + '</h4>');
 			el.append(header);
 
-			var input = $('<input type="text" id="heat-name-' + heat.id + '" class="set_heat_name" data-heat="' + heat.id + '" placeholder="' + __('Name') + ' (' + __('Heat') + ' ' + heat.id + ')" maxlength="80">');
+			var input = $('<input type="text" id="heat-name-' + heat.id + '" class="set_heat_name" data-heat="' + heat.id + '" placeholder="' + __('Name') + ' (' + heat.displayname + ')" maxlength="80">');
 			input.val(heat.name);
 			el.append(input);
 

--- a/src/server/templates/format.html
+++ b/src/server/templates/format.html
@@ -391,9 +391,10 @@
 						var field = $('<div class="field field-round-type">');
 						field.append('<label for="class_round_type_' + race_class.id + '">' + __('Round Type') + '</label>');
 						var selectbox = $('<select class="set_race_class_round_type" id="class_round_type_' + race_class.id + '" data-class_id="' + race_class.id + '">')
-						selectbox.append('<option value="0">' + __('Races per heat') + '</option>');
-						selectbox.append('<option value="1">' + __('Fixed Groups') + '</option>');
+						selectbox.append('<option value="0">' + __('Count races per heat') + '</option>');
+						selectbox.append('<option value="1">' + __('Generate heat groups') + '</option>');
 						selectbox.val(race_class.round_type);
+						selectbox.prop('disabled', locked);
 						field.append(selectbox);
 						el.append(field);
 
@@ -419,15 +420,44 @@
 						input.val(race_class.order);
 						el.append(input);
 
-						var heats_el = $('<ol class="heats">');
-						for (var i in rotorhazard.event.heats) {
-							var heat = rotorhazard.event.heats[i];
-							if (heat.class_id == race_class.id) {
-								heats_el.append(create_heat_ui(heat));
+						if (race_class.round_type == 1) {
+							var groups_el = $('<div class="groups">');
+							var heats_by_group = [];
+							for (var i in rotorhazard.event.heats) {
+								heat = rotorhazard.event.heats[i];
+								if (heat.class_id == race_class.id) {
+									var group = heat.group_id == null ? -1 : heat.group_id;
+									if (!heats_by_group[group]) {
+										heats_by_group[group] = []
+									};
+									heats_by_group[group].push(heat);
+								}
 							}
+							for (var i in heats_by_group) {
+								groups_el.append('<p>' + __('Round') + ' ' + (parseInt(i)+1) + '</p>');
+
+								var heats_el = $('<ol class="heats">');
+								for (var j in heats_by_group[i]) {
+									var heat = heats_by_group[i][j];
+									heats_el.append(create_heat_ui(heat));
+								}
+								heats_el.append('<li class="new_heat_container"><button class="add_heat" data-id="' + race_class.id + '" data-group="' + i + '">' + __('Add Heat') + '</button></li>');
+								groups_el.append(heats_el);
+							}
+							el.append(groups_el);
+
+						} else {
+							var heats_el = $('<ol class="heats">');
+							for (var i in rotorhazard.event.heats) {
+								var heat = rotorhazard.event.heats[i];
+								if (heat.class_id == race_class.id) {
+									heats_el.append(create_heat_ui(heat, race_class));
+								}
+							}
+							heats_el.append('<li class="new_heat_container"><button class="add_heat" data-id="' + race_class.id + '">' + __('Add Heat') + '</button></li>');
+							el.append(heats_el);
+
 						}
-						heats_el.append('<li class="new_heat_container"><button class="add_heat" data-id="' + race_class.id + '">' + __('Add Heat') + '</button></li>');
-						el.append(heats_el);
 
 						el.appendTo(classlist);
 					}
@@ -658,6 +688,9 @@
 			var data = {
 				class: parseInt($(this).data('id')),
 			};
+			if (typeof $(this).data('group') !== 'undefined') {
+				data.group = $(this).data('group')
+			}
 			socket.emit('add_heat', data);
 		});
 
@@ -677,7 +710,7 @@
 			$('#generating-message').prop('hidden', true);
 		});
 
-		function create_heat_ui(heat) {
+		function create_heat_ui(heat, race_class=null) {
 			var el = $('<li class="rh-heat" data-heat="' + heat.id + '">');
 
 			if (heat.status == 2) {
@@ -703,7 +736,7 @@
 			if (locked) {
 				if (heat.active) {
 					actions.prepend('<button class="deactivate_heat eye-icon" data-id="' + heat.id + '" title="' + __('Deactivate Heat') + ': ' + heat.displayname + '">' + svg_asset.eye_visible + '</button>');
-				} else {
+				} else if (race_class && !race_class.round_type) {
 					actions.prepend('<button class="activate_heat eye-icon" data-id="' + heat.id + '" title="' + __('Activate Heat') + ': ' + heat.displayname + '">' + svg_asset.eye_invisible + '</button>');
 				}
 

--- a/src/server/templates/marshal.html
+++ b/src/server/templates/marshal.html
@@ -308,11 +308,18 @@
 
 			var heat = parseInt($(this).val());
 
-			for (var round_i in race_list.heats[heat].rounds) {
-				$('#selected_round').append('<option value="' + round_i + '">' + __('Round') + ' ' + round_i + '</option>');
+			if (1 in race_list.heats[heat].rounds && !(2 in race_list.heats[heat].rounds) ) {
+				$('#selected_round').append('<option value="1">-</option>');
+				$('#selected_round').val(1);
+				$('#selected_round').prop('hidden', true);
+			} else {
+				for (var round_i in race_list.heats[heat].rounds) {
+					$('#selected_round').append('<option value="' + round_i + '">' + __('Round') + ' ' + round_i + '</option>');
+				}
+				$('#selected_round').val(round_i);
+				$('#selected_round').prop('hidden', false);
 			}
 
-			$('#selected_round').val(round_i);
 			$('#selected_round option').each(function(){
 				if (this.value == prev_round) {
 					$('#selected_round').val(prev_round);
@@ -394,7 +401,7 @@
 			current_race_data.round_id = round;
 			current_race_data.heat_id = heat;
 			current_race_data.race_id = race_list.heats[heat].rounds[round].race_id;
-			current_race_data.class_id = race_list.heats[heat].rounds[round].class_id;
+			current_race_data.class_id = race_list.heats[heat].class_id;
 			current_race_data.format_id = race_list.heats[heat].rounds[round].format_id;
 			current_race_data.start_time = race_list.heats[heat].rounds[round].start_time;
 			current_race_data.start_time_formatted = race_list.heats[heat].rounds[round].start_time_formatted;

--- a/src/server/templates/run.html
+++ b/src/server/templates/run.html
@@ -572,9 +572,11 @@
 				if (single_class) {
 					for (var h in rotorhazard.event.heats) {
 						var heat = rotorhazard.event.heats[h];
-						var opt = $('<option value="' + heat.id + '" data-class="' + heat.class_id + '">');
-						opt.html(heat.displayname);
-						$('#set_current_heat').append(opt);
+						if (heat.active) {
+							var opt = $('<option value="' + heat.id + '" data-class="' + heat.class_id + '">');
+							opt.html(heat.displayname);
+							$('#set_current_heat').append(opt);
+						}
 					}
 				} else {
 					for (var c in heats_by_class) {


### PR DESCRIPTION
Introduces a class property that changes the concept of "rounds" from a heat > races hierarchy to a round group > heats hierarchy.
* Changes the meaning of the term "round" in the UI from 'races per heat' to 'heats per round group'
* Prevents more than one race from being run in each heat
* Automatically create round groups as races are run
* Automatically regenerate (duplicate) heats into new round groups
* Handle conversion between round types

Other systems often expect the round>heat paradigm and expect RH to behave similarly. Being able to switch to this mode allows the system to align with these expectations and streamline usage for those users. For example, users who want to "switch a pilot to another heat" are expecting this paradigm and can now proceed aligned with their expectations. This also improves compatibility with MultiGP which expects a similar setup for posting results and cannot handle the heat > races paradigm (originally introduced by Delta5).