### PR TITLE
Add pilots' callout with interval

### DIFF
--- a/src/server/RHData.py
+++ b/src/server/RHData.py
@@ -3894,6 +3894,23 @@ def doReplace(rhapi, text, args, spoken_flag=False, delay_sec_holder=None):
             result_str = rhapi.race.phonetic_status_msg if spoken_flag else rhapi.race.status_message
             text = text.replace('%RACE_RESULT%', result_str if result_str else '')
 
+        # %PILOTS_INTERVAL_#_SECS% : List of pilot callsigns separated by an interval of given number of seconds
+        # cannot be used with other string formats
+        if '%PILOTS_INTERVAL_' in text:
+            num_str = text[17:]
+            pos = num_str.find('_SECS%')
+            vlen = 24
+            if pos < 0:
+                pos = num_str.find('_SEC%')
+                vlen -= 1
+            if pos > 0:
+                num_str = num_str[:pos]
+                if num_str.replace('.','',1).isdigit():
+                    if isinstance(delay_sec_holder, list):
+                        delay_sec_holder.clear()
+                        delay_sec_holder.append(float(num_str))
+                        text = getPilotsListStr(rhapi, ' . ', spoken_flag).split(' . ')
+
     return text
 
 def heatNodeSorter( x):

--- a/src/server/bundled_plugins/rh_actions_builtin/__init__.py
+++ b/src/server/bundled_plugins/rh_actions_builtin/__init__.py
@@ -20,7 +20,11 @@ class ActionsBuiltin():
             if len(delay_sec_holder) <= 0 or not isinstance(delay_sec_holder[0], float):
                 self._rhapi.ui.message_speak(text)
             else:
-                gevent.spawn_later(delay_sec_holder[0], self._rhapi.ui.message_speak, text)
+                if isinstance(text, str):
+                    gevent.spawn_later(delay_sec_holder[0], self._rhapi.ui.message_speak, text)
+                else:
+                    for i, piece in enumerate(text):
+                        gevent.spawn_later(delay_sec_holder[0]*(i+1), self._rhapi.ui.message_speak, piece)
 
     def messageEffect(self, action, args):
         if 'text' in action:


### PR DESCRIPTION
This PR adds a speak action that calls the current pilots with a configurable pause between each pilot. It is done by a new variable %PILOTS_INTERVAL_#_SECS% which is available only for speak effects.

Common usage: during a qualifying heat, we want a staggered start where each pilot takes off when s/he is called by the laptimer. This is what we usually did when using LiveTime.
