### PR TITLE
Interface and node mapping/abstraction layer

### DIFF
--- a/src/interface/MockInterface.py
+++ b/src/interface/MockInterface.py
@@ -137,7 +137,7 @@ class MockInterface(BaseHardwareInterface):
     # External functions for setting data
     #
 
-    def set_frequency(self, node_index, frequency):
+    def set_frequency(self, node_index, frequency, *_args):
         node = self.nodes[node_index]
         node.debug_pass_count = 0  # reset debug pass count on frequency change
         if frequency:

--- a/src/interface/MockInterface.py
+++ b/src/interface/MockInterface.py
@@ -32,7 +32,7 @@ class MockInterface(BaseHardwareInterface):
         self.nodes = [] # Array to hold each node object
         self.data = []
         # i2c_addrs = [8, 10, 12, 14, 16, 18, 20, 22] # Software limited to 8 nodes
-        for index in range(int(os.environ.get('RH_NODES', '8'))):
+        for index in range(int(kwargs['num_nodes'])):
             node = Node() # New node instance
             node.i2c_addr = 2 * index + 8 # Set current loop i2c_addr
             node.index = index

--- a/src/interface/Node.py
+++ b/src/interface/Node.py
@@ -3,6 +3,8 @@
 class Node:
     '''Node class represents the arduino/rx pair.'''
     def __init__(self):
+        self.provider = None
+        self.provider_type = None
         self.api_level = 0
         self.api_valid_flag = False
         self.index = -1

--- a/src/interface/RHInterface.py
+++ b/src/interface/RHInterface.py
@@ -521,7 +521,7 @@ class RHInterface(BaseHardwareInterface):
     # External functions for setting data
     #
 
-    def set_frequency(self, node_index, frequency):
+    def set_frequency(self, node_index, frequency, *_args):
         node = self.nodes[node_index]
         node.debug_pass_count = 0  # reset debug pass count on frequency change
         if frequency:

--- a/src/server/Config.py
+++ b/src/server/Config.py
@@ -81,6 +81,7 @@ class Config:
         self.config['GENERAL']['RACE_START_DELAY_EXTRA_SECS'] = 0.9  # amount of extra time added to prestage time
         self.config['GENERAL']['LOG_SENSORS_DATA_RATE'] = 300  # rate at which to log sensor data
         self.config['GENERAL']['SERIAL_PORTS'] = []
+        self.config['GENERAL']['MOCK_NODES'] = 0
         self.config['GENERAL']['LAST_MODIFIED_TIME'] = 0
 
         self.config['SECRETS']['ADMIN_USERNAME'] = 'admin'
@@ -185,6 +186,7 @@ class Config:
                 'SHUTDOWN_BUTTON_DELAYMS',
                 'DB_AUTOBKP_NUM_KEEP',
                 'SERIAL_PORTS',
