### PR TITLE
Add Co-op Racing Mode

### DIFF
--- a/doc/RHAPI.md
+++ b/doc/RHAPI.md
@@ -679,7 +679,7 @@ Race formats are represented with the `RaceFormat` class, which has the followin
 - `staging_delay_tones` (int): Whether to play staging tones each second during random delay phase
 - `number_laps_win` (int): Number of laps used to declare race winner, if > 0
 - `win_condition` (int): Condition used to determine race winner and race ranking
-- `team_racing_mode` (boolean): Whether local simultaneous team racing mode will be used
+- `team_racing_mode` (int): Racing mode, 0 for individual, 1 for team, 2 for co-op
 - `start_behavior` (int): Handling of first crossing
 - `points_method` (String): JSON-serialized arguments for points algorithm
 
@@ -745,7 +745,7 @@ Add a new race format to the database. Returns the new `RaceFormat`.
 - `start_behavior` _(optional)_ (int): First crossing behavior for new race format
 - `win_condition` _(optional)_ (int): Win condition for new race format
 - `number_laps_win` _(optional)_ (int): Lap count setting for new race format
-- `team_racing_mode` _(optional)_ (boolean): Team racing setting for new race format
+- `team_racing_mode` _(optional)_ (int): Racing mode, 0 for individual, 1 for team, 2 for co-op
 - `points_method` _(optional)_ (string): JSON-serialized arguments for new race format
 
 #### db.raceformat_duplicate(source_format_or_id)
@@ -766,7 +766,7 @@ Alter race format data. Returns tuple of this `RaceFormat` and affected races as
 - `start_behavior` _(optional)_ (int): First crossing behavior for new race format
 - `win_condition` _(optional)_ (int): Win condition for new race format
 - `number_laps_win` _(optional)_ (int): Lap count setting for new race format
-- `team_racing_mode` _(optional)_ (boolean): Team racing setting for new race format
+- `team_racing_mode` _(optional)_ (int): Racing mode, 0 for individual, 1 for team, 2 for co-op
 - `points_method` _(optional)_ (string): JSON-serialized arguments for new race format
 - `points_settings`  _(optional)_ (dict): arguments to pass to class ranking
 - `attributes` _(optional)_ (dict): Attributes to alter, attribute values assigned to respective keys

--- a/doc/User Guide.md
+++ b/doc/User Guide.md
@@ -179,7 +179,9 @@ _Win Condition_ determines how the timer calls out the winner of the race, the i
 * __Fastest 3 Consecutive Laps__: Considers all laps a pilot has completed and uses the three consecutive laps with the fastest combined time.
 * __None__: Does not declare a winner under any circumstance. Heats generated from a class with this condition will be assigned randomly.
 
-_Team Racing Mode_ activates alternate scoring for additional race formats. Win conditions in team racing mode differ somewhat:
+__Team/Co-op Racing Mode__ provides access to racing modes in which pilots may compete together in groups. 
+
+__Team Racing__ allows groups of pilots to complete as teams. The team for each pilot may be set in the 'Pilots' section. Win conditions in team racing mode differ somewhat:
 * __Most Laps in Fastest Time__: Teams are judged on combined lap count of all members and how long it took to complete those laps.
 * __Most Laps Only__: Teams are judged on total combined lap count of all members.
 * __Most Laps Only with Overtime__: Teams are judged on total combined lap count of all members. If tied when time expires, the first team (of those tied) to add a lap becomes the winner.
@@ -189,6 +191,13 @@ _Team Racing Mode_ activates alternate scoring for additional race formats. Win 
 
 With _Fastest Lap_ and _Fastest 3 Consecutive Laps_, teams with differing numbers of pilots can compete together fairly.
 
