### PR TITLE
Modify 'rh_led_handler_graph' plugin to support LED strips

### DIFF
--- a/src/server/bundled_plugins/rh_led_handler_graph/manifest.json
+++ b/src/server/bundled_plugins/rh_led_handler_graph/manifest.json
@@ -6,7 +6,7 @@
     "info_uri": "https://github.com/RotorHazard/RotorHazard/",
     "license": "RotorHazard",
     "license_uri": "https://github.com/RotorHazard/RotorHazard/blob/main/LICENSE",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "required_rhapi_version": "1.0",
     "update_uri": null,
     "text_domain": null


### PR DESCRIPTION
LED strips and panels are supported (panels when LED row count is > 1).  An LED strip can be laid out in a "serpentine" pattern to display multiple nodes on a single strip.