### PR TITLE
Schedule race starts for secondaries

### DIFF
--- a/src/server/ClusterNodeSet.py
+++ b/src/server/ClusterNodeSet.py
@@ -282,15 +282,9 @@ class SecondaryNode:
                     gevent.sleep(9)
         logger.debug("Exiting worker thread for secondary timer {}".format(self.id+1))
 
-    def emit(self, event, data = None):
-        if data is None: data = {}
-        data['correction_ms'] = self.timeDiffMedianMs
-
+    def emit(self, event, data=None):
         try:
             if self.lastContactTime > 0:
-                if event == 'stage_race':
-                    data['start_time_epoch_ms'] = self._racecontext.race.start_time_epoch_ms
-
                 self.sio.emit(event, data)
                 self.lastContactTime = monotonic()
                 self.numContacts += 1
@@ -781,8 +775,10 @@ class ClusterNodeSet:
         for secondary in self.secondaries:
             gevent.spawn(secondary.emit, event, data)
 
-    def emitToSplits(self, event, data = None):
+    def emitToSplits(self, event, data=None, addTimeCorrFlag=False):
         for secondary in self.splitSecondaries:
+            if addTimeCorrFlag and type(data) is dict:
+                data['correction_ms'] = secondary.timeDiffMedianMs
             gevent.spawn(secondary.emit, event, data)
 
     def emitEventTrigger(self, data = None):

--- a/src/server/ClusterNodeSet.py
+++ b/src/server/ClusterNodeSet.py
@@ -283,8 +283,14 @@ class SecondaryNode:
         logger.debug("Exiting worker thread for secondary timer {}".format(self.id+1))
 
     def emit(self, event, data = None):
+        if data is None: data = {}
+        data['correction_ms'] = self.timeDiffMedianMs
+
         try:
             if self.lastContactTime > 0:
+                if event == 'stage_race':
+                    data['start_time_epoch_ms'] = self._racecontext.race.start_time_epoch_ms
+
                 self.sio.emit(event, data)
                 self.lastContactTime = monotonic()
                 self.numContacts += 1

--- a/src/server/RHRace.py
+++ b/src/server/RHRace.py
@@ -297,7 +297,9 @@ class RHRace():
                 }
 
                 if self._racecontext.cluster:
-                    self._racecontext.cluster.emitToSplits('stage_race')
+                    splitsData = {}
+                    splitsData['start_time_epoch_ms'] = self._racecontext.race.start_time_epoch_ms
+                    self._racecontext.cluster.emitToSplits('stage_race', splitsData, addTimeCorrFlag=True)
 
                 self._racecontext.events.trigger(Evt.RACE_STAGE, eventPayload)
                 self._racecontext.rhui.emit_race_stage(eventPayload)

--- a/src/server/RHRace.py
+++ b/src/server/RHRace.py
@@ -129,7 +129,15 @@ class RHRace():
             if data and data.get('secondary_format'):
                 self.format = self._racecontext.serverstate.secondary_race_format
 
-            assigned_start = data.get('start_time_s', False) if data else None
+            assigned_start_epoch = data.get('start_time_epoch_ms', False) if data else None
+            if assigned_start_epoch:
+                if data.get('correction_ms'):
+                    assigned_start_epoch = assigned_start_epoch + data['correction_ms']
+
+                assigned_start = self._racecontext.serverstate.epoch_millis_to_monotonic(
+                    assigned_start_epoch)
+            else:
+                assigned_start = data.get('start_time_s', False) if data else None
 
             race_format = self.format
             if race_format is self._racecontext.serverstate.secondary_race_format and \
@@ -193,9 +201,6 @@ class RHRace():
                         heatNode = FauxHeatNode
                         heatNode.node_index = idx
                         heatNodes.append(heatNode)
-
-            if self._racecontext.cluster:
-                self._racecontext.cluster.emitToSplits('stage_race')
 
             if self.race_status != RaceStatus.READY:
                 if race_format is self._racecontext.serverstate.secondary_race_format:  # if running as secondary timer