+__Co-op Racing__ allows all pilots in a race to work as a cooperative group to improve their combined performance. Pilots of varying abilities can race together, with everyone contributing and working on improving their skills. There are two versions of co-op racing, described below. In both versions, all pilots in the current heat race together as a group. In the first race, a benchmark performance is set, and in each race after that the group attempts to improve and achieve a new best performance. 
+
+* _Co-op Fastest Time to X Laps_: The group attempts to complete the given number of laps (X) in the fastest time. When this racing format is enabled (on the 'Run' page), the current "Co-op Best Time" value will be shown with the heat settings for the group (in the "Classes and Heats" section on the 'Format' page), and the value may be altered or cleared there.  
+
+* _Co-op Most Laps in X:XX_: The group attempts to complete the most number of laps in the given race time (X:XX). When this racing format is enabled (on the 'Run' page), the current "Co-op Best # of Laps" value will be shown with the heat settings for the group (in the "Classes and Heats" section on the 'Format' page), and the value may be altered or cleared there.
+
+The "%COOP_RACE_INFO%" and "%COOP_RACE_LAP_TOTALS%" variables can be used in callouts with co-op races, see the [Event Actions](#event-actions) section for descriptions. 
 
 #### Data Management
 
@@ -218,7 +227,7 @@ All audio controls are local to the browser and device where you set them, inclu
 
 Voice select chooses the text-to-speech engine. Available selections are provided by the web browser and operating system.
 
-Announcements allow the user to choose to hear each pilot's callsign, lap number, and/or lap time as they cross. The "Race Clock" announcement will periodically call out how much time has elapsed or is remaining, depending on the timer mode in the race format. "Team Lap Total" is used only when "Team Racing Mode" is enabled.
+Announcements allow the user to choose to hear each pilot's callsign, lap number, and/or lap time as they cross. The "Race Clock" announcement will periodically call out how much time has elapsed or is remaining, depending on the timer mode in the race format. "Team/Co-op Lap Total" applies when "Team Racing Mode" or "Co-op Racing Mode" is enabled, and configures whether or not the lap total for the pilot group is announced on each lap. The "On Team/Co-op Races (short call)" option will result in a short version of the callout (simply "Lap X").
 
 Voice volume, rate, and pitch control all text-to-speech announcements. "Tone Volume" controls race start and end signals.
 
@@ -272,8 +281,11 @@ The variables listed below may be used for the  effects.
 | %FREQS%                   | List of pilot callsigns and frequency assignments                       |
 | %LEADER%                  | Callsign of pilot currently leading race                                |
 | %LEADER_CALL%             | Callsign of pilot currently leading race, in the form "NAME is leading" |
-| %SPLIT_TIME%              | Split time for pilot (see [Secondary / Split Timers](../doc/Cluster.md) doc)  |
-| %SPLIT_SPEED%             | Split speed for pilot (see [Secondary / Split Timers](../doc/Cluster.md) doc) |
+| %SPLIT_TIME%              | Split time for pilot (see [Secondary / Split Timers](../doc/Cluster.md) doc)          |
+| %SPLIT_SPEED%             | Split speed for pilot (see [Secondary / Split Timers](../doc/Cluster.md) doc)         |
+| %RACE_RESULT%             | Race result status message (race winner or co-op result)                |
+| %COOP_RACE_INFO%          | Co-op race mode information (target time or laps)                       |
+| %COOP_RACE_LAP_TOTALS%    | Pilot lap counts for race in co-op mode                                 |
 | %CURRENT_TIME_AP%         | Current time (12-hour clock)                                            |
 | %CURRENT_TIME_24%         | Current time (24-hour clock)                                            |
 | %CURRENT_TIME_SECS_AP%    | Current time, with seconds (12-hour clock)                              |
@@ -319,7 +331,7 @@ Once a race has concluded, you must choose "Save Laps" or "Discard Laps" before 
 
 (The spacebar can also be used as a hotkey for the Start, Stop and Save functions.)
 
-The Race Management panel provides quick access to change the current Race Format, Profile, Minimum Lap Time, or Team Racing Mode. _Audio Control_ and _LED Control_ are the same as the Settings page. The History Export dumps a CSV file to be downloaded of the recorded RSSI values in the most recently completed race. "Time Until Race Start" will schedule a race to be run at a future time. Operators may use this to set a hard limit on the amount of time allowed for pilots to prepare, or to start the timer and then participate in the race themselves.
+The Race Management panel provides quick access to change the current Race Format, Profile, Minimum Lap Time, or Team/Co-op Racing Mode. _Audio Control_ and _LED Control_ are the same as the Settings page. The History Export dumps a CSV file to be downloaded of the recorded RSSI values in the most recently completed race. "Time Until Race Start" will schedule a race to be run at a future time. Operators may use this to set a hard limit on the amount of time allowed for pilots to prepare, or to start the timer and then participate in the race themselves.
 
 The Callout panel may be used to configure voice callouts, which can be triggered by clicking on the "play" button or hitting the associated hot-key sequence.  (For instance, hitting Ctl+Alt+1 will trigger the first voice callout.)  Many of the variables listed under "Event Actions" may be used on these callouts.
 

--- a/src/server/Database.py
+++ b/src/server/Database.py
@@ -99,6 +99,8 @@ class Heat(Base):
     auto_frequency = DB.Column(DB.Boolean, nullable=False)
     group_id = DB.Column(DB.Integer, nullable=False)
     active = DB.Column(DB.Boolean, nullable=False, default=True)
+    coop_best_time = DB.Column(DB.Float, nullable=True, default=0.0)  # best time achieved in co-op racing mode (seconds)
+    coop_num_laps = DB.Column(DB.Integer, nullable=True, default=0)   # best # of laps in co-op racing mode
 
     # DEPRECATED: compatibility for 'note' property / renamed to 'name'
     @property
@@ -392,7 +394,7 @@ class RaceFormat(Base):
     staging_delay_tones = DB.Column('staging_tones', DB.Integer, nullable=False)
     number_laps_win = DB.Column(DB.Integer, nullable=False)
     win_condition = DB.Column(DB.Integer, nullable=False)
-    team_racing_mode = DB.Column(DB.Boolean, nullable=False)
+    team_racing_mode = DB.Column(DB.Integer, nullable=False)
     start_behavior = DB.Column(DB.Integer, nullable=False)
     points_method = DB.Column(DB.String, nullable=True)
 

--- a/src/server/RHAPI.py
+++ b/src/server/RHAPI.py
@@ -1060,6 +1060,14 @@ class RaceAPI():
         return self._racecontext.race.race_status
 
     @property
+    def status_message(self):
+        return self._racecontext.race.status_message
+
+    @property
+    def phonetic_status_msg(self):
+        return self._racecontext.race.phonetic_status_msg
+
+    @property
     def stage_time_internal(self):
         return self._racecontext.race.stage_time_monotonic
 
@@ -1109,6 +1117,11 @@ class RaceAPI():
     @callWithDatabaseWrapper
     def team_results(self):
         return self._racecontext.race.get_team_results()
+
+    @property
+    @callWithDatabaseWrapper
+    def coop_results(self):
+        return self._racecontext.race.get_coop_results()
 
     @property
     def win_status(self):

--- a/src/server/RHRace.py
+++ b/src/server/RHRace.py
@@ -83,6 +83,7 @@ class RHRace():
         self.results = None # current race results
         self.cacheStatus = None # whether cache is valid
         self.status_message = '' # Race status message (winner, team info)
+        self.phonetic_status_msg = '' # Phonetic version of 'status_message'
 
         self.team_results = None # current race results
         self.team_cacheStatus = None # whether cache is valid
@@ -188,7 +189,20 @@ class RHRace():
                     gevent.spawn(emit_alert_msg, self, \
                                  self._racecontext.language.__('No valid pilots in race'))
 
-                logger.info("Staging new race, format: {}".format(getattr(race_format, "name", "????")))
+                if race_format and hasattr(race_format, "name"):
+                    f_desc_str = race_format.name
+                    if race_format.team_racing_mode == RacingMode.COOP_ENABLED:
+                        if race_format.win_condition == WinCondition.FIRST_TO_LAP_X:
+                            if heat_data.coop_best_time and heat_data.coop_best_time > 0.001:
+                                f_desc_str += ", target time is " + \
+                                        RHUtils.format_time_to_str(int(heat_data.coop_best_time*1000 + 0.5), \
+                                                self._racecontext.serverconfig.get_item('UI', 'timeFormat'))
+                        else:
+                            if heat_data.coop_num_laps and heat_data.coop_num_laps > 0:
+                                f_desc_str += ", target laps is " + str(heat_data.coop_num_laps)
+                else:
+                    f_desc_str = "????"
+                logger.info("Staging new race, format: {}".format(f_desc_str))
                 max_round = self._racecontext.rhdata.get_max_round(self.current_heat)
                 if max_round is None:
                     max_round = 0
@@ -245,6 +259,7 @@ class RHRace():
                 self.race_leader_pilot_id = RHUtils.PILOT_ID_NONE
                 self.race_initial_pass_flag = False
                 self.status_message = ''
+                self.phonetic_status_msg = ''
                 self.any_races_started = True
 
                 self.set_race_format_time_fields(race_format, heat_data)
@@ -814,27 +829,30 @@ class RHRace():
                                     lap_ok_flag = False
 
                             if lap_ok_flag:
-                                node_finished_flag = self.get_node_finished_flag(node.index)
-                                if not node_finished_flag:
-                                    # set next node race status as 'finished' if timer mode is count-down race and race-time has expired
-                                    if race_format.unlimited_time == 0 and lap_time_stamp > race_format.race_time_sec * 1000:
-                                        pilot_done_flag = True
-                                    elif self.format.win_condition == WinCondition.FIRST_TO_LAP_X:
-                                        if race_format.start_behavior != StartBehavior.FIRST_LAP:
-                                            if lap_number >= race_format.number_laps_win:
-                                                pilot_done_flag = True
-                                        else:
-                                            if lap_number + 1 >= race_format.number_laps_win:
-                                                pilot_done_flag = True
+                                if race_format.team_racing_mode == race_format.team_racing_mode == RacingMode.INDIVIDUAL:
+                                    node_finished_flag = self.get_node_finished_flag(node.index)
+                                    if not node_finished_flag:
+                                        # set next node race status as 'finished' if timer mode is count-down race and race-time has expired
+                                        if race_format.unlimited_time == 0 and lap_time_stamp > race_format.race_time_sec * 1000:
+                                            pilot_done_flag = True
+                                        elif self.format.win_condition == WinCondition.FIRST_TO_LAP_X:
+                                            if race_format.start_behavior != StartBehavior.FIRST_LAP:
+                                                if lap_number >= race_format.number_laps_win:
+                                                    pilot_done_flag = True
+                                            else:
+                                                if lap_number + 1 >= race_format.number_laps_win:
+                                                    pilot_done_flag = True
+                                    else:
+                                        lap_late_flag = True  # "late" lap pass (after grace lap)
+                                        logger.info('Ignoring lap after pilot done: Node={}, lap={}, lapTime={}, sinceStart={}, source={}, pilot: {}' \
+                                                   .format(node.index+1, lap_number, lap_time_fmtstr, lap_ts_fmtstr, \
+                                                           self._racecontext.interface.get_lap_source_str(source), pilot_namestr))
                                 else:
-                                    lap_late_flag = True  # "late" lap pass (after grace lap)
-                                    logger.info('Ignoring lap after pilot done: Node={}, lap={}, lapTime={}, sinceStart={}, source={}, pilot: {}' \
-                                               .format(node.index+1, lap_number, lap_time_fmtstr, lap_ts_fmtstr, \
-                                                       self._racecontext.interface.get_lap_source_str(source), pilot_namestr))
-
-                                if self.win_status == WinStatus.DECLARED and race_format.unlimited_time == 1 and \
-                                                            self.format.win_condition == WinCondition.FIRST_TO_LAP_X:
-                                    if self.format.team_racing_mode == RacingMode.TEAM_ENABLED:
+                                    node_finished_flag = False
+                                    pilot_done_flag = False
+                                if self.format.team_racing_mode == RacingMode.TEAM_ENABLED:
+                                    if self.win_status == WinStatus.DECLARED and race_format.unlimited_time == 1 and \
+                                                                self.format.win_condition == WinCondition.FIRST_TO_LAP_X:
                                         lap_late_flag = True  # "late" lap pass after team race winner declared (when no time limit)
                                         if pilot_obj:
                                             t_str = ", Team " + pilot_obj.team
@@ -843,11 +861,12 @@ class RHRace():
                                         logger.info('Ignoring lap after race winner declared: Node={}, lap={}, lapTime={}, sinceStart={}, source={}, pilot: {}{}' \
                                                    .format(node.index+1, lap_number, lap_time_fmtstr, lap_ts_fmtstr, \
                                                            self._racecontext.interface.get_lap_source_str(source), pilot_namestr, t_str))
-                                    elif self.format.team_racing_mode == RacingMode.COOP_ENABLED:
-                                        lap_late_flag = True  # "late" lap pass after co-op race done (when no time limit)
+                                elif self.format.team_racing_mode == RacingMode.COOP_ENABLED:
+                                    if self.win_status == WinStatus.DECLARED:
+                                        lap_late_flag = True  # "late" lap pass after co-op race done
                                         logger.info('Ignoring lap after co-op race done: Node={}, lap={}, lapTime={}, sinceStart={}, source={}, pilot: {}' \
-                                                   .format(node.index+1, lap_number, lap_time_fmtstr, lap_ts_fmtstr, \
-                                                           self._racecontext.interface.get_lap_source_str(source), pilot_namestr))
+                                                    .format(node.index+1, lap_number, lap_time_fmtstr, lap_ts_fmtstr, \
+                                                            self._racecontext.interface.get_lap_source_str(source), pilot_namestr))
 
                                 if logger.getEffectiveLevel() <= logging.DEBUG:  # if DEBUG msgs actually being logged
                                     late_str = " (late lap)" if lap_late_flag else ""
@@ -922,9 +941,11 @@ class RHRace():
                                         # if winning team has been declared then don't announce team lap number
                                         if self.win_status == WinStatus.DECLARED:
                                             team_phonetic = ' '
+                                            team_short_phonetic = None
                                         else:
                                             team_phonetic = self.__("Team") + " " + team_name + ", " + self.__("Lap") + \
                                                             " " + str(team_laps)
+                                            team_short_phonetic = self.__("Lap") + " " + str(team_laps)
                                         self._racecontext.rhui.emit_phonetic_data(pilot_id, lap_id, lap_time, team_phonetic, \
                                                         (check_leader and \
                                                          team_name == Results.get_leading_team_name(self.team_results)), \
@@ -937,10 +958,13 @@ class RHRace():
                                         # if win has been declared then don't announce coop lap number
                                         if self.win_status == WinStatus.DECLARED:
                                             team_phonetic = ' '
+                                            team_short_phonetic = None
                                         else:
                                             team_phonetic =  self.__("Co-op") + " " +  self.__("Lap") + " " + str(coop_laps)
+                                            team_short_phonetic = self.__("Lap") + " " + str(coop_laps)
                                         self._racecontext.rhui.emit_phonetic_data(pilot_id, lap_id, lap_time, \
-                                                                                  team_phonetic, False, node_finished_flag, node.index)
+                                                            team_phonetic, False, node_finished_flag, node.index, \
+                                                            team_short_phonetic=team_short_phonetic)
                                     else:
                                         if check_leader:
                                             leader_pilot_id = Results.get_leading_pilot_id(self, self._racecontext.interface, True)
