### PR TITLE
Fix: use class id as param to acutally commit to DB

### DIFF
--- a/src/server/RHData.py
+++ b/src/server/RHData.py
@@ -2044,12 +2044,12 @@ class RHData():
         if cache_invalid:
             logger.error('Class {} ranking has invalid status'.format(race_class.id))
             token = monotonic()
-            self.clear_ranking_raceClass(race_class, token)
+            self.clear_ranking_raceClass(race_class.id, token)
 
         # cache rebuild
         logger.debug('Building Class {} ranking'.format(race_class.id))
         build = Results.calc_class_ranking_leaderboard(self._racecontext, class_id=race_class.id)
-        self.set_ranking_raceClass(race_class, token, build)
+        self.set_ranking_raceClass(race_class.id, token, build)
         return build
 
     def set_results_raceClass(self, raceClass_or_id, token, results):


### PR DESCRIPTION
The ranking was not commited correctly into database somehow due to DB context not beeing the same when getting the object and updating it.

When using the class id as param to both clear and set ranking functions, it forces the functions to get the raceClass using the same db session as the one used for commit.