### PR TITLE
Add config flag for update behavior

### DIFF
--- a/src/server/Config.py
+++ b/src/server/Config.py
@@ -127,6 +127,7 @@ class Config:
         # plugin defaults
         self.config['PLUGINS']['REMOTE_DATA_URI'] = None
         self.config['PLUGINS']['REMOTE_CATEGORIES_URI'] = None
+        self.config['PLUGINS']['UPDATE_BEHAVIOR'] = 'check'
 
         self.InitResultStr = None
         self.InitResultLogLevel = logging.INFO

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -3708,7 +3708,7 @@ def rh_program_initialize(reg_endpoints_flag=True):
                 if not plugin.is_bundled:
                     any_remote_flag = True
                     break
-            if any_remote_flag:
+            if any_remote_flag and RaceContext.serverconfig.get_item('PLUGINS', 'UPDATE_BEHAVIOR') == 'check':
                 logger.info("Querying plugins server for updates")
                 RaceContext.plugin_manager.load_remote_plugin_data()
                 remote_loaded = True

--- a/src/server/templates/plugins.html
+++ b/src/server/templates/plugins.html
@@ -232,6 +232,25 @@
 			socket.emit('plugin_install', data);
 		});
 
+		socket.on('config_update', function (msg) {
+			for (var section in msg.config) {
+				for (var key in msg.config[section]) {
+					var value = msg.config[section][key];
+
+					$('.set_config[data-section="' + section +'"][data-key="' + key +'"]').val(value);
+				}
+			}
+		});
+
+		$(document).on('change', '.set-config', function (event) {
+			value = $(this).val();
+			var data = {
+				section: $(this).data('section'),
+				key: $(this).data('key'),
+				value: value
+			};
+			socket.emit('set_config', data);
+		});
 	});
 </script>
 
@@ -242,6 +261,20 @@
 		<h1>{{ __('Community Plugins') }}</h1>
 		<p>{{ __('Extend the functionality of your timer by installing plugins built, maintained, and provided by the community. All plugins listed here are open-source and free to use at any event.') }}</p>
 		<p>{{ __('For more information, including how to contribute, see:') }} <a href="https://rotorhazard.github.io/community-plugins/">{{ __('Community Plugins documentation') }} &#10132;&#xFE0E;</a></p>
+
+		<hr / >
+
+		<ol class="form">
+			<li>
+				<div class="label-block">
+					<label for="set-plugin-update">{{ __('Plugin Updates') }}</label>
+				</div>
+				<select id="set-plugin-update" class="set-config" data-section="PLUGINS" data-key="UPDATE_BEHAVIOR">
+					<option value="check" {{'selected' if getConfig('PLUGINS', 'UPDATE_BEHAVIOR')=='check'}}>{{ __('Check for updates at startup') }}</option>
+					<option value="none" {{'selected' if getConfig('PLUGINS', 'UPDATE_BEHAVIOR')=='none'}}>{{ __('Never check for updates') }}</option>
+				</select>
+			</li>
+		</ol>
 	</div>
 </div>
 


### PR DESCRIPTION
Allows users to prevent automatic checks at startup. (System still won't check if there are no non-bundled plugins installed.)