@@ -1206,6 +1230,7 @@ class RHRace():
             self.race_leader_pilot_id = RHUtils.PILOT_ID_NONE
             self.race_initial_pass_flag = False
             self.status_message = ''
+            self.phonetic_status_msg = ''
             self._racecontext.rhui.emit_current_laps() # Race page, blank laps to the web client
             self._racecontext.rhui.emit_current_leaderboard() # Race page, blank leaderboard to the web client
             self._racecontext.rhui.emit_race_status() # Race page, to set race button states
@@ -1337,12 +1362,13 @@ class RHRace():
                 self.race_winner_lap_id = 0
                 self.race_winner_pilot_id = RHUtils.PILOT_ID_NONE
                 self.status_message = ''
+                self.phonetic_status_msg = ''
                 logger.info("Race status msg:  <None>")
                 return win_status_dict
 
             if win_status_dict['status'] == WinStatus.DECLARED:
                 # announce winner
-                status_msg_str = log_msg_str = phonetic_str = None
+                status_msg_str = phonetic_status_msg = log_msg_str = phonetic_str = None
                 win_data = win_status_dict['data']
                 winner_flag = True
                 if race_format.team_racing_mode == RacingMode.TEAM_ENABLED:
@@ -1358,52 +1384,79 @@ class RHRace():
                     coop_leaderboard = self.team_results.get('by_race_time')
                     if type(coop_leaderboard) is list and len(coop_leaderboard) > 0:
                         coop_leaderboard = coop_leaderboard[0]
-                    coop_time = coop_leaderboard.get('coop_total_time') if type(coop_leaderboard) is dict else None
-                    if coop_time:
-                        total_time_ms = coop_leaderboard.get('coop_total_time_raw', 0)
-                        coop_time_secs = round(float(total_time_ms)/1000, 3)  # save time in seconds, rounded to nearest ms
-                        phonetic_time = RHUtils.format_phonetic_time_to_str(total_time_ms, \
-                                            self._racecontext.rhdata.get_option('timeFormatPhonetic'))
-                        new_best_str = ""
-                        diff_str = ""
-                        phonetic_diff_str = ""
-                        if self.unlimited_time:  # if first race to establish target time
-                            log_msg_str = "Race status msg:  Race done, co-op time is " + coop_time
-                            self.coop_best_time = coop_time_secs
-                            winner_flag = False  # don't play winner tone when announcing
-                        else:
-                            self._racecontext.rhui.emit_race_stop()
-                            time_format = self._racecontext.serverconfig.get_item('UI', 'timeFormat')
-                            prev_coop_time_ms = int(self.coop_best_time*1000 + 0.5)
-                            prev_coop_time_str = RHUtils.format_time_to_str(prev_coop_time_ms, time_format)
-                            if coop_time_secs >= self.coop_best_time:  # co-op time was not better than target time
-                                diff_ms = int(coop_time_secs*1000+0.5) - prev_coop_time_ms
-                                diff_str = RHUtils.format_split_time_to_str(diff_ms, time_format)
-                                log_msg_str = "Race status msg:  Race done, co-op time is " + coop_time + ", prev co-op time was " + \
-                                              prev_coop_time_str + " (" + diff_str + " behind)"
-                                diff_str += " " + self.__("behind") + ")"
-                                phonetic_diff_str = " " + self.__("behind")
-                                winner_flag = False  # don't play winner tone when announcing
-                            else:  # new best co-op time established
-                                diff_ms = prev_coop_time_ms - int(coop_time_secs*1000+0.5)
-                                diff_str = RHUtils.format_split_time_to_str(diff_ms, time_format)
-                                log_msg_str = "Race status msg:  Race done, new best co-op time is " + coop_time + ", prev co-op time was " + \
-                                              prev_coop_time_str + " (" + diff_str + " ahead)"
-                                new_best_str = self.__('success! New best') + ' '
-                                diff_str += " " + self.__("ahead") + ")"
-                                phonetic_diff_str = " " + self.__("ahead")
+                    if race_format.win_condition == WinCondition.FIRST_TO_LAP_X:
+                        coop_time = coop_leaderboard.get('coop_total_time') if type(coop_leaderboard) is dict else None
+                        if coop_time:
+                            total_time_ms = coop_leaderboard.get('coop_total_time_raw', 0)
+                            coop_time_secs = round(float(total_time_ms)/1000, 3)  # save time in seconds, rounded to nearest ms
+                            phonetic_time = RHUtils.format_phonetic_time_to_str(total_time_ms, \
+                                                self._racecontext.rhdata.get_option('timeFormatPhonetic'))
+                            new_best_str = ""
+                            diff_str = ""
+                            phonetic_diff_str = ""
+                            if self.unlimited_time:  # if first race to establish target time
+                                log_msg_str = "Race status msg:  Race done, co-op time is " + coop_time
                                 self.coop_best_time = coop_time_secs
-                            diff_str = ", " + self.__("previous co-op time was ") + prev_coop_time_str + ", (" + diff_str
-                            phonetic_diff_str = ", " + self.__("previous co-op time was ") + \
-                                                RHUtils.format_phonetic_time_to_str(prev_coop_time_ms, \
-                                                    self._racecontext.serverconfig.get_item('UI', 'timeFormatPhonetic')) + ", " + \
-                                                RHUtils.format_phonetic_time_to_str(diff_ms, \
-                                                    self._racecontext.serverconfig.get_item('UI', 'timeFormatPhonetic')) + \
-                                                phonetic_diff_str
-                        status_msg_str = self.__("Race done") + ", " + new_best_str + self.__("co-op time is") + \
-                                         " " + coop_time + diff_str
-                        phonetic_str = self.__("Race done") + ", " + new_best_str + self.__("co-op time is") + \
-                                       " " + phonetic_time + phonetic_diff_str
+                                winner_flag = False  # don't play winner tone when announcing
+                            else:
+                                self._racecontext.rhui.emit_race_stop()
+                                time_format = self._racecontext.serverconfig.get_item('UI', 'timeFormat')
+                                prev_coop_time_ms = int(self.coop_best_time*1000 + 0.5)
+                                prev_coop_time_str = RHUtils.format_time_to_str(prev_coop_time_ms, time_format)
+                                if coop_time_secs >= self.coop_best_time:  # co-op time was not better than target time
+                                    diff_ms = int(coop_time_secs*1000+0.5) - prev_coop_time_ms
+                                    diff_str = RHUtils.format_split_time_to_str(diff_ms, time_format)
+                                    log_msg_str = "Race status msg:  Race done, co-op time is " + coop_time + ", prev co-op time was " + \
+                                                  prev_coop_time_str + " (" + diff_str + " behind)"
+                                    diff_str += " " + self.__("behind") + ")"
+                                    phonetic_diff_str = " " + self.__("behind")
+                                    winner_flag = False  # don't play winner tone when announcing
+                                else:  # new best co-op time established
+                                    diff_ms = prev_coop_time_ms - int(coop_time_secs*1000+0.5)
+                                    diff_str = RHUtils.format_split_time_to_str(diff_ms, time_format)
+                                    log_msg_str = "Race status msg:  Race done, new best co-op time is " + coop_time + \
+                                                  ", prev co-op time was " + prev_coop_time_str + " (" + diff_str + " ahead)"
+                                    new_best_str = self.__('success! New best') + ' '
+                                    diff_str += " " + self.__("ahead") + ")"
+                                    phonetic_diff_str = " " + self.__("ahead")
+                                    self.coop_best_time = coop_time_secs
+                                diff_str = ", " + self.__("previous co-op time was ") + prev_coop_time_str + ", (" + diff_str
+                                phonetic_diff_str = ", " + self.__("previous co-op time was ") + \
+                                                    RHUtils.format_phonetic_time_to_str(prev_coop_time_ms, \
+                                                        self._racecontext.serverconfig.get_item('UI', 'timeFormatPhonetic')) + ", " + \
+                                                    RHUtils.format_phonetic_time_to_str(diff_ms, \
+                                                        self._racecontext.serverconfig.get_item('UI', 'timeFormatPhonetic')) + \
+                                                    phonetic_diff_str
+                            status_msg_str = self.__("Race done") + ", " + new_best_str + self.__("co-op time is") + \
+                                             " " + coop_time + diff_str
+                            phonetic_status_msg = new_best_str + self.__("co-op time is") + " " + \
+                                                  phonetic_time + phonetic_diff_str
+                            phonetic_str = self.__("Race done") + ", " + phonetic_status_msg
+                    else:  # co-op race most laps in fixed time
+                        coop_laps = coop_leaderboard.get('laps') if type(coop_leaderboard) is dict else None
+                        if coop_laps:
+                            new_best_str = ""
+                            prev_laps_str = ""
+                            if type(self.coop_num_laps) is not int or self.coop_num_laps <= 0:  # if first race to establish benchmark laps
+                                log_msg_str = "Race status msg:  Race done, number of laps is " + str(coop_laps)
+                                self.coop_num_laps = coop_laps
+                                winner_flag = False  # don't play winner tone when announcing
+                            else:
+                                prev_laps_str = ", " + self.__("previous co-op lap count was ") + str(self.coop_num_laps)
+                                if coop_laps <= self.coop_num_laps:  # number of laps was not more than target
+                                    log_msg_str = "Race status msg:  Race done, co-op lap count is " + \
+                                                  str(coop_laps) + ", prev co-op lap count was " + str(self.coop_num_laps)
+                                    winner_flag = False  # don't play winner tone when announcing
+                                else:  # new best co-op time established
+                                    log_msg_str = "Race status msg:  Race done, new best co-op lap count is " + \
+                                                  str(coop_laps) + ", prev co-op lap count was " + str(self.coop_num_laps)
+                                    new_best_str = self.__('success! New best') + ' '
+                                    self.coop_num_laps = coop_laps
+                            status_msg_str = self.__("Race done") + ", " + new_best_str + self.__("co-op lap count is") + \
+                                             " " + str(coop_laps) + prev_laps_str
+                            phonetic_status_msg = new_best_str + self.__("co-op lap count is") + " " + \
+                                                  str(coop_laps) + prev_laps_str
+                            phonetic_str = self.__("Race done") + ", " + phonetic_status_msg
 
                 else:
                     win_str = win_data.get('callsign', '')
