### PR TITLE
Remove Video Receiver link from doc/README.md

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -16,7 +16,6 @@
 * [Plugins](Plugins.md)
 * [Split Timing Guide](Cluster.md)
 * [USB Nodes](USB%20Nodes.md)
-* [Video Receiver Control](Video%20Receiver.md)
 
 ## General Reference
 * [FPV Frequency Reference Chart](Frequency%20Reference.md)


### PR DESCRIPTION
This documentation was removed in commit 7574f0bc80dbc030d8fe1bdd12bb27b75f73e6bb, which left a dead link.