### PR TITLE
Only query server at startup if remote plugins installed

### DIFF
--- a/src/server/RHUI.py
+++ b/src/server/RHUI.py
@@ -467,6 +467,15 @@ class RHUI():
         plugin_data = self._racecontext.plugin_manager.get_display_data()
         category_data = self._racecontext.plugin_manager.get_remote_categories()
 
+        if not category_data or len(category_data) == 0:
+            try:
+                logger.info("Querying plugins server for updates")
+                self._racecontext.plugin_manager.load_remote_plugin_data()
+                category_data = self._racecontext.plugin_manager.get_remote_categories()
+                self._racecontext.plugin_manager.apply_update_statuses()
+            except:
+                logger.exception("Unable to load remote plugins")
+
         emit_payload = {
             'remote_categories': category_data,
             'remote_data': plugin_data

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -3645,19 +3645,27 @@ def rh_program_initialize(reg_endpoints_flag=True):
 
         try:
             RaceContext.plugin_manager.load_local_plugin_data()
-        except (FileNotFoundError, TypeError, json.JSONDecodeError):
-            print("Unable to load local plugins")
+        except:
+            logger.exception("Unable to load local plugins")
             local_loaded = False
         else:
             local_loaded = True
 
         try:
-            RaceContext.plugin_manager.load_remote_plugin_data()
-        except (requests.Timeout, requests.ConnectionError):
-            print("Unable to load remote plugins")
+            any_remote_flag = False
+            for plugin in RaceContext.serverstate.plugins:
+                if not plugin.is_bundled:
+                    any_remote_flag = True
+                    break
+            if any_remote_flag:
+                logger.info("Querying plugins server for updates")
+                RaceContext.plugin_manager.load_remote_plugin_data()
+                remote_loaded = True
+            else:
+                remote_loaded = False
+        except:
+            logger.exception("Unable to load remote plugins")
             remote_loaded = False
-        else:
-            remote_loaded = True
 
         if local_loaded and remote_loaded:
             RaceContext.plugin_manager.apply_update_statuses()


### PR DESCRIPTION
Only query remote plugins server at startup if remote plugins installed.
Query on demand if needed via community plugins page.