### PR TITLE
Add default mode for secondary timer to prevent crashing

### DIFF
--- a/src/server/templates/settings.html
+++ b/src/server/templates/settings.html
@@ -2293,7 +2293,8 @@
 			$('#secondary--new').find('input').each(function(){
 				if ($(this).val()) {
 					secondaries.push({
-						address: $(this).val()
+						address: $(this).val(),
+						mode: "split"
 					});
 					$(this).empty();
 				}


### PR DESCRIPTION
Before:
The `mode` is not created the first time you add a new secondary timer, it is only created after you change the `mode` from selector. That will cause a crash.

https://github.com/user-attachments/assets/656aace8-5318-48c8-a27a-b29a827d5bff


Now:
There is a default `mode: "split"` so that the UI won't crash