### PR TITLE
Trigger pilot delete event when deleting a pilot

### DIFF
--- a/src/server/RHData.py
+++ b/src/server/RHData.py
@@ -965,6 +965,10 @@ class RHData():
                     heatNode.pilot_id = RHUtils.PILOT_ID_NONE
             self.commit()
 
+            self._Events.trigger(Evt.PILOT_DELETE, {
+                'pilot_id': pilot.id,
+                })
+
             logger.info('Pilot {0} deleted'.format(pilot.id))
 
             self._racecontext.race.clear_results() # refresh leaderboard


### PR DESCRIPTION
While playing with RHAPI I found out that deleting a pilot was not triggering any event, fixed now.