@@ -1428,15 +1481,17 @@ class RHRace():
                 if status_msg_str and ((not del_lap_flag) or self.win_status != previous_win_status or \
                                             status_msg_str != self.status_message):
                     self.status_message = status_msg_str
+                    self.phonetic_status_msg = phonetic_status_msg if phonetic_status_msg else status_msg_str
                     logger.info(log_msg_str)
                     self._racecontext.rhui.emit_phonetic_text(phonetic_str, 'race_winner', winner_flag)
-                    self._racecontext.events.trigger(Evt.RACE_WIN, {
-                        'win_status': win_status_dict,
-                        'message': self.status_message,
-                        'node_index': win_data.get('node', -1),
-                        'color': self.seat_colors[win_data['node']] \
-                                                if 'node' in win_data else None,
-                        })
+                    if win_status_dict.get('race_win_event_flag', True):
+                        self._racecontext.events.trigger(Evt.RACE_WIN, {
+                            'win_status': win_status_dict,
+                            'message': self.status_message,
+                            'node_index': win_data.get('node', -1),
+                            'color': self.seat_colors[win_data['node']] \
+                                                    if 'node' in win_data else None,
+                            })
 
             elif win_status_dict['status'] == WinStatus.TIE:
                 # announce tied

--- a/src/server/RHUI.py
+++ b/src/server/RHUI.py
@@ -515,7 +515,8 @@ class RHUI():
                 'staging_tones': 0,
                 'hide_stage_timer': race_format.start_delay_min_ms != race_format.start_delay_max_ms,
                 'pi_starts_at_s': self._racecontext.race.start_time_monotonic,
-                'pi_staging_at_s': self._racecontext.race.stage_time_monotonic
+                'pi_staging_at_s': self._racecontext.race.stage_time_monotonic,
+                'show_init_time_flag': self._racecontext.race.show_init_time_flag
             }
         if class_id and race_class.round_type == RoundType.GROUPED:
             emit_payload['next_round'] = heat.group_id + 1

--- a/src/server/RHUI.py
+++ b/src/server/RHUI.py
@@ -900,7 +900,9 @@ class RHUI():
             current_heat['status'] = heat.status
             current_heat['auto_frequency'] = heat.auto_frequency
             current_heat['active'] = heat.active
-            current_heat['coop_best_time'] = heat.coop_best_time
+            current_heat['coop_best_time'] = RHUtils.format_secs_to_duration_str(heat.coop_best_time) \
+                                    if isinstance(heat.coop_best_time, (int, float)) and \
+                                                        heat.coop_best_time >= 0.001 else ''
             current_heat['coop_num_laps'] = heat.coop_num_laps
             current_heat['next_round'] = self._racecontext.rhdata.get_max_round(heat.id)
 
@@ -1207,7 +1209,8 @@ class RHUI():
         else:
             self._socket.emit('current_heat', emit_payload)
 
-    def emit_phonetic_data(self, pilot_id, lap_id, lap_time, team_phonetic, leader_flag=False, node_finished=False, node_index=None, **params):
+    def emit_phonetic_data(self, pilot_id, lap_id, lap_time, team_phonetic, leader_flag=False, \
+                           node_finished=False, node_index=None, team_short_phonetic=None, **params):
         '''Emits phonetic data.'''
         raw_time = lap_time
         phonetic_time = RHUtils.format_phonetic_time_to_str(lap_time, self._racecontext.serverconfig.get_item('UI', 'timeFormatPhonetic'))
@@ -1217,6 +1220,7 @@ class RHUI():
             'raw_time': raw_time,
             'phonetic': phonetic_time,
             'team_phonetic' : team_phonetic,
+            'team_short_phonetic': team_short_phonetic,
             'leader_flag' : leader_flag,
             'node_finished': node_finished,
         }

--- a/src/server/RHUtils.py
+++ b/src/server/RHUtils.py
@@ -76,6 +76,43 @@ def format_phonetic_time_to_str(millis, timeformat='{m} {s}.{d}'):
     else:
         return timeformat.format(m=str(minutes), s=str(seconds).zfill(2), d=str(tenths))
 
