### PR TITLE
Permissive scheduler

### DIFF
--- a/doc/RHAPI.md
+++ b/doc/RHAPI.md
@@ -1315,10 +1315,11 @@ Pilot database ID of current race leader. Returns `int`, or `None`.
 _Read only_
 Internal (monotonic) timestamp of scheduled race staging start time. Returns `int`, or `None` if race is not scheduled. 
 
-#### race.schedule(sec_or_none, minutes=0)
+#### race.schedule(sec_or_none, minutes=0, force_save=False)
 Schedule race with a relative future time offset. Fails if `race.status` is not `READY`. Cancels existing schedule if both values are falsy. Returns boolean success value.
 - `sec_or_none`: seconds ahead to schedule race
 - `minutes` _(optional)_: minutes ahead to schedule race
+- `force_save` _(optional)_: if `True` and active race is stopped at scheduled time, save and stage race
 
 #### race.stage()
 Begin race staging sequence. May fail if `race.status` is not `READY`. No return value.

--- a/src/server/RHAPI.py
+++ b/src/server/RHAPI.py
@@ -1224,8 +1224,8 @@ class RaceAPI():
     def race_leader_pilot_id(self):
         return self._racecontext.race.race_leader_pilot_id
     
-    def schedule(self, sec_or_none, minutes=0):
-        return self._racecontext.race.schedule(sec_or_none, minutes)
+    def schedule(self, sec_or_none, minutes=0, force_save=False):
+        return self._racecontext.race.schedule(sec_or_none, minutes, force_save)
 
     @property
     def scheduled(self):

--- a/src/server/RHRace.py
+++ b/src/server/RHRace.py
@@ -58,6 +58,7 @@ class RHRace():
         # sequence
         self.scheduled = False # Whether to start a race when time
         self.scheduled_time = 0 # Start race when time reaches this value
+        self.scheduler_forcing_save = False # Scheduler will force race status to ready by saving active race if needed
         self.start_token = False # Check start thread matches correct stage sequence
         # status
         self.race_status = RaceStatus.READY
@@ -114,7 +115,7 @@ class RHRace():
 
 
     @catchLogExceptionsWrapper
-    def stage(self, data=None, immediate=False):
+    def stage(self, data=None, immediate=False, from_scheduler=False):
         # need to show alert via spawn in case a clear-messages event was just triggered
         if request:
             @catchLogExceptionsWrapper
@@ -124,7 +125,7 @@ class RHRace():
 
         data = self._filters.run_filters(Flt.RACE_STAGE, data)
 
-        with (self._racecontext.rhdata.get_db_session_handle()):  # make sure DB session/connection is cleaned up
+        with ((self._racecontext.rhdata.get_db_session_handle())):  # make sure DB session/connection is cleaned up
 
             if data and data.get('secondary_format'):
                 self.format = self._racecontext.serverstate.secondary_race_format
@@ -216,6 +217,18 @@ class RHRace():
                         heatNodes.append(heatNode)
 
             if self.race_status != RaceStatus.READY:
+                if from_scheduler:
+                    if self.race_status != RaceStatus.DONE and self.scheduler_forcing_save:
+                        self.scheduler_forcing_save = False
+                        logger.info("Race scheduler is forcing active race save")
+                        self.do_save_actions()
+                    else:
+                        self.scheduler_forcing_save = False
+                        logger.info("Scheduled race prevented by unsaved active race")
+                        self._racecontext.rhui.emit_priority_message(
+                            self.__("Scheduled race not started: Active race results not finalized"), True)
+                        return
+
                 if race_format is self._racecontext.serverstate.secondary_race_format:  # if running as secondary timer
                     if self.race_status == RaceStatus.RACING:
                         return  # if race in progress then leave it be
@@ -1332,20 +1345,18 @@ class RHRace():
             node.first_cross_flag = False
             node.show_crossing_flag = False
 
-    def schedule(self, s, m=0):
+    def schedule(self, s, m=0, force_save=False):
         with self._racecontext.rhdata.get_db_session_handle():  # make sure DB session/connection is cleaned up
-
-            if self.race_status != RaceStatus.READY:
-                logger.info("Ignoring request to schedule race: Status not READY")
-                return False
 
             if s or m:
                 self.scheduled = True
                 self.scheduled_time = monotonic() + (int(m) * 60) + int(s)
+                self.scheduler_forcing_save = force_save
 
                 self._racecontext.events.trigger(Evt.RACE_SCHEDULE, {
                     'scheduled_at': self.scheduled_time,
                     'heat_id': self.current_heat,
+                    'forced_save': force_save
                     })
 
                 self._racecontext.rhui.emit_priority_message(self.__("Next race begins in") + " {0:01d}:{1:02d}".format(int(m), int(s)), True)
@@ -1354,6 +1365,7 @@ class RHRace():
             else:
                 if self.scheduled:
                     self.scheduled = False
+                    self.scheduler_forcing_save = False
                     self._racecontext.events.trigger(Evt.RACE_SCHEDULE_CANCEL, {
                         'heat_id': self.current_heat,
                         })

