### PR TITLE
fix: avoid rewriting available_node when looping over it

### DIFF
--- a/src/server/heat_automation.py
+++ b/src/server/heat_automation.py
@@ -219,7 +219,7 @@ class HeatAutomator:
                             for slot_idx, slot_match in enumerate(available_node['matches']):
                                 if slot_match['slot'] == m_slot:
                                     available_node['matches'][slot_idx] = None
-                                available_node['matches'] = [x for x in available_node['matches'] if x is not None]
+                            available_node['matches'] = [x for x in available_node['matches'] if x is not None]
                     else:
                         # calc function didn't make an assignment
                         random.shuffle(available_seats)


### PR DESCRIPTION
A wrong identation lead to overwritting available_node while looping over it.
While it seems not bothering most of the time, it's totally unecessary and could be a potential source of problem.