### PR TITLE
Add ws2812 LED support for Pi 5

### DIFF
--- a/doc/Software Setup.md
+++ b/doc/Software Setup.md
@@ -359,6 +359,16 @@ sudo apt-get install libopenjp2-7-dev
 - If your multiline panel image requires rotation, use `PANEL_ROTATE` with the number of 90-degree CCW rotations needed (0..3). 
 - If alternating lines appear jumbled, try setting `INVERTED_PANEL_ROWS` to `true`.
 
+#### Raspberry Pi 5
+
+When the hardware is a Raspberry Pi 5, the '[rpi5-ws2812](https://github.com/niklasr22/rpi5-ws2812)' library is used (because the '[rpi-ws281x](https://github.com/jgarff/rpi_ws281x)' library does not support the Pi 5). This library should cover most use cases, but the following LED configuration parameters are not supported (and will be ignored):
+- GPIO Pin (only GPIO10 supported)
+- Strip Type (only GRB supported)
+- Frequency
+- DMA
+- Inverted Control Signal
+- Channel
+
 #### LED Controller
 
 An alternative to the above methods is to use an LED Controller module, which may be connected to a USB port on any computer that is running the RotorHazard Server. See the [LED Controller repository](https://github.com/RotorHazard/LEDCtrlr) for details on how to wire and program an Arduino board as an LED controller.

--- a/src/server/requirements.txt
+++ b/src/server/requirements.txt
@@ -32,5 +32,6 @@ packaging==24.*
 smbus2==0.4.*
 RPi.GPIO==0.7.*
 rpi-ws281x==4.3.*
+rpi5-ws2812==0.1.*
 pi-ina219==1.4.*
 RPi.bme280==0.2.*

--- a/src/server/ws281x_leds.py
+++ b/src/server/ws281x_leds.py
@@ -11,11 +11,10 @@ def get_pixel_interface(config, brightness, *args, **kwargs):
     try:
         pixelModule = importlib.import_module('rpi_ws281x')
         Pixel = getattr(pixelModule, 'Adafruit_NeoPixel')
-        logger.info('LED: selecting library "rpi_ws281x"')
     except ImportError:
         pixelModule = importlib.import_module('neopixel')
         Pixel = getattr(pixelModule, 'Adafruit_NeoPixel')
-        logger.info('LED: selecting library "neopixel" (older)')
+        logger.info('LED: using library "neopixel" (older)')
 
     led_strip_config = config['LED_STRIP']
     if led_strip_config == 'RGB':
@@ -47,8 +46,58 @@ def get_pixel_interface(config, brightness, *args, **kwargs):
         logger.info('LED: disabled (Invalid LED_STRIP value: {0})'.format(led_strip_config))
         return None
 
-    logger.info('LED: hardware GPIO enabled, count={0}, pin={1}, freqHz={2}, dma={3}, invert={4}, chan={5}, strip={6}/{7}'.\
+    try:
+        # if Raspberry Pi 5 then don't attempt to initialize 'rpi_ws281x' (to avoid "segmentation fault" messages)
+        _is_pi5_flag = False
+        try:
+            with open("/proc/device-tree/model", 'r') as fileHnd:
+                _modelStr = fileHnd.read()
+            if _modelStr.startswith("Raspberry Pi ") and int(_modelStr[13:15]) == 5:
+                _is_pi5_flag = True
+        except:
+            pass
+        if _is_pi5_flag:
+            raise RuntimeError("Not attempting to initialize 'rpi_ws281x' because Raspberry Pi 5 detected")
+
+        pixel_obj = Pixel(config['LED_COUNT'], config['LED_GPIO'], config['LED_FREQ_HZ'], config['LED_DMA'], \
+                          config['LED_INVERT'], int(brightness), config['LED_CHANNEL'], led_strip)
+        pixel_obj.begin()
+        pixel_obj.begin = lambda : None  # don't allow 'begin()' to be invoked again
+        logger.info('LED: selecting library "rpi_ws281x"')
+        logger.info('LED: hardware GPIO enabled, count={0}, pin={1}, freqHz={2}, dma={3}, invert={4}, chan={5}, strip={6}/{7}'. \
                 format(config['LED_COUNT'], config['LED_GPIO'], config['LED_FREQ_HZ'], config['LED_DMA'], \
-                config['LED_INVERT'], config['LED_CHANNEL'], led_strip_config, led_strip))
-    return Pixel(config['LED_COUNT'], config['LED_GPIO'], config['LED_FREQ_HZ'], config['LED_DMA'], \
-                 config['LED_INVERT'], int(brightness), config['LED_CHANNEL'], led_strip)
+                       config['LED_INVERT'], config['LED_CHANNEL'], led_strip_config, led_strip))
+        return pixel_obj
+
+    except Exception as ex:
+        logger.debug("Result of attempting to initialize 'rpi_ws281x' library:  '{}'".format(ex))
+
+    try:
+        import rpi5_ws2812
+        from rpi5_ws2812.ws2812 import WS2812SpiDriver as rpi5_WS2812SpiDriver
+        from rpi5_ws2812.ws2812 import Color as rpi5_ws2812_Color
+        rpi5_strip = rpi5_WS2812SpiDriver(spi_bus=0, spi_device=0, led_count=config['LED_COUNT']).get_strip()
+
+        # emulate 'rpi_ws281x' functions:
+
+        rpi5_strip.begin = lambda : None
+        rpi5_strip.numPixels = rpi5_strip.num_pixels
+        rpi5_strip.setPixelColor = lambda i, val : rpi5_strip.set_pixel_color(i,
+                                       rpi5_ws2812_Color((val >> 16), ((val >> 8) & 255), (val & 255)))
+        rpi5_strip.setBrightness = lambda val : rpi5_strip.set_brightness(val / 100.0)
+        rpi5_strip.getBrightness = lambda : rpi5_strip.get_brightness * 100.0
+
+        def _get_rpi5_pix_clr(i):
+            val = rpi5_strip._pixels[i]
+            return (val.r << 16) | (val.g << 8) | val.b
+
+        rpi5_strip.getPixelColor = lambda i : _get_rpi5_pix_clr(i)
+
+        rpi5_strip.setBrightness(int(brightness))  # set initial configured brightness
+
+        logger.info("LED: using 'rpi5-ws2812' library instead of 'rpi_ws281x' (only GPIO10 supported)")
+        logger.info('LED: hardware GPIO enabled, count={0}'.format(config['LED_COUNT']))
+        return rpi5_strip
+    except:
+        logger.exception("Error attempting to use 'rpi5-ws2812' library")
+        return None


### PR DESCRIPTION
When the hardware is a Raspberry Pi 5, use the '[rpi5-ws2812](https://github.com/niklasr22/rpi5-ws2812)' library (because the '[rpi-ws281x](https://github.com/jgarff/rpi_ws281x)' library does not support the Pi 5).  This library should cover most use cases, but the following LED configuration parameters are not supported (and will be ignored):
- GPIO Pin (only GPIO10 supported)
- Strip Type (only GRB supported)
- Frequency
- DMA
- Inverted Control Signal
- Channel