+                'MOCK_NODES'
             ],
             'SECRETS': [
                 'ADMIN_USERNAME',

--- a/src/server/RHAPI.py
+++ b/src/server/RHAPI.py
@@ -13,6 +13,7 @@ import logging
 import RHUtils
 from RHUI import UIField, UIFieldType
 from eventmanager import Evt
+from interface_mapper import InterfaceType
 
 logger = logging.getLogger(__name__)
 
@@ -1272,6 +1273,8 @@ class HardwareInterfaceAPI():
     def seats(self):
         return self._racecontext.interface.nodes
 
+    def add(self, interface):
+        return self._racecontext.interface.add_interface(interface, InterfaceType.RHAPI)
 
 #
 # Server Config

--- a/src/server/RHAPI.py
+++ b/src/server/RHAPI.py
@@ -685,9 +685,10 @@ class DatabaseAPI():
 
             if set_id == self._racecontext.race.profile.id:
                 self._racecontext.race.profile = result
-                for idx, value in enumerate(json.loads(result.frequencies)['f']):
+                freqs = json.loads(result.frequencies)
+                for idx, value in enumerate(freqs['f']):
                     if idx < self._racecontext.race.num_nodes:
-                        self._racecontext.interface.set_frequency(idx, value)
+                        self._racecontext.interface.set_frequency(idx, value, freqs['b'][idx], freqs['c'][idx])
                 self._racecontext.rhui.emit_frequency_data()
 
             return result

--- a/src/server/RHAPI.py
+++ b/src/server/RHAPI.py
@@ -203,6 +203,8 @@ class FieldsAPI():
     def register_option(self, field:UIField, panel=None, order=0):
         return self._racecontext.rhui.register_general_setting(field, panel, order)
 
+    def register_variable(self, field:UIField, getter_fn, setter_fn, args=None, panel=None, order=0):
+        return self._racecontext.rhui.register_ui_variable(field, getter_fn, setter_fn, args, panel, order)
 
 #
 # Database Access

--- a/src/server/RHAPI.py
+++ b/src/server/RHAPI.py
@@ -1376,6 +1376,9 @@ class ServerAPI():
     def enable_heartbeat_event(self):
         self._racecontext.serverstate.enable_heartbeat_event = True
 
+    def set_min_mocks(self, mocks):
+        self._racecontext.serverstate.mock_nodes = mocks
+
     @property
     def info(self):
         return self._racecontext.serverstate.info_dict

--- a/src/server/RHAPI.py
+++ b/src/server/RHAPI.py
@@ -1428,6 +1428,9 @@ class ServerAPI():
     def data_dir(self):
         return self._racecontext.serverstate.data_dir
 
+    def set_restart_required(self):
+        return self._racecontext.serverstate.set_restart_required()
+
 #
 # Filters
 #

--- a/src/server/RaceContext.py
+++ b/src/server/RaceContext.py
@@ -7,6 +7,7 @@ import RHTimeFns
 import logging
 from eventmanager import Evt
 from led_event_manager import NoLEDManager
+from interface_mapper import InterfaceType
 
 logger = logging.getLogger(__name__)
 
@@ -128,30 +129,41 @@ class ServerState:
         return self._info_html
 
     def build_info(self):
+        self.has_rh_interface = False
+        self.has_other_interface = False
         # Node API levels
         node_api_level = 0
         node_api_match = True
         node_api_lowest = 0
         node_api_levels = [None]
 
-        info_node = self._racecontext.interface.get_info_node_obj()
-        if info_node:
-            if info_node.api_level:
-                node_api_level = info_node.api_level
-                node_api_lowest = node_api_level
-                if len(self._racecontext.interface.nodes):
-                    node_api_levels = []
-                    for node in self._racecontext.interface.nodes:
-                        node_api_levels.append(node.api_level)
-                        if node.api_level != node_api_level:
-                            node_api_match = False
-                        if node.api_level < node_api_lowest:
-                            node_api_lowest = node.api_level
-                    # if multi-node and all api levels same then only include one entry
-                    if node_api_match and self._racecontext.interface.nodes[0].multi_node_index >= 0:
-                        node_api_levels = node_api_levels[0:1]
-                else:
-                    node_api_levels = [node_api_level]
+        rh_interface = False
+        for mapped_interface in self._racecontext.interface.mapped_interfaces:
+            if mapped_interface.type == InterfaceType.RH:
+                self.has_rh_interface = True
+                rh_interface = mapped_interface.interface
+            else:
+                self.has_other_interface = True
+
+        if rh_interface:
+            info_node = rh_interface.get_info_node_obj()
+            if info_node:
+                if info_node.api_level:
+                    node_api_level = info_node.api_level
+                    node_api_lowest = node_api_level
+                    if len(rh_interface.nodes):
+                        node_api_levels = []
+                        for node in rh_interface.nodes:
+                            node_api_levels.append(node.api_level)
+                            if node.api_level != node_api_level:
+                                node_api_match = False
+                            if node.api_level < node_api_lowest:
+                                node_api_lowest = node.api_level
+                        # if multi-node and all api levels same then only include one entry
+                        if node_api_match and rh_interface.nodes[0].multi_node_index >= 0:
+                            node_api_levels = node_api_levels[0:1]
+                    else:
+                        node_api_levels = [node_api_level]
 
         self.node_api_match = node_api_match
         self.node_api_lowest = node_api_lowest

--- a/src/server/RaceContext.py
+++ b/src/server/RaceContext.py
@@ -83,6 +83,7 @@ class ServerState:
 
     # PLUGIN STATUS
     plugins = None
+    mock_nodes = 0
 
     @property
     def info_dict(self):

--- a/src/server/interface_mapper.py
+++ b/src/server/interface_mapper.py
@@ -1,0 +1,222 @@
+'''Interface mapping abstraction'''
+
+import logging
+import sys
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+class InterfaceType:
+    MOCK = 0
+    RH = 1
+
+@dataclass
+class NodeMap:
+    interface: any
+    type: InterfaceType
+    index: int
+    object: any
+
+@dataclass
+class InterfaceMeta:
+    interface: any
+    type: InterfaceType
+
+
+class InterfaceMapper:
+    def __init__(self):
+        self._interfaces = []
+        self._nodemap = []
+
+    def add_interface(self, interface, if_type:InterfaceType):
+        interface.pass_record_callback = self.pass_record_callback
+        interface.new_enter_or_exit_at_callback = self.new_enter_or_exit_at_callback
+        interface.node_crossing_callback = self.node_crossing_callback
+        self._interfaces.append(InterfaceMeta(interface, if_type))
+        for idx, node in enumerate(interface.nodes):
+            self._nodemap.append(
+                NodeMap(
+                    interface=interface,
+                    type=if_type,
+                    index=idx,
+                    object=node
+                )
+            )
+
+    @property
+    def nodes(self):
+        nodelist = []
+        for node in self._nodemap:
+            nodelist.append(node.object)
+        return nodelist
+
+    def pass_record_callback(self):
+        pass
+
+    def new_enter_or_exit_at_callback(self):
+        pass
+
+    def node_crossing_callback(self):
+        pass
+
+    def start(self):
+        for iface in self._interfaces:
+            iface.interface.start()
+
+    def stop(self):
+        for iface in self._interfaces:
+            iface.interface.stop()
+
+    def update_loop(self):
+        for iface in self._interfaces:
+            iface.interface.update_loop()
+
+    def update(self):
+        for iface in self._interfaces:
+            iface.interface.update()
+
+    #
+    # External functions for setting data
+    #
+
+    def set_frequency(self, node_index, frequency):
+        mapped_node = self._nodemap[node_index]
+        local_index = mapped_node.index
+        return mapped_node.interface.set_frequency(local_index, frequency)
+
+    def transmit_enter_at_level(self, node, level):
+        for mapped_node in self._nodemap:
+            if node == mapped_node:
+                return mapped_node.interface.transmit_enter_at_level(node, level)
+
+    def set_enter_at_level(self, node_index, level):
+        mapped_node = self._nodemap[node_index]
+        local_index = mapped_node.index
+        return mapped_node.interface.set_enter_at_level(local_index, level)
+
+    def transmit_exit_at_level(self, node, level):
+        for mapped_node in self._nodemap:
+            if node == mapped_node:
+                return mapped_node.interface.transmit_exit_at_level(node, level)
+
+    def set_exit_at_level(self, node_index, level):
+        mapped_node = self._nodemap[node_index]
+        local_index = mapped_node.index
+        return mapped_node.interface.set_exit_at_level(local_index, level)
+
+    def force_end_crossing(self, node_index):
+        mapped_node = self._nodemap[node_index]
+        local_index = mapped_node.index
+        return mapped_node.interface.force_end_crossing(local_index)
+
+    def jump_to_bootloader(self):
+        for iface in self._interfaces:
+            iface.interface.jump_to_bootloader()
+
+    def send_status_message(self, msgTypeVal, msgDataVal):
+        for iface in self._interfaces:
+            iface.interface.send_status_message()
+        return False # TODO: Return value
+
+    def send_shutdown_button_state(self, stateVal):
+        for iface in self._interfaces:
+            iface.interface.send_shutdown_button_state()
+        return False # TODO: Return value
+
+    def send_shutdown_started_message(self):
+        for iface in self._interfaces:
+            iface.interface.send_shutdown_started_message()
+        return False # TODO: Return value
+
+    def send_server_idle_message(self):
+        for iface in self._interfaces:
+            iface.interface.send_server_idle_message()
+        return False # TODO: Return value
+
+    def get_fwupd_serial_name(self):
+        for iface in self._interfaces:
+            iface.interface.get_fwupd_serial_name()
+        return None # TODO: Return value
+
+    def close_fwupd_serial_port(self):
+        for iface in self._interfaces:
+            iface.interface.close_fwupd_serial_port()
+
+    def get_info_node_obj(self):
+        return self.nodes[0] if self.nodes and len(self.nodes) > 0 else None
+
+    def get_intf_total_error_count(self):
+        count = 0
+        for iface in self._interfaces:
+            count += iface.interface.get_intf_total_error_count()
+        return count
+
+    def set_intf_error_report_percent_limit(self, percentVal):
+        for iface in self._interfaces:
+            iface.interface.set_intf_error_report_percent_limit(percentVal)
+
+    def get_intf_error_report_str(self, **kwargs):
+        for iface in self._interfaces:
+            iface.interface.get_intf_error_report_str(**kwargs)
+        return None # TODO: Return value
+
+
+
+
+    def get_lap_source_str(self, source_idx):
+        return self._interfaces[0].get_lap_source_str(source_idx)
+
+    #
+    # External functions for setting data
+    #
+
+    def intf_simulate_lap(self, node_index, ms_val):
+        mapped_node = self._nodemap[node_index]
+        local_index = mapped_node.index
+        return mapped_node.interface.intf_simulate_lap(local_index, ms_val)
+
+    def set_race_status(self, race_status):
+        for iface in self._interfaces:
+            iface.interface.set_race_status(race_status)
+
+    def set_calibration_threshold_global(self, threshold):
+        return threshold  # dummy function; no longer supported
+
+    def enable_calibration_mode(self):
+        pass  # dummy function; no longer supported
+
+    def set_calibration_offset_global(self, offset):
+        return offset  # dummy function; no longer supported
+
+    def set_trigger_threshold_global(self, threshold):
+        return threshold  # dummy function; no longer supported
+
+    def start_capture_enter_at_level(self, node_index):
+        mapped_node = self._nodemap[node_index]
+        local_index = mapped_node.index
+        return mapped_node.interface.start_capture_enter_at_level(local_index)
+
+    def start_capture_exit_at_level(self, node_index):
+        mapped_node = self._nodemap[node_index]
+        local_index = mapped_node.index
+        return mapped_node.interface.start_capture_exit_at_level(local_index)
+
+    #
+    # Get Json Node Data Functions
+    #
+
+    def get_heartbeat_json(self):
+        json = {}
+        for iface in self._interfaces:
+            data = iface.interface.get_heartbeat_json()
+            for key, val in data.items():
+                if key in json:
+                    json[key].extend(data[key])
+                else:
+                    json[key] = val
+        return json
+
+    def set_frequency(self, node_index, frequency):
+        mapped_node = self._nodemap[node_index]
+        local_index = mapped_node.index
+        return mapped_node.interface.set_frequency(local_index, frequency)

--- a/src/server/interface_mapper.py
+++ b/src/server/interface_mapper.py
@@ -37,7 +37,6 @@ class InterfaceMapper:
             for node in interface.nodes:  # put mock nodes at latest API level
                 node.api_level = args['api_level']
 
-
         for idx, node in enumerate(interface.nodes):
             self._nodemap.append(
                 NodeMap(
@@ -120,28 +119,28 @@ class InterfaceMapper:
 
     def send_status_message(self, msgTypeVal, msgDataVal):
         for iface in self._interfaces:
-            iface.interface.send_status_message()
-        return False # TODO: Return value
+            if iface.type == InterfaceType.RH:
+                return iface.interface.send_status_message()
 
     def send_shutdown_button_state(self, stateVal):
         for iface in self._interfaces:
-            iface.interface.send_shutdown_button_state()
-        return False # TODO: Return value
+            if iface.type == InterfaceType.RH:
+                return iface.interface.send_shutdown_button_state()
 
     def send_shutdown_started_message(self):
         for iface in self._interfaces:
-            iface.interface.send_shutdown_started_message()
-        return False # TODO: Return value
+            if iface.type == InterfaceType.RH:
+                return iface.interface.send_shutdown_started_message()
 
     def send_server_idle_message(self):
         for iface in self._interfaces:
-            iface.interface.send_server_idle_message()
-        return False # TODO: Return value
+            if iface.type == InterfaceType.RH:
+                return iface.interface.send_server_idle_message()
 
     def get_fwupd_serial_name(self):
         for iface in self._interfaces:
-            iface.interface.get_fwupd_serial_name()
-        return None # TODO: Return value
+            if iface.type == InterfaceType.RH:
+                return iface.interface.get_fwupd_serial_name()
 
     def close_fwupd_serial_port(self):
         for iface in self._interfaces:
@@ -162,11 +161,10 @@ class InterfaceMapper:
 
     def get_intf_error_report_str(self, **kwargs):
         for iface in self._interfaces:
-            iface.interface.get_intf_error_report_str(**kwargs)
-        return None # TODO: Return value
+            if iface.type == InterfaceType.RH:
+                return iface.interface.get_intf_error_report_str(**kwargs)
 
-
-
+    # From Base
 
     def get_lap_source_str(self, source_idx):
         return self._interfaces[0].get_lap_source_str(source_idx)
@@ -220,8 +218,3 @@ class InterfaceMapper:
                 else:
                     json[key] = val
         return json
-
-    def set_frequency(self, node_index, frequency):
-        mapped_node = self._nodemap[node_index]
-        local_index = mapped_node.index
-        return mapped_node.interface.set_frequency(local_index, frequency)

--- a/src/server/interface_mapper.py
+++ b/src/server/interface_mapper.py
@@ -8,6 +8,7 @@ logger = logging.getLogger(__name__)
 class InterfaceType:
     MOCK = 0
     RH = 1
+    RHAPI = 2
 
 @dataclass
 class NodeMap:

--- a/src/server/interface_mapper.py
+++ b/src/server/interface_mapper.py
@@ -99,10 +99,10 @@ class InterfaceMapper:
     # External functions for setting data
     #
 
-    def set_frequency(self, node_index, frequency):
+    def set_frequency(self, node_index, frequency, band, channel):
         mapped_node = self._node_map[node_index]
         local_index = mapped_node.index
-        return mapped_node.interface.set_frequency(local_index, frequency)
+        return mapped_node.interface.set_frequency(local_index, frequency, band, channel)
 
     def transmit_enter_at_level(self, node, level):
         for mapped_node in self._node_map:

--- a/src/server/interface_mapper.py
+++ b/src/server/interface_mapper.py
@@ -1,7 +1,6 @@
 '''Interface mapping abstraction'''
 
 import logging
-import sys
 from dataclasses import dataclass
 
 logger = logging.getLogger(__name__)
@@ -28,11 +27,17 @@ class InterfaceMapper:
         self._interfaces = []
         self._nodemap = []
 
-    def add_interface(self, interface, if_type:InterfaceType):
+    def add_interface(self, interface, if_type:InterfaceType, args=None):
         interface.pass_record_callback = self.pass_record_callback
         interface.new_enter_or_exit_at_callback = self.new_enter_or_exit_at_callback
         interface.node_crossing_callback = self.node_crossing_callback
         self._interfaces.append(InterfaceMeta(interface, if_type))
+
+        if if_type == InterfaceType.MOCK:
+            for node in interface.nodes:  # put mock nodes at latest API level
+                node.api_level = args['api_level']
+
+
         for idx, node in enumerate(interface.nodes):
             self._nodemap.append(
                 NodeMap(

--- a/src/server/interface_mapper.py
+++ b/src/server/interface_mapper.py
@@ -25,21 +25,22 @@ class InterfaceMeta:
 
 class InterfaceMapper:
     def __init__(self):
-        self._interfaces = []
-        self._nodemap = []
+        self._interface_map = []
+        self._node_map = []
 
     def add_interface(self, interface, if_type:InterfaceType, args=None):
-        interface.pass_record_callback = self.pass_record_callback
-        interface.new_enter_or_exit_at_callback = self.new_enter_or_exit_at_callback
-        interface.node_crossing_callback = self.node_crossing_callback
-        self._interfaces.append(InterfaceMeta(interface, if_type))
+        self._interface_map.append(InterfaceMeta(interface, if_type))
+
+        for node in interface.nodes:  # store node provider and type
+            node.provider = interface
+            node.provider_type = if_type
 
         if if_type == InterfaceType.MOCK:
             for node in interface.nodes:  # put mock nodes at latest API level
                 node.api_level = args['api_level']
 
         for idx, node in enumerate(interface.nodes):
-            self._nodemap.append(
+            self._node_map.append(
                 NodeMap(
                     interface=interface,
                     type=if_type,
@@ -48,10 +49,24 @@ class InterfaceMapper:
                 )
             )
 
+    def add_callbacks(self):
+        for ifmeta in self._interface_map:
+            ifmeta.interface.pass_record_callback = self.pass_record_callback
+            ifmeta.interface.new_enter_or_exit_at_callback = self.new_enter_or_exit_at_callback
+            ifmeta.interface.node_crossing_callback = self.node_crossing_callback
+
+    def reindex_nodes(self):
+        for idx, node_map in enumerate(self._node_map):
+            node_map.object.index = idx
+
+    @property
+    def mapped_interfaces(self):
+        return self._interface_map
+
     @property
     def nodes(self):
         nodelist = []
-        for node in self._nodemap:
+        for node in self._node_map:
             nodelist.append(node.object)
         return nodelist
 
@@ -65,19 +80,19 @@ class InterfaceMapper:
         pass
 
     def start(self):
-        for iface in self._interfaces:
+        for iface in self._interface_map:
             iface.interface.start()
 
     def stop(self):
-        for iface in self._interfaces:
+        for iface in self._interface_map:
             iface.interface.stop()
 
     def update_loop(self):
-        for iface in self._interfaces:
+        for iface in self._interface_map:
             iface.interface.update_loop()
 
     def update(self):
-        for iface in self._interfaces:
+        for iface in self._interface_map:
             iface.interface.update()
 
     #
@@ -85,66 +100,66 @@ class InterfaceMapper:
     #
 
     def set_frequency(self, node_index, frequency):
-        mapped_node = self._nodemap[node_index]
+        mapped_node = self._node_map[node_index]
         local_index = mapped_node.index
         return mapped_node.interface.set_frequency(local_index, frequency)
 
     def transmit_enter_at_level(self, node, level):
-        for mapped_node in self._nodemap:
+        for mapped_node in self._node_map:
             if node == mapped_node:
                 return mapped_node.interface.transmit_enter_at_level(node, level)
 
     def set_enter_at_level(self, node_index, level):
-        mapped_node = self._nodemap[node_index]
+        mapped_node = self._node_map[node_index]
         local_index = mapped_node.index
         return mapped_node.interface.set_enter_at_level(local_index, level)
 
     def transmit_exit_at_level(self, node, level):
-        for mapped_node in self._nodemap:
+        for mapped_node in self._node_map:
             if node == mapped_node:
                 return mapped_node.interface.transmit_exit_at_level(node, level)
 
     def set_exit_at_level(self, node_index, level):
-        mapped_node = self._nodemap[node_index]
+        mapped_node = self._node_map[node_index]
         local_index = mapped_node.index
         return mapped_node.interface.set_exit_at_level(local_index, level)
 
     def force_end_crossing(self, node_index):
-        mapped_node = self._nodemap[node_index]
+        mapped_node = self._node_map[node_index]
         local_index = mapped_node.index
         return mapped_node.interface.force_end_crossing(local_index)
 
     def jump_to_bootloader(self):
-        for iface in self._interfaces:
+        for iface in self._interface_map:
             iface.interface.jump_to_bootloader()
 
     def send_status_message(self, msgTypeVal, msgDataVal):
-        for iface in self._interfaces:
+        for iface in self._interface_map:
             if iface.type == InterfaceType.RH:
                 return iface.interface.send_status_message()
 
     def send_shutdown_button_state(self, stateVal):
-        for iface in self._interfaces:
+        for iface in self._interface_map:
             if iface.type == InterfaceType.RH:
                 return iface.interface.send_shutdown_button_state()
 
     def send_shutdown_started_message(self):
-        for iface in self._interfaces:
+        for iface in self._interface_map:
             if iface.type == InterfaceType.RH:
                 return iface.interface.send_shutdown_started_message()
 
     def send_server_idle_message(self):
-        for iface in self._interfaces:
+        for iface in self._interface_map:
             if iface.type == InterfaceType.RH:
                 return iface.interface.send_server_idle_message()
 
     def get_fwupd_serial_name(self):
-        for iface in self._interfaces:
+        for iface in self._interface_map:
             if iface.type == InterfaceType.RH:
                 return iface.interface.get_fwupd_serial_name()
 
     def close_fwupd_serial_port(self):
-        for iface in self._interfaces:
+        for iface in self._interface_map:
             iface.interface.close_fwupd_serial_port()
 
     def get_info_node_obj(self):
@@ -152,35 +167,35 @@ class InterfaceMapper:
 
     def get_intf_total_error_count(self):
         count = 0
-        for iface in self._interfaces:
+        for iface in self._interface_map:
             count += iface.interface.get_intf_total_error_count()
         return count
 
     def set_intf_error_report_percent_limit(self, percentVal):
-        for iface in self._interfaces:
+        for iface in self._interface_map:
             iface.interface.set_intf_error_report_percent_limit(percentVal)
 
     def get_intf_error_report_str(self, **kwargs):
-        for iface in self._interfaces:
+        for iface in self._interface_map:
             if iface.type == InterfaceType.RH:
                 return iface.interface.get_intf_error_report_str(**kwargs)
 
     # From Base
 
     def get_lap_source_str(self, source_idx):
-        return self._interfaces[0].get_lap_source_str(source_idx)
+        return self._interface_map[0].interface.get_lap_source_str(source_idx)
 
     #
     # External functions for setting data
     #
 
     def intf_simulate_lap(self, node_index, ms_val):
-        mapped_node = self._nodemap[node_index]
+        mapped_node = self._node_map[node_index]
         local_index = mapped_node.index
         return mapped_node.interface.intf_simulate_lap(local_index, ms_val)
 
     def set_race_status(self, race_status):
-        for iface in self._interfaces:
+        for iface in self._interface_map:
             iface.interface.set_race_status(race_status)
 
     def set_calibration_threshold_global(self, threshold):
@@ -196,12 +211,12 @@ class InterfaceMapper:
         return threshold  # dummy function; no longer supported
 
     def start_capture_enter_at_level(self, node_index):
-        mapped_node = self._nodemap[node_index]
+        mapped_node = self._node_map[node_index]
         local_index = mapped_node.index
         return mapped_node.interface.start_capture_enter_at_level(local_index)
 
     def start_capture_exit_at_level(self, node_index):
-        mapped_node = self._nodemap[node_index]
+        mapped_node = self._node_map[node_index]
         local_index = mapped_node.index
         return mapped_node.interface.start_capture_exit_at_level(local_index)
 
@@ -211,7 +226,7 @@ class InterfaceMapper:
 
     def get_heartbeat_json(self):
         json = {}
-        for iface in self._interfaces:
+        for iface in self._interface_map:
             data = iface.interface.get_heartbeat_json()
             for key, val in data.items():
                 if key in json:

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -3266,7 +3266,6 @@ def shutdown_button_long_press():
     on_shutdown_pi()
 
 def _do_init_rh_interface():
-    RaceContext.interface = InterfaceMapper()
     try:
         rh_interface_name = os.environ.get('RH_INTERFACE', 'RH') + "Interface"
         try:
@@ -3623,6 +3622,9 @@ def rh_program_initialize(reg_endpoints_flag=True):
 
         # RotorHazard events dispatch
         Events.on(Evt.UI_DISPATCH, 'ui_dispatch_event', RaceContext.rhui.dispatch_quickbuttons, {}, 50)
+
+        # Create interface mapping
+        RaceContext.interface = InterfaceMapper()
 
         # Plugin handling
         plugin_modules = []

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -1042,7 +1042,7 @@ def on_set_frequency(data):
         })
     RaceContext.race.profile = profile
 
-    RaceContext.interface.set_frequency(node_index, frequency)
+    RaceContext.interface.set_frequency(node_index, frequency, band, channel)
 
     RaceContext.race.clear_results()
 
@@ -1130,7 +1130,7 @@ def hardware_set_all_frequencies(freqs):
     '''do hardware update for frequencies'''
     logger.debug("Sending frequency values to nodes: " + str(freqs["f"]))
     for idx in range(RaceContext.race.num_nodes):
-        RaceContext.interface.set_frequency(idx, freqs["f"][idx])
+        RaceContext.interface.set_frequency(idx, freqs["f"][idx], freqs["b"][idx], freqs["c"][idx])
 
         RaceContext.race.clear_results()
 
@@ -1147,7 +1147,9 @@ def restore_node_frequency(node_index):
     gevent.sleep(0.250)  # pause to get clear of heartbeat actions for scanner
     profile_freqs = json.loads(RaceContext.race.profile.frequencies)
     freq = profile_freqs["f"][node_index]
-    RaceContext.interface.set_frequency(node_index, freq)
+    band = profile_freqs["b"][node_index]
+    channel = profile_freqs["c"][node_index]
+    RaceContext.interface.set_frequency(node_index, freq, band, channel)
     logger.info('Frequency restored: Node {0} Frequency {1}'.format(node_index+1, freq))
 
 @SOCKET_IO.on('set_enter_at_level')
@@ -3082,7 +3084,7 @@ def assign_frequencies():
     freqs = json.loads(profile.frequencies)
 
     for idx in range(RaceContext.race.num_nodes):
-        RaceContext.interface.set_frequency(idx, freqs["f"][idx])
+        RaceContext.interface.set_frequency(idx, freqs["f"][idx], freqs["b"][idx], freqs["c"][idx])
         RaceContext.race.clear_results()
         Events.trigger(Evt.FREQUENCY_SET, {
             'nodeIndex': idx,

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -2571,6 +2571,14 @@ def on_set_config_section(data):
         'value': data['value'],
         })
 
+@SOCKET_IO.on('set_ui_variable')
+@catchLogExcWithDBWrapper
+def on_set_ui_variable(data):
+    for var in RaceContext.rhui.ui_variables:
+        if data['name'] == var.name:
+            var.setter_fn(data['value'], var.args)
+            break
+
 @SOCKET_IO.on('set_consecutives_count')
 @catchLogExcWithDBWrapper
 def on_set_consecutives_count(data):

--- a/src/server/templates/advanced-settings.html
+++ b/src/server/templates/advanced-settings.html
@@ -222,6 +222,12 @@
 				</div>
 				<input type="text" id="set-node-update-url" class="set-config" data-section="GENERAL" data-key="DEF_NODE_FWUPDATE_URL" value="{{ getConfig('GENERAL', 'DEF_NODE_FWUPDATE_URL') }}">
 			</li>
+			<li>
+				<div class="label-block">
+					<label for="set-mock-nodes">{{ __('Mock Nodes (minimum)') }}</label>
+				</div>
+				<input type="number" id="set-mock-nodes" class="set-config" data-section="GENERAL" data-key="MOCK_NODES" value="{{ getConfig('GENERAL', 'MOCK_NODES') }}" min="0">
+			</li>
 		</ol>
 		<div id="serial-port-setup">
 			{{ __('Loading...') }}

--- a/src/server/templates/settings.html
+++ b/src/server/templates/settings.html
@@ -208,9 +208,22 @@
 						}
 
 						var field = rhui.buildField(settings);
-
 						form_el.append(field);
 					}
+
+					for (var f_idx in panel.variables) {
+						var settings = { ...panel.variables[f_idx] };
+
+						settings.wrapperEl = 'li';
+						settings.fieldClass = 'set_ui_variable';
+						settings.data = {
+							field: settings.name,
+						}
+
+						var field = rhui.buildField(settings);
+						form_el.append(field);
+					}
+
 					panel_content_el.append(form_el);
 					panel_content_el.append(rhui.buildQuickbuttons(panel.quickbuttons));
 
@@ -255,6 +268,18 @@
 				};
 				socket.emit('set_option', data);
 			}
+		});
+
+		$(document).on('change', '.set_ui_variable', function (event) {
+			var field = $(this).data('field');
+			var section = $(this).data('section');
+			var value = rhui.getFieldVal(this);
+
+			var data = {
+				name: field,
+				value: value
+			};
+			socket.emit('set_ui_variable', data);
 		});
 
 		socket.on('heartbeat', function (msg) {


### PR DESCRIPTION
- Maps nodes from different interfaces into a centralized location
- Allows multiple interfaces to be loaded and run simultaneously
- Set mock nodes by config value, command-line argument, or environment var
- New RHAPI endpoints allow plugin interfaces

Also Includes RHAPI features:
- set restart-required flag
- UI Variables (name TBD) allow mapping of UIFields to functions instead of db/config values