@@ -280,14 +285,19 @@ class RHRace():
                 eventPayload = {
                     'hide_stage_timer': hide_stage_timer,
                     'pi_staging_at_s': self.stage_time_monotonic,
+                    'server_staging_epoch_ms': self._racecontext.serverstate.monotonic_to_epoch_millis(self.stage_time_monotonic),
                     'staging_tones': staging_tones,
                     'pi_starts_at_s': self.start_time_monotonic,
+                    'server_start_epoch_ms': self.start_time_epoch_ms,
                     'unlimited_time': race_format.unlimited_time,
                     'race_time_sec': race_format.race_time_sec,
                     'color': ColorVal.ORANGE,
                     'heat_id': self.current_heat,
                     'race_node_colors': self.seat_colors,
                 }
+
+                if self._racecontext.cluster:
+                    self._racecontext.cluster.emitToSplits('stage_race')
 
                 self._racecontext.events.trigger(Evt.RACE_STAGE, eventPayload)
                 self._racecontext.rhui.emit_race_stage(eventPayload)

--- a/src/server/RaceContext.py
+++ b/src/server/RaceContext.py
@@ -265,6 +265,9 @@ class ServerState:
     def monotonic_to_epoch_millis(self, secs):
         return 1000.0*secs + self.mtonic_to_epoch_millis_offset
 
+    def epoch_millis_to_monotonic(self, secs):
+        return (secs - self.mtonic_to_epoch_millis_offset)/1000.0
+
     # SERVER GLOBALS
 
     # race format used in secondary mode (must be initialized after database)

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -629,7 +629,7 @@ def connect_handler(auth):
     gevent.spawn_later(0.050, finish_connect_handler)
 
 @SOCKET_IO.on('disconnect')
-def disconnect_handler():
+def disconnect_handler(*args):
     '''Emit disconnect event.'''
     logger.debug('Client disconnected')
 
@@ -637,7 +637,7 @@ def disconnect_handler():
 
 @SOCKET_IO.on('join_cluster')
 @catchLogExcWithDBWrapper
-def on_join_cluster():
+def on_join_cluster(*args):
     RaceContext.race.format = RaceContext.serverstate.secondary_race_format
     RaceContext.rhui.emit_current_laps()
     RaceContext.rhui.emit_race_status()
@@ -1118,7 +1118,7 @@ def on_delete_heat(data):
 
 @SOCKET_IO.on('add_race_class')
 @catchLogExcWithDBWrapper
-def on_add_race_class():
+def on_add_race_class(*args):
     '''Adds the next available pilot id number in the database.'''
     RaceContext.rhdata.add_raceClass()
     RaceContext.rhui.emit_class_data()
@@ -1164,7 +1164,7 @@ def on_delete_class(data):
 
 @SOCKET_IO.on('add_pilot')
 @catchLogExcWithDBWrapper
-def on_add_pilot():
+def on_add_pilot(*args):
     '''Adds the next available pilot id number in the database.'''
     RaceContext.rhdata.add_pilot()
     RaceContext.rhui.emit_pilot_data()
@@ -1224,7 +1224,7 @@ def on_set_seat_color(data):
 
 @SOCKET_IO.on('reset_seat_color')
 @catchLogExcWithDBWrapper
-def on_reset_seat_color():
+def on_reset_seat_color(*args):
     '''Update seat color.'''
     RaceContext.serverconfig.set_item('LED', 'seatColors', [])
     RaceContext.race.updateSeatColors()
@@ -1239,7 +1239,7 @@ def on_reset_seat_color():
 
 @SOCKET_IO.on('add_profile')
 @catchLogExcWithDBWrapper
-def on_add_profile():
+def on_add_profile(*args):
     '''Adds new profile (frequency set) in the database.'''
     source_profile = RaceContext.race.profile
     new_profile = RaceContext.rhdata.duplicate_profile(source_profile)
@@ -1259,7 +1259,7 @@ def on_alter_profile(data):
 
 @SOCKET_IO.on('delete_profile')
 @catchLogExcWithDBWrapper
-def on_delete_profile():
+def on_delete_profile(*args):
     '''Delete profile'''
     profile = RaceContext.race.profile
     result = RaceContext.rhdata.delete_profile(profile)
