### PR TITLE
Stop serializing FPVTrackside lap data

### DIFF
--- a/src/server/bundled_plugins/rh_connector_trackside/__init__.py
+++ b/src/server/bundled_plugins/rh_connector_trackside/__init__.py
@@ -164,8 +164,7 @@ class TracksideConnector():
                             'lap_time': lap.lap_time,
                             'lap_time_formatted': lap.lap_time_formatted,
                             'lap_time_stamp': lap.lap_time_stamp,
-                        })
-                    laps = json.dumps(laps)
+                        })    
                     break
             else:
                 return False


### PR DESCRIPTION
The laps array seems to be getting double encoded.

Related to this feature in fpvtrackside
https://github.com/uewepuep/FPVTracksideCore/pull/10