--- a/src/server/RHRace.py
+++ b/src/server/RHRace.py
@@ -125,7 +125,7 @@ class RHRace():
 
         data = self._filters.run_filters(Flt.RACE_STAGE, data)
 
-        with ((self._racecontext.rhdata.get_db_session_handle())):  # make sure DB session/connection is cleaned up
+        with (self._racecontext.rhdata.get_db_session_handle()):  # make sure DB session/connection is cleaned up
 
             if data and data.get('secondary_format'):
                 self.format = self._racecontext.serverstate.secondary_race_format

--- a/src/server/RHRace.py
+++ b/src/server/RHRace.py
@@ -220,13 +220,14 @@ class RHRace():
                 if from_scheduler:
                     if self.race_status != RaceStatus.DONE and self.scheduler_forcing_save:
                         self.scheduler_forcing_save = False
-                        logger.info("Race scheduler is forcing active race save")
+                        logger.info("Race scheduler forcing active race save")
                         self.do_save_actions()
                     else:
                         self.scheduler_forcing_save = False
                         logger.info("Scheduled race prevented by unsaved active race")
                         self._racecontext.rhui.emit_priority_message(
                             self.__("Scheduled race not started: Active race results not finalized"), True)
+                        self.schedule(0)
                         return
 
                 if race_format is self._racecontext.serverstate.secondary_race_format:  # if running as secondary timer
@@ -586,7 +587,6 @@ class RHRace():
                     node.start_thresh_lower_time = self.end_time + 0.1
 
         self.timer_running = False # indicate race timer not running
-        self.scheduled = False # also stop any deferred start
 
         self._racecontext.rhui.emit_race_status() # Race page, to set race button states
         self._racecontext.rhui.emit_current_leaderboard()

--- a/src/server/bundled_plugins/rh_actions_builtin/__init__.py
+++ b/src/server/bundled_plugins/rh_actions_builtin/__init__.py
@@ -54,8 +54,13 @@ class ActionsBuiltin():
         except:
             mins = 0
 
+        try:
+            force_save = int(action.get('force_save'))
+        except:
+            force_save = False
+
         if secs or mins:
-            self._rhapi.race.schedule(secs, mins)
+            self._rhapi.race.schedule(secs, mins, force_save)
 
     def register_handlers(self, args):
         for effect in [
@@ -97,6 +102,8 @@ class ActionsBuiltin():
                 [
                     UIField('sec', "Seconds", UIFieldType.BASIC_INT),
                     UIField('min', "Minutes", UIFieldType.BASIC_INT),
+                    UIField('force_save', "Save stopped race", UIFieldType.CHECKBOX,
+                            value=False),
                 ],
                 name='schedule',
             )

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -2941,7 +2941,7 @@ def heartbeat_thread_function():
             # check if race is to be started
             if RaceContext.race.scheduled:
                 if time_now > RaceContext.race.scheduled_time:
-                    on_stage_race()
+                    RaceContext.race.stage(from_scheduler=True)
                     RaceContext.race.scheduled = False
 
             # if any comm errors then log them (at defined intervals; faster if debug mode)

--- a/src/server/templates/current.html
+++ b/src/server/templates/current.html
@@ -609,7 +609,7 @@
 		});
 
 		socket.on('stop_timer', function (msg) {
-			rotorhazard.timer.stopAll();
+			rotorhazard.timer.race.stop();
 		});
 
 		socket.on('pilot_data', function (msg) {

--- a/src/server/templates/run.html
+++ b/src/server/templates/run.html
@@ -1160,7 +1160,7 @@
 		}
 
 		socket.on('stop_timer', function (msg) {
-			rotorhazard.timer.stopAll();
+			rotorhazard.timer.race.stop();
 		});
 
 		socket.on('stage_ready', function (msg) {
@@ -1174,7 +1174,7 @@
 				$('button#stop_race').prop('disabled', true);
 				$('button#save_laps').prop('disabled', true);
 				$('button#discard_laps').prop('disabled', true);
-				rotorhazard.timer.stopAll();
+				rotorhazard.timer.race.stop();
 				$('.time-display').html('--:--');
 				socket.emit('stage_race');
 			}
@@ -1187,7 +1187,7 @@
 				$('button#stop_race').prop('disabled', true);
 				$('button#save_laps').prop('disabled', true);
 				$('button#discard_laps').prop('disabled', true);
-				rotorhazard.timer.stopAll();
+				rotorhazard.timer.race.stop();
 				socket.emit('stop_race');
 			}
 		});

--- a/src/server/templates/streamresults.html
+++ b/src/server/templates/streamresults.html
@@ -208,7 +208,7 @@
 		});
 
 		socket.on('stop_timer', function (msg) {
-			rotorhazard.timer.stopAll();
+			rotorhazard.timer.race.stop();
 		});
 	});
 


### PR DESCRIPTION
Allows scheduler to be invoked at any time; moves checks to occur at staging instead of at scheduling
- New flag allows scheduler to save a stopped race and then proceed
- Provides flag access from builtin schedule action
- Provides RHAPI access
- Changes to allow scheduler and race timer to be tracked concurrently
- RHAPI documentation

Resolves #1108