@@ -1358,7 +1358,7 @@ def on_alter_race(data):
 
 @SOCKET_IO.on('backup_database')
 @catchLogExcWithDBWrapper
-def on_backup_database():
+def on_backup_database(*args):
     '''Backup database.'''
     bkp_name = RaceContext.rhdata.backup_db_file(True)  # make copy of DB file
 
@@ -1381,7 +1381,7 @@ def on_backup_database():
 
 @SOCKET_IO.on('list_backups')
 @catchLogExceptionsWrapper
-def on_list_backups():
+def on_list_backups(*args):
     '''List database files in db_bkp'''
 
     if not os.path.exists(DB_BKP_DIR_NAME):
@@ -1654,7 +1654,7 @@ def on_generate_heats_v2(data):
 
 @SOCKET_IO.on('shutdown_pi')
 @catchLogExceptionsWrapper
-def on_shutdown_pi():
+def on_shutdown_pi(*args):
     '''Shutdown the raspberry pi.'''
     if  RaceContext.interface.send_shutdown_started_message():
         gevent.sleep(0.25)  # give shutdown-started message a chance to transmit to node
@@ -1677,7 +1677,7 @@ def on_shutdown_pi():
 
 @SOCKET_IO.on('reboot_pi')
 @catchLogExceptionsWrapper
-def on_reboot_pi():
+def on_reboot_pi(*args):
     '''Reboot the raspberry pi.'''
     if RaceContext.cluster:
         RaceContext.cluster.emit('reboot_pi')
@@ -1698,7 +1698,7 @@ def on_reboot_pi():
 
 @SOCKET_IO.on('kill_server')
 @catchLogExceptionsWrapper
-def on_kill_server():
+def on_kill_server(*args):
     '''Shutdown this server.'''
     if RaceContext.cluster:
         RaceContext.cluster.emit('kill_server')
@@ -1942,7 +1942,7 @@ def on_use_led_effect(data):
 # TODO: Remove
 @SOCKET_IO.on('get_pi_time')
 @catchLogExceptionsWrapper
-def on_get_pi_time():
+def on_get_pi_time(*args):
     # never broadcasts to all (client must make request)
     emit('pi_time', {
         'pi_time_s': monotonic()
@@ -1950,7 +1950,7 @@ def on_get_pi_time():
 
 @SOCKET_IO.on('get_server_time')
 @catchLogExceptionsWrapper
-def on_get_server_time():
+def on_get_server_time(*args):
     return {'server_time_s': monotonic()}
 
 @SOCKET_IO.on('schedule_race')
@@ -1960,7 +1960,7 @@ def on_schedule_race(data):
 
 @SOCKET_IO.on('cancel_schedule_race')
 @catchLogExceptionsWrapper
-def cancel_schedule_race():
+def cancel_schedule_race(*args):
     RaceContext.race.schedule(None)
 
 @SOCKET_IO.on('stage_race')
@@ -2203,7 +2203,7 @@ def on_set_consecutives_count(data):
 
 @SOCKET_IO.on('get_race_scheduled')
 @catchLogExceptionsWrapper
-def get_race_elapsed():
+def get_race_elapsed(*args):
     # get current race status; never broadcasts to all
     emit('race_scheduled', {
         'scheduled': RaceContext.race.scheduled,
@@ -2221,7 +2221,7 @@ def save_callouts(data):
 
 @SOCKET_IO.on('reload_callouts')
 @catchLogExcWithDBWrapper
-def reload_callouts():
+def reload_callouts(*args):
     RaceContext.rhui.emit_callouts()
 
 @SOCKET_IO.on('play_callout_text')
@@ -2238,7 +2238,7 @@ def imdtabler_update_freqs(data):
 
 @SOCKET_IO.on('clean_cache')
 @catchLogExcWithDBWrapper
-def clean_results_cache():
+def clean_results_cache(*args):
     ''' wipe all results caches '''
     Events.trigger(Evt.CACHE_CLEAR)
     RaceContext.rhdata.clear_results_all()


### PR DESCRIPTION
Schedule race start during staging instead of reacting to a start event

Improves start synchronization, preventing network delays from delaying secondary response at start
Useful for sync of remote start signals, such as LED panel

Closes #490 