+# Formats the given seconds value to a time-duration string in the form MM:SS:mmm
+def format_secs_to_duration_str(secs_val):
+    total_ms = int(secs_val * 1000 + 0.5)  # round to nearest ms
+    total_secs = total_ms // 1000
+    total_int_secs = int(total_secs)
+    mins_val = int(total_int_secs // 60)
+    mins_str = str(mins_val)
+    secs_str = str(int(total_int_secs % 60))
+    ms_str = str(int(total_ms % 1000)).zfill(3)
+    if ms_str[-1] == '0':  # remove trailing zeros (if not in tenths position)
+        ms_str = ms_str[0:-1]
+        if ms_str[-1] == '0':
+            ms_str = ms_str[0:-1]
+    return "{}:{}.{}".format(mins_str, secs_str.zfill(2), ms_str)
+
+# Parses the given time-duration string (in the form MM:SS:mmm) to seconds; returns None if parsing error
+def parse_duration_str_to_secs(dur_str):
+    try:
+        dur_str = str(dur_str)
+        if dur_str:
+            p = dur_str.rfind(':')
+            secs_str = dur_str[p+1:]
+            if p <= 0:
+                secs_val = float(secs_str)
+            else:
+                rem_str = dur_str[0:p]
+                p = rem_str.rfind(':')
+                if p <= 0:
+                    secs_val = float(secs_str) + (int(rem_str[p+1:]) * 60)
+                else:
+                    secs_val = float(secs_str) + (int(rem_str[p+1:]) * 60) + (int(rem_str[0:p]) * 3600)
+            total_ms = int(secs_val * 1000 + 0.5)  # round to nearest ms
+            return round(total_ms / 1000, 3)
+    except:
+        pass
+    return None
+
 
 # Previous (now deprecated) versions of time-formatting functions:
 

--- a/src/server/Results.py
+++ b/src/server/Results.py
@@ -1107,11 +1107,12 @@ def calc_coop_leaderboard(racecontext):
             if coopGroup['members']:
                 contribution_amt = float(coopGroup['contributing']) / coopGroup['members']
             if coopGroup['combined_average_lap_raw']:
-                average_lap_raw = float(coopGroup['combined_average_lap_raw']) / coopGroup['contributing']
+                average_lap_raw = round(float(coopGroup['combined_average_lap_raw']) / coopGroup['contributing'], 3)
             if coopGroup['combined_fastest_lap_raw']:
-                average_fastest_lap_raw = float(coopGroup['combined_fastest_lap_raw']) / coopGroup['contributing']
+                average_fastest_lap_raw = round(float(coopGroup['combined_fastest_lap_raw']) / coopGroup['contributing'], 3)
             if coopGroup['combined_consecutives_raw']:
-                average_consecutives_raw = float(coopGroup['combined_consecutives_raw']) / coopGroup['contributing']
+                average_consecutives_raw = round(float(coopGroup['combined_consecutives_raw']) / coopGroup['contributing'], 3)
+        coopGroup['coop_total_time_raw'] = round(coopGroup['coop_total_time_raw'], 3)
 
         leaderboard = [{
             'name': "Group",

--- a/src/server/filtermanager.py
+++ b/src/server/filtermanager.py
@@ -80,6 +80,7 @@ class Flt:
     LAPS_SAVE = 'lapsSave'
     RACE_RESULTS = 'raceResults'
     RACE_TEAM_RESULTS = 'raceTeamResults'
+    RACE_COOP_RESULTS = 'raceCoopResults'
     RACE_SET_HEAT = 'raceSetHeat'
 
     EMIT_UI = 'emitUI'

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -1919,12 +1919,12 @@ def on_alter_race_format(data):
         RaceContext.race.format = race_format
         # keep time fields in the current race in sync with the current race format
         RaceContext.race.set_race_format_time_fields(RaceContext.race.format, RaceContext.race.current_heat)
+        RaceContext.rhui.emit_format_data()
         RaceContext.rhui.emit_heat_data()
         RaceContext.rhui.emit_race_status()
         RaceContext.rhui.emit_current_laps()
 
         if 'format_name' in data:
-            RaceContext.rhui.emit_format_data()
             RaceContext.rhui.emit_class_data()
 
         if len(race_list):

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -1,6 +1,6 @@
 '''RotorHazard server script'''
 RELEASE_VERSION = "4.3.0-dev.2" # Public release version code
-SERVER_API = 45 # Server API version
+SERVER_API = 46 # Server API version
 NODE_API_SUPPORTED = 18 # Minimum supported node version
 NODE_API_BEST = 35 # Most recent node API
 JSON_API = 3 # JSON API version
@@ -1174,13 +1174,16 @@ def on_activate_heat(data):
 def on_alter_heat(data):
     '''Update heat.'''
     heat, altered_race_list = RaceContext.rhdata.alter_heat(data)
-    if RaceContext.race.current_heat == heat.id:  # if current heat was altered then update heat data
-        RaceContext.race.set_heat(heat.id, silent=True)
-    RaceContext.rhui.emit_heat_data(noself=True)
-    if ('name' in data or 'pilot' in data or 'class' in data) and len(altered_race_list):
-        RaceContext.rhui.emit_result_data() # live update rounds page
-        message = __('Alterations made to heat: {0}').format(heat.display_name)
-        RaceContext.rhui.emit_priority_message(message, False)
+    if not data.get('coop_data_flag', False):  # if only co-op data modified then skip rest of heat-data handling
+        if RaceContext.race.current_heat == heat.id:  # if current heat was altered then update heat data
+            RaceContext.race.set_heat(heat.id, silent=True)
+        RaceContext.rhui.emit_heat_data(noself=True)
+        if ('name' in data or 'pilot' in data or 'class' in data) and len(altered_race_list):
+            RaceContext.rhui.emit_result_data() # live update rounds page
+            message = __('Alterations made to heat: {0}').format(heat.display_name)
+            RaceContext.rhui.emit_priority_message(message, False)
+    else:
+        RaceContext.rhui.emit_heat_data()
 
 @SOCKET_IO.on('delete_heat')
 @catchLogExcWithDBWrapper
@@ -3547,7 +3550,7 @@ def rh_program_initialize(reg_endpoints_flag=True):
                                                                             staging_delay_tones=0,
                                                                             number_laps_win=0,
                                                                             win_condition=WinCondition.NONE,
-                                                                            team_racing_mode=False,
+                                                                            team_racing_mode=0,
                                                                             start_behavior=0,
                                                                             points_method=None)
 

--- a/src/server/static/rotorhazard.css
+++ b/src/server/static/rotorhazard.css
@@ -1482,6 +1482,11 @@ main.page-home {
 	display: block;
 }
 
+.heats label.coop_best_field {
+	font-size: 1.2em;
+	margin: 0 0.5rem 0 0;
+}
+
 .pilots {
 	padding: 0;
 	list-style: none;

--- a/src/server/static/rotorhazard.js
+++ b/src/server/static/rotorhazard.js
@@ -761,6 +761,7 @@ function timerModel() {
 	this.time_staging_tenths = null; // staging-relative time
 	this.count_up = false; // use fixed-length timer
 	this.duration_tenths = 0; // fixed-length duration, in tenths
+	this.initial_disp_tenths = null; // time value to show before start
 	this.has_looped = false; // prevent expire callbacks until timer runs 1 loop
 	this.allow_expire = false; // prevent multiple expire callbacks
 
@@ -944,22 +945,32 @@ function timerModel() {
 		if (self.callbacks.stop instanceof Function) {
 			self.callbacks.stop(this);
 		}
+		this.time = 0;  // clear to make sure sure 'Ready' message doesn't get stuck showing on timer
 	}
 
 	this.renderHTML = function() {
+		var active_time_tenths = 0;
 		if (this.local_zero_time == null || typeof this.time_tenths != 'number' || !this.running) {
-			return '--:--';
+			if (this.initial_disp_tenths) {
+				active_time_tenths = this.initial_disp_tenths;
+			} else {
+				return '--:--';
+			}
+		} else {
+			this.initial_disp_tenths = null;
 		}
 
 		if (this.hidden_staging && this.time < 0) {
 			return __l('Ready');
 		}
 
-		var active_time_tenths = this.time_tenths;
+		if (!active_time_tenths) {
+			active_time_tenths = this.time_tenths;
 
-		// hold timer during prestage
-		if (this.phased_staging && this.time_staging_tenths < 0) {
-			active_time_tenths = Math.trunc((this.local_staging_start_time - this.local_zero_time) / 100);
+			// hold timer during prestage
+			if (this.phased_staging && this.time_staging_tenths < 0) {
+				active_time_tenths = Math.trunc((this.local_staging_start_time - this.local_zero_time) / 100);
+			}
 		}
 
 		var active_time_s = Math.trunc(active_time_tenths / 10);
@@ -985,6 +996,10 @@ function timerModel() {
 		} else {
 			return sign + minute + ':' + second + '.' + decimal;
 		}
+	}
+
+	this.renderHTMLandUpdate = function() {
+		$('.time-display').html(this.renderHTML());
 	}
 }
 

--- a/src/server/static/rotorhazard.js
+++ b/src/server/static/rotorhazard.js
@@ -3,9 +3,9 @@ var sound_beep = $('#sound_beep')[0];
 var sound_stage = $('#sound_stage')[0];
 
 // bitmask values for 'phonetic_split_call' function
-const SPLMSK_PILOT_NAME = 0x01
-const SPLMSK_SPLIT_ID = 0x02
-const SPLMSK_SPLIT_TIME = 0x04
+const SPLMSK_PILOT_NAME = 0x01;
+const SPLMSK_SPLIT_ID = 0x02;
+const SPLMSK_SPLIT_TIME = 0x04;
 
 // minimum value in logarithmic volume range and limit value for "zero" volume
 const MIN_LOG_VOLUME = 0.01;
@@ -16,9 +16,13 @@ const LEADER_FLAG_CHAR = 'L';
 const WINNER_FLAG_CHAR = 'W';
 
 // Display sync warning above (ms)
-const SYNC_WARNING_THRESHOLD_1 = 2
-const SYNC_WARNING_THRESHOLD_3 = 10
-const SYNC_WARNING_THRESHOLD_10 = 60
+const SYNC_WARNING_THRESHOLD_1 = 2;
+const SYNC_WARNING_THRESHOLD_3 = 10;
+const SYNC_WARNING_THRESHOLD_10 = 60;
+
+const RACING_MODE_INDV = 0;   // INDIVIDUAL
+const RACING_MODE_TEAM = 1;   // TEAM_ENABLED
+const RACING_MODE_COOP = 2;   // COOP_ENABLED
 
 var speakObjsQueue = [];
 var checkSpeakQueueFlag = true;
@@ -1710,7 +1714,7 @@ function build_leaderboard(leaderboard, display_type, meta, display_starts=false
 		var display_type = 'by_race_time';
 	if (typeof(meta) === 'undefined') {
 		var meta = new Object;
-		meta.team_racing_mode = false;
+		meta.team_racing_mode = RACING_MODE_INDV;
 		meta.start_behavior = 0;
 		meta.consecutives_count = 0;
 		meta.primary_leaderboard = null;
@@ -1734,7 +1738,7 @@ function build_leaderboard(leaderboard, display_type, meta, display_starts=false
 	var header_row = $('<tr>');
 	header_row.append('<th class="pos"><span class="screen-reader-text">' + __('Rank') + '</span></th>');
 	header_row.append('<th class="pilot">' + __('Pilot') + '</th>');
-	if (meta.team_racing_mode) {
+	if (meta.team_racing_mode == RACING_MODE_TEAM) {
 		header_row.append('<th class="team">' + __('Team') + '</th>');
 	}
 	if (display_starts == true) {
@@ -1779,7 +1783,7 @@ function build_leaderboard(leaderboard, display_type, meta, display_starts=false
 
 		row.append('<td class="pos">'+ (leaderboard[i].position != null ? leaderboard[i].position : '-') +'</td>');
 		row.append('<td class="pilot">'+ leaderboard[i].callsign +'</td>');
-		if (meta.team_racing_mode) {
+		if (meta.team_racing_mode == RACING_MODE_TEAM) {
 			row.append('<td class="team">'+ leaderboard[i].team_name +'</td>');
 		}
 		if (display_starts == true) {
@@ -1899,16 +1903,21 @@ function build_team_leaderboard(leaderboard, display_type, meta) {
 		display_type = 'by_race_time';
 	if (typeof(meta) === 'undefined') {
 		meta = new Object;
-		meta.team_racing_mode = true;
+		meta.team_racing_mode = RACING_MODE_TEAM;
 		meta.consecutives_count = 0;
 	}
+	var coop_flag = (leaderboard.length == 1 && leaderboard[0].name == "Group")
 
 	var twrap = $('<div class="responsive-wrap">');
 	var table = $('<table class="leaderboard">');
 	var header = $('<thead>');
 	var header_row = $('<tr>');
-	header_row.append('<th class="pos"><span class="screen-reader-text">' + __('Rank') + '</span></th>');
-	header_row.append('<th class="team">' + __('Team') + '</th>');
+	if (coop_flag) {
+		header_row.append('<th class="team">' + __('Co-op') + '</th>');
+	} else {
+		header_row.append('<th class="pos"><span class="screen-reader-text">' + __('Rank') + '</span></th>');
+		header_row.append('<th class="team">' + __('Team') + '</th>');
+	}
 	header_row.append('<th class="contribution">' + __('Contributors') + '</th>');
 	if (display_type == 'by_race_time') {
 		header_row.append('<th class="laps">' + __('Laps') + '</th>');
@@ -1927,7 +1936,9 @@ function build_team_leaderboard(leaderboard, display_type, meta) {
 
 	for (var i in leaderboard) {
 		var row = $('<tr>');
-		row.append('<td class="pos">'+ (leaderboard[i].position != null ? leaderboard[i].position : '-') +'</td>');
+		if (!coop_flag) {
+			row.append('<td class="pos">'+ (leaderboard[i].position != null ? leaderboard[i].position : '-') +'</td>');
+		}
 		row.append('<td class="team">'+ leaderboard[i].name +'</td>');
 		row.append('<td class="contribution">'+ leaderboard[i].contributing + '/' + leaderboard[i].members + '</td>');
 		if (display_type == 'by_race_time') {
@@ -1975,7 +1986,7 @@ function build_ranking(ranking) {
 	var header_row = $('<tr>');
 	header_row.append('<th class="pos"><span class="screen-reader-text">' + __('Rank') + '</span></th>');
 	header_row.append('<th class="pilot">' + __('Pilot') + '</th>');
-	if ('team_racing_mode' in meta && meta.team_racing_mode) {
+	if ('team_racing_mode' in meta && meta.team_racing_mode == RACING_MODE_TEAM) {
 		header_row.append('<th class="team">' + __('Team') + '</th>');
 	}
 	for (var f in meta.rank_fields) {
@@ -1992,7 +2003,7 @@ function build_ranking(ranking) {
 
 		row.append('<td class="pos">'+ (leaderboard[i].position != null ? leaderboard[i].position : '-') +'</td>');
 		row.append('<td class="pilot">'+ leaderboard[i].callsign +'</td>');
-		if ('team_racing_mode' in meta && meta.team_racing_mode) {
+		if ('team_racing_mode' in meta && meta.team_racing_mode == RACING_MODE_TEAM) {
 			row.append('<td class="team">'+ leaderboard[i].team_name +'</td>');
 		}
 		for (var f in meta.rank_fields) {

--- a/src/server/templates/current.html
+++ b/src/server/templates/current.html
@@ -16,6 +16,7 @@
 	var request_time;
 	var request_pi_time;
 	var resume_check = true;
+	var leaderboard_current_flag = true;
 
 	function race_kickoff(msg) {
 		rotorhazard.timer.stopAll();
@@ -181,6 +182,18 @@
 			}
 		}
 
+		function any_laps_recorded() {
+			if (current_laps && 'node_index' in current_laps) {
+				for (var node_i in current_laps.node_index) {
+					if ('laps' in current_laps.node_index[node_i] &&
+							current_laps.node_index[node_i].laps.length > 0) {
+						return true;
+					}
+				}
+			}
+			return false;
+		}
+
 		socket.on('race_scheduled', function (msg) {
 			if (msg.scheduled) {
 				var deferred_start = msg.scheduled_at * 1000;  // convert seconds (pi) to millis (JS)
@@ -192,6 +205,7 @@
 
 		socket.on('race_status', function (msg) {
 			rotorhazard.event.race_status = msg;
+			rotorhazard.timer.race.duration_tenths = msg.race_time_sec * 10;
 
 			switch (msg.race_status) {
 				case 1: // Race running
@@ -200,6 +214,10 @@
 					$('body').removeClass('race-stopped');
 					$('body').removeClass('race-new');
 					$('.timing-clock').removeClass('staging');
+					if (msg.show_init_time_flag) {
+						rotorhazard.timer.deferred.initial_disp_tenths = null;
+						rotorhazard.timer.race.initial_disp_tenths = null;
+					}
 					if (resume_check) {
 						race_kickoff(msg);
 					}
@@ -224,6 +242,16 @@
 					$('body').removeClass('race-stopped');
 					$('body').addClass('race-new');
 					$('.timing-clock').removeClass('staging');
+					if (msg.show_init_time_flag) {
+						if ((!leaderboard_current_flag) || (!any_laps_recorded())) {
+							rotorhazard.timer.deferred.initial_disp_tenths = rotorhazard.timer.race.duration_tenths;
+							rotorhazard.timer.race.initial_disp_tenths = rotorhazard.timer.race.duration_tenths;
+						}
+					} else {
+						rotorhazard.timer.deferred.initial_disp_tenths = null;
+						rotorhazard.timer.race.initial_disp_tenths = null;
+					}
+					rotorhazard.timer.deferred.renderHTMLandUpdate();
 					if (resume_check) {
 						socket.emit('get_race_scheduled');
 					}
@@ -419,11 +447,12 @@
 				} else {
 					$('.current-heat').html(msg.current.displayname);
 				}
-
 				$('#next-race').slideDown();
+				leaderboard_current_flag = false;
 			} else {
 				var race = msg.current;
 				$('#next-race').slideUp();
+				leaderboard_current_flag = true;
 			}
 
 			if (race.round) {

--- a/src/server/templates/current.html
+++ b/src/server/templates/current.html
@@ -514,7 +514,11 @@
 					if (msg.team_phonetic && rotorhazard.voice_team_lap_count != 0) {
 						if (ttstext.length > 0)
 							ttstext += ", ";
-						ttstext += msg.team_phonetic;
+						if (rotorhazard.voice_team_lap_count == 2 && msg.team_short_phonetic) {
+							ttstext += msg.team_short_phonetic;
+						} else {
+							ttstext += msg.team_phonetic;
+						}
 					}
 	
 					if (ttstext.length > 0) {
@@ -928,6 +932,7 @@
 					<select id="voice_team_lap_count">
 						<option value="0">{{ __('Never') }}</option>
 						<option value="1">{{ __('On Team/Co-op Races') }}</option>
+						<option value="2">{{ __('On Team/Co-op Races (short call)') }}</option>
 					</select>
 				</li>
 				<li>

--- a/src/server/templates/current.html
+++ b/src/server/templates/current.html
@@ -462,30 +462,30 @@
 					var ttstext = '';
 	
 					if (rotorhazard.voice_callsign == 1 ||
-								(rotorhazard.voice_callsign == 2 && (!msg.team_name))) {
+								(rotorhazard.voice_callsign == 2 && (!msg.team_phonetic))) {
 						ttstext = msg.callsign;
 						if (msg.pilot)
 							ttstext = msg.pilot;
 					}
 	
 					if (rotorhazard.voice_lap_count == 1 ||
-								(rotorhazard.voice_lap_count == 2 && msg.lap && (!msg.team_name))) {
+								(rotorhazard.voice_lap_count == 2 && msg.lap && (!msg.team_phonetic))) {
 						if (ttstext.length > 0)
 							ttstext += ", ";
 						ttstext += __l('Lap') + " " + msg.lap;
 					}
 	
 					if (rotorhazard.voice_lap_time == 1 ||
-								(rotorhazard.voice_lap_time == 2 && (!msg.team_name))) {
+								(rotorhazard.voice_lap_time == 2 && (!msg.team_phonetic))) {
 						if (ttstext.length > 0)
 							ttstext += ", ";
 						ttstext += msg.phonetic;
 					}
 	
-					if (msg.team_name && msg.team_laps && rotorhazard.voice_team_lap_count != 0) {
+					if (msg.team_phonetic && rotorhazard.voice_team_lap_count != 0) {
 						if (ttstext.length > 0)
 							ttstext += ", ";
-						ttstext += __l('Team') + " " + msg.team_name + ", " + __l('Lap') + " " + msg.team_laps;
+						ttstext += msg.team_phonetic;
 					}
 	
 					if (ttstext.length > 0) {
@@ -493,7 +493,7 @@
 							if (rotorhazard.beep_race_leader_lap) {
 								speak(LEADER_FLAG_CHAR);
 							}
-							if (rotorhazard.voice_race_leader && (!msg.team_name)) {
+							if (rotorhazard.voice_race_leader && (!msg.team_phonetic)) {
 								setTimeout(callout_current_leader, (rotorhazard.voice_race_leader * 1000), (msg.pilot ? msg.pilot : msg.callsign));
 							}
 						}
@@ -858,7 +858,7 @@
 					</div>
 					<select id="voice_callsign">
 						<option value="0">{{ __('Never') }}</option>
-						<option value="2">{{ __('Only on Non-team Races') }}</option>
+						<option value="2">{{ __('Only on Non-Team/Non-Co-op Races') }}</option>
 						<option value="1">{{ __('Always') }}</option>
 					</select>
 				</li>
@@ -868,7 +868,7 @@
 					</div>
 					<select id="voice_lap_count">
 						<option value="0">{{ __('Never') }}</option>
-						<option value="2">{{ __('Only on Non-team Races') }}</option>
+						<option value="2">{{ __('Only on Non-Team/Non-Co-op Races') }}</option>
 						<option value="1">{{ __('Always') }}</option>
 					</select>
 				</li>
@@ -878,7 +878,7 @@
 					</div>
 					<select id="voice_lap_time">
 						<option value="0">{{ __('Never') }}</option>
-						<option value="2">{{ __('Only on Non-team Races') }}</option>
+						<option value="2">{{ __('Only on Non-Team/Non-Co-op Races') }}</option>
 						<option value="1">{{ __('Always') }}</option>
 					</select>
 				</li>
@@ -894,11 +894,11 @@
 				</li>
 				<li>
 					<div class="label-block">
-						<label for="voice_team_lap_count">{{ __('Team Lap Total') }}</label>
+						<label for="voice_team_lap_count">{{ __('Team/Co-op Lap Total') }}</label>
 					</div>
 					<select id="voice_team_lap_count">
 						<option value="0">{{ __('Never') }}</option>
-						<option value="1">{{ __('On Team Races') }}</option>
+						<option value="1">{{ __('On Team/Co-op Races') }}</option>
 					</select>
 				</li>
 				<li>

--- a/src/server/templates/event.html
+++ b/src/server/templates/event.html
@@ -342,7 +342,7 @@
 								format_details['Laps to Win'] = raceformat.number_laps_win;
 							}
 
-							if (raceformat.team_racing_mode) {
+							if (raceformat.team_racing_mode == RACING_MODE_TEAM) {
 								format_details['Team Racing'] = 'Yes';
 							}
 

--- a/src/server/templates/format.html
+++ b/src/server/templates/format.html
@@ -924,6 +924,38 @@
 			afc.append(label);
 			el.append(afc);
 
+			// if Co-op racing mode then show best time/laps field associated with heat
+			if (typeof rotorhazard.event.race_formats != "undefined") {
+				var format_id = parseInt($('#set_race_format').val());
+				var rf = rotorhazard.event.race_formats.find(obj => {return obj.id == format_id});
+				if (rf && rf.team_racing_mode == RACING_MODE_COOP) {
+					if (rf.win_condition == 2) {  // if First to X Laps
+						var coopTimeField = $('<div>');
+						coopTimeField.append('<label class="coop_best_field" for="heat-coop-best-time-' + heat.id + '">' + __('Co-op Best Time') + '</label>');
+						var input = $('<input type="text" id="heat-coop-best-time-' + heat.id + '" class="set_heat_coop_best_time" data-heat="' + heat.id + '" >');
+						input.val(heat.coop_best_time ? String(heat.coop_best_time) : '');
+						var clFieldOl = $('<ol>');
+						var clFieldLi = $('<li>');
+						clFieldLi.append(coopTimeField);
+						clFieldLi.append(input);
+						clFieldOl.append(clFieldLi);
+						el.append(clFieldOl);
+							// if Most Laps in Fastest Time | Most Laps Only | Most Laps Only with Overtime
+					} else if (rf.win_condition == 1 || rf.win_condition == 5 || rf.win_condition == 6) {
+						var coopLapsField = $('<div>');
+						coopLapsField.append('<label class="coop_best_field" for="heat-coop-num-laps-' + heat.id + '">' + __('Co-op Best # of Laps') + '</label>');
+						var input = $('<input type="number" id="heat-coop-num-laps-' + heat.id + '" class="set_heat_coop_num_laps" data-heat="' + heat.id + '" step="1" min="0">');
+						input.val(heat.coop_num_laps ? String(heat.coop_num_laps) : '');
+						var clFieldOl = $('<ol>');
+						var clFieldLi = $('<li>');
+						clFieldLi.append(coopLapsField);
+						clFieldLi.append(input);
+						clFieldOl.append(clFieldLi);
+						el.append(clFieldOl);
+					}
+				}
+			}
+
 			el.append('<button class="btn-danger plan-reset" data-id="' + heat.id + '">' + __('Revert to Plan') + '</button>');
 			el.append('<button class="plan-calc" data-id="' + heat.id + '">' + __('Seed Now') + '</button>');
 
@@ -1172,6 +1204,26 @@
 			}
 
 			display_classes();
+		});
+
+		$(document).on("change", '.set_heat_coop_best_time', function (event) {
+			var heat_id = parseInt($(this).data('heat'));
+			var data = {
+				heat: heat_id,
+				coop_best_time: parseFloat($(this).val()),
+				coop_data_flag: true  // set flag to indicate only co-op data was modified
+			};
+			socket.emit('alter_heat', data);
+		});
+
+		$(document).on("change", '.set_heat_coop_num_laps', function (event) {
+			var heat_id = parseInt($(this).data('heat'));
+			var data = {
+				heat: heat_id,
+				coop_num_laps: parseInt($(this).val()),
+				coop_data_flag: true  // set flag to indicate only co-op data was modified
+			};
+			socket.emit('alter_heat', data);
 		});
 
 		$(document).on("focus", '.set_heat_attr', function(){
@@ -1664,6 +1716,7 @@
 				$('#set_points_params').html(svg_asset.gear);
 
 				display_format();
+				display_unclassified_heats();  // update to show/hide fields for co-op racing mode
 			}
 		}
 
@@ -1720,11 +1773,11 @@
 		}
 
 		function update_race_format_ui() {
-			format_id = $('#set_race_format').val();
+			var format_id = parseInt($('#set_race_format').val());
 			var rf = rotorhazard.event.race_formats.find(obj => {return obj.id == format_id});
 
-			$('.format-race-duration-fields').toggle(rf.unlimited_time == 0);
-			$('#format-laps-to-win-field').toggle(rf.win_condition == 2);
+			$('.format-race-duration-fields').prop('hidden', (rf.unlimited_time == 0));
+			$('#format-laps-to-win-field').prop('hidden', (rf.win_condition != 2));
 
 			var issues = []
 
@@ -1774,6 +1827,8 @@
 		$('#set_race_format').change(function (event) {
 			current_format = $('#set_race_format').val();
 			display_format();
+			display_unclassified_heats();  // update to show/hide fields for co-op racing mode
+
 		});
 
 		$('button#add_race_format').click(function (event) {
@@ -1917,10 +1972,10 @@
 			};
 			socket.emit('alter_race_format', data);
 			rotorhazard.race_format.start_behavior = parseInt($(this).val());
-			update_race_format_ui();
 
 			var rf = rotorhazard.event.race_formats.find(obj => {return obj.id == format_id});
 			rf.start_behavior = start_behavior;
+			update_race_format_ui();
 		})
 
 		$('#set_win_condition').change(function (event) {
@@ -1932,10 +1987,11 @@
 			};
 			socket.emit('alter_race_format', data);
 			rotorhazard.race_format.win_condition = parseInt($(this).val());
-			update_race_format_ui();
 
 			var rf = rotorhazard.event.race_formats.find(obj => {return obj.id == format_id});
 			rf.win_condition = win_condition;
+			update_race_format_ui();
+			display_unclassified_heats();  // update to show/hide fields for co-op racing mode
 		})
 
 		$('#set_number_laps_win').change(function (event) {
@@ -1953,7 +2009,7 @@
 
 		$('#set_team_racing_mode').change(function (event) {
 			var format_id = parseInt($('#set_race_format').val());
-			var team_racing_mode = parseInt($(this).val()); // 0=disabled, 1=enabled
+			var team_racing_mode = parseInt($(this).val());  // 0=individual, 1=team, 2=co-op
 			var data = {
 				format_id: format_id,
 				team_racing_mode: team_racing_mode
@@ -1962,6 +2018,7 @@
 
 			var rf = rotorhazard.event.race_formats.find(obj => {return obj.id == format_id});
 			rf.team_racing_mode = team_racing_mode;
+			display_unclassified_heats();  // update to show/hide fields for co-op racing mode
 		})
 
 		$('#set_points_method').change(function (event) {
@@ -2859,11 +2916,12 @@
 			</li>
 			<li>
 				<div class="label-block">
-					<label for="set_team_racing_mode">{{ __('Team Racing Mode') }}</label>
+					<label for="set_team_racing_mode">{{ __('Team/Co-op Racing Mode') }}</label>
 				</div>
 				<select id="set_team_racing_mode">
-					<option value="0">{{ __('Team Racing Disabled') }}</option>
-					<option value="1">{{ __('Team Racing Enabled') }}</option>
+					<option value="0">{{ __('Individual') }}</option>
+					<option value="1">{{ __('Team Racing') }}</option>
+					<option value="2">{{ __('Co-op Racing') }}</option>
 				</select>
 			</li>
 		</ol>

--- a/src/server/templates/format.html
+++ b/src/server/templates/format.html
@@ -1210,7 +1210,7 @@
 			var heat_id = parseInt($(this).data('heat'));
 			var data = {
 				heat: heat_id,
-				coop_best_time: parseFloat($(this).val()),
+				coop_best_time: $(this).val(),
 				coop_data_flag: true  // set flag to indicate only co-op data was modified
 			};
 			socket.emit('alter_heat', data);
@@ -1776,7 +1776,7 @@
 			var format_id = parseInt($('#set_race_format').val());
 			var rf = rotorhazard.event.race_formats.find(obj => {return obj.id == format_id});
 
-			$('.format-race-duration-fields').prop('hidden', (rf.unlimited_time == 0));
+			$('.format-race-duration-fields').prop('hidden', (rf.unlimited_time != 0));
 			$('#format-laps-to-win-field').prop('hidden', (rf.win_condition != 2));
 
 			var issues = []

--- a/src/server/templates/results.html
+++ b/src/server/templates/results.html
@@ -45,7 +45,7 @@
 			}
 
 			var defaultMeta = new Object;
-			defaultMeta.team_racing_mode = false;
+			defaultMeta.team_racing_mode = RACING_MODE_INDV;
 			defaultMeta.start_behavior = 0;
 			defaultMeta.consecutives_count = msg.consecutives_count;
 

--- a/src/server/templates/run.html
+++ b/src/server/templates/run.html
@@ -388,6 +388,10 @@
 					$('body').removeClass('race-stopped');
 					$('body').removeClass('race-new');
 					$('.timing-clock').removeClass('staging');
+					if (msg.show_init_time_flag) {
+						rotorhazard.timer.deferred.initial_disp_tenths = null;
+						rotorhazard.timer.race.initial_disp_tenths = null;
+					}
 					if (resume_check) {
 						race_kickoff(msg);
 					}
@@ -439,7 +443,16 @@
 					$('body').addClass('race-new');
 					$('.timing-clock').removeClass('staging');
 					rotorhazard.timer.race.stop();
-					rotorhazard.timer.race.renderHTML();
+					if (msg.show_init_time_flag) {
+						if (!any_laps_recorded()) {
+							rotorhazard.timer.deferred.initial_disp_tenths = rotorhazard.timer.race.duration_tenths;
+							rotorhazard.timer.race.initial_disp_tenths = rotorhazard.timer.race.duration_tenths;
+						}
+					} else {
+						rotorhazard.timer.deferred.initial_disp_tenths = null;
+						rotorhazard.timer.race.initial_disp_tenths = null;
+					}
+					rotorhazard.timer.deferred.renderHTMLandUpdate();
 					if (resume_check) {
 						socket.emit('get_race_scheduled');
 					}

--- a/src/server/templates/run.html
+++ b/src/server/templates/run.html
@@ -1010,7 +1010,11 @@
 					if (msg.team_phonetic && rotorhazard.voice_team_lap_count != 0) {
 						if (ttstext.length > 0)
 							ttstext += ", ";
-						ttstext += msg.team_phonetic;
+						if (rotorhazard.voice_team_lap_count == 2 && msg.team_short_phonetic) {
+							ttstext += msg.team_short_phonetic;
+						} else {
+							ttstext += msg.team_phonetic;
+						}
 					}
 	
 					if (ttstext.length > 0) {
@@ -2618,6 +2622,7 @@
 					<select id="voice_team_lap_count">
 						<option value="0">{{ __('Never') }}</option>
 						<option value="1">{{ __('On Team/Co-op Races') }}</option>
+						<option value="2">{{ __('On Team/Co-op Races (short call)') }}</option>
 					</select>
 				</li>
 				<li>

--- a/src/server/templates/run.html
+++ b/src/server/templates/run.html
@@ -973,7 +973,7 @@
 					var ttstext = '';
 	
 					if (rotorhazard.voice_callsign == 1 ||
-								(rotorhazard.voice_callsign == 2 && (!msg.team_name))) {
+								(rotorhazard.voice_callsign == 2 && (!msg.team_phonetic))) {
 						if (msg.callsign)
 							ttstext = msg.callsign;
 						if (msg.pilot)
@@ -981,23 +981,23 @@
 					}
 	
 					if (rotorhazard.voice_lap_count == 1 ||
-								(rotorhazard.voice_lap_count == 2 && msg.lap && (!msg.team_name))) {
+								(rotorhazard.voice_lap_count == 2 && msg.lap && (!msg.team_phonetic))) {
 						if (ttstext.length > 0)
 							ttstext += ", ";
 						ttstext += __l('Lap') + " " + msg.lap;
 					}
 	
 					if (rotorhazard.voice_lap_time == 1 ||
-								(rotorhazard.voice_lap_time == 2 && (!msg.team_name))) {
+								(rotorhazard.voice_lap_time == 2 && (!msg.team_phonetic))) {
 						if (ttstext.length > 0)
 							ttstext += ", ";
 						ttstext += msg.phonetic;
 					}
 	
-					if (msg.team_name && msg.team_laps && rotorhazard.voice_team_lap_count != 0) {
+					if (msg.team_phonetic && rotorhazard.voice_team_lap_count != 0) {
 						if (ttstext.length > 0)
 							ttstext += ", ";
-						ttstext += __l('Team') + " " + msg.team_name + ", " + __l('Lap') + " " + msg.team_laps;
+						ttstext += msg.team_phonetic;
 					}
 	
 					if (ttstext.length > 0) {
@@ -1005,7 +1005,7 @@
 							if (rotorhazard.beep_race_leader_lap) {
 								speak(LEADER_FLAG_CHAR);
 							}
-							if (rotorhazard.voice_race_leader && (!msg.team_name)) {
+							if (rotorhazard.voice_race_leader && (!msg.team_phonetic)) {
 								setTimeout(callout_current_leader, (rotorhazard.voice_race_leader * 1000), (msg.pilot ? msg.pilot : msg.callsign), false);
 							}
 						}
@@ -2564,7 +2564,7 @@
 					</div>
 					<select id="voice_callsign">
 						<option value="0">{{ __('Never') }}</option>
-						<option value="2">{{ __('Only on Non-team Races') }}</option>
+						<option value="2">{{ __('Only on Non-Team/Non-Co-op Races') }}</option>
 						<option value="1">{{ __('Always') }}</option>
 					</select>
 				</li>
@@ -2574,7 +2574,7 @@
 					</div>
 					<select id="voice_lap_count">
 						<option value="0">{{ __('Never') }}</option>
-						<option value="2">{{ __('Only on Non-team Races') }}</option>
+						<option value="2">{{ __('Only on Non-Team/Non-Co-op Races') }}</option>
 						<option value="1">{{ __('Always') }}</option>
 					</select>
 				</li>
@@ -2584,7 +2584,7 @@
 					</div>
 					<select id="voice_lap_time">
 						<option value="0">{{ __('Never') }}</option>
-						<option value="2">{{ __('Only on Non-team Races') }}</option>
+						<option value="2">{{ __('Only on Non-Team/Non-Co-op Races') }}</option>
 						<option value="1">{{ __('Always') }}</option>
 					</select>
 				</li>
@@ -2600,11 +2600,11 @@
 				</li>
 				<li>
 					<div class="label-block">
-						<label for="voice_team_lap_count">{{ __('Team Lap Total') }}</label>
+						<label for="voice_team_lap_count">{{ __('Team/Co-op Lap Total') }}</label>
 					</div>
 					<select id="voice_team_lap_count">
 						<option value="0">{{ __('Never') }}</option>
-						<option value="1">{{ __('On Team Races') }}</option>
+						<option value="1">{{ __('On Team/Co-op Races') }}</option>
 					</select>
 				</li>
 				<li>

--- a/src/server/templates/settings.html
+++ b/src/server/templates/settings.html
@@ -1964,11 +1964,12 @@
 				</li>
 				<li>
 					<div class="label-block">
-						<label for="voice_team_lap_count">{{ __('Team Lap Total') }}</label>
+						<label for="voice_team_lap_count">{{ __('Team/Co-op Lap Total') }}</label>
 					</div>
 					<select id="voice_team_lap_count">
 						<option value="0">{{ __('Never') }}</option>
-						<option value="1">{{ __('On Team Races') }}</option>
+						<option value="1">{{ __('On Team/Co-op Races') }}</option>
+						<option value="2">{{ __('On Team/Co-op Races (short call)') }}</option>
 					</select>
 				</li>
 				<li>

--- a/src/server/templates/settings.html
+++ b/src/server/templates/settings.html
@@ -1928,7 +1928,7 @@
 					</div>
 					<select id="voice_callsign">
 						<option value="0">{{ __('Never') }}</option>
-						<option value="2">{{ __('Only on Non-team Races') }}</option>
+						<option value="2">{{ __('Only on Non-Team/Non-Co-op Races') }}</option>
 						<option value="1">{{ __('Always') }}</option>
 					</select>
 				</li>
@@ -1938,7 +1938,7 @@
 					</div>
 					<select id="voice_lap_count">
 						<option value="0">{{ __('Never') }}</option>
-						<option value="2">{{ __('Only on Non-team Races') }}</option>
+						<option value="2">{{ __('Only on Non-Team/Non-Co-op Races') }}</option>
 						<option value="1">{{ __('Always') }}</option>
 					</select>
 				</li>
@@ -1948,7 +1948,7 @@
 					</div>
 					<select id="voice_lap_time">
 						<option value="0">{{ __('Never') }}</option>
-						<option value="2">{{ __('Only on Non-team Races') }}</option>
+						<option value="2">{{ __('Only on Non-Team/Non-Co-op Races') }}</option>
 						<option value="1">{{ __('Always') }}</option>
 					</select>
 				</li>

--- a/src/tests/test_server.py
+++ b/src/tests/test_server.py
@@ -124,7 +124,7 @@ class ServerTest(unittest.TestCase):
             'start_delay_max_ms': 4000,
             'number_laps_win': 5,
             'win_condition': 0,
-            'team_racing_mode': True
+            'team_racing_mode': 1
         }
         self.client.emit('alter_race_format', data)
         resp = self.get_response('format_data')


### PR DESCRIPTION
__Co-op Racing__ allows all pilots in a race to work as a cooperative group to improve their combined performance. Pilots of varying abilities can race together, with everyone contributing and working on improving their skills. There are two versions of co-op racing, described below. In both versions, all pilots in the current heat race together as a group. In the first race, a benchmark performance is set, and in each race after that the group attempts to improve and achieve a new best performance. 

* _Co-op Fastest Time to X Laps_: The group attempts to complete the given number of laps (X) in the fastest time. When this racing format is enabled (on the 'Run' page), the current "Co-op Best Time" value will be shown with the heat settings for the group (in the "Classes and Heats" section on the 'Format' page), and the value may be altered or cleared there.  

* _Co-op Most Laps in X:XX_: The group attempts to complete the most number of laps in the given race time (X:XX). When this racing format is enabled (on the 'Run' page), the current "Co-op Best # of Laps" value will be shown with the heat settings for the group (in the "Classes and Heats" section on the 'Format' page), and the value may be altered or cleared there.

The "%COOP_RACE_INFO%" and "%COOP_RACE_LAP_TOTALS%" variables can be used in callouts with co-op races, see the Event Actions section for descriptions.