### PR TITLE
Server restart improvements

### DIFF
--- a/src/server/log.py
+++ b/src/server/log.py
@@ -356,6 +356,8 @@ def wait_for_queue_empty():
 
 def close_logging():
     try:
+        sys.stdout = sys.__stdout__
+        sys.stderr = sys.__stderr__
         global queued_handler_obj
         if queued_handler_obj:
             queued_handler_obj.close()


### PR DESCRIPTION
Handle restart when programDir != dataDir
Expand '~' to user-home dir
Ignore "--launchb" argument when restarting
Restore stdout/stderr when closing logging
