### PR TITLE
Add Evt.RACE_CLOCK_CALLOUT for race countdown callouts

### DIFF
--- a/doc/RHAPI.md
+++ b/doc/RHAPI.md
@@ -118,6 +118,13 @@ Fired at the exact moment the race begins.
 - `heat_id` (int): ID of the current heat
 - `color` (str): RGB hex color associated with this event
 
+#### Evt.RACE_CLOCK_CALLOUT
+
+Emitted at race clock callout milestones in count-down race formats. Each event is sent before the milestone by `GENERAL > SYNC_LEADTIME_SECS`, while `scheduled_at_monotonic` identifies the exact time the milestone occurs. Plugins can use that timestamp to schedule race clock audio, hardware effects, or other time-sensitive integrations in sync with the race clock.
+
+- `seconds_remaining` (int): Number of seconds remaining when this callout is due
+- `scheduled_at_monotonic` (float): Monotonic timestamp of when this callout is due; use this to schedule time-sensitive audio output
+
 #### Evt.RACE_FINISH
 
 Fired when the race timer expires (count-down formats only). The race is still in progress until `Evt.RACE_STOP`.

--- a/src/server/RHRace.py
+++ b/src/server/RHRace.py
@@ -508,7 +508,23 @@ class RHRace():
         with self._racecontext.rhdata.get_db_session_handle():  # make sure DB session/connection is cleaned up
             race_format = self.format
             if race_format and race_format.unlimited_time == 0: # count down
-                gevent.sleep(race_format.race_time_sec)
+                race_time = race_format.race_time_sec
+                elapsed = 0.0
+                for threshold in (60, 30, 10):
+                    if threshold >= race_time:
+                        continue
+                    sleep_time = race_time - threshold - elapsed
+                    if sleep_time > 0:
+                        gevent.sleep(sleep_time)
+                        elapsed += sleep_time
+                    if self.race_status != RaceStatus.RACING or self.start_token != start_token:
+                        return
+                    self._racecontext.events.trigger(Evt.RACE_CLOCK_WARNING, {
+                        'seconds_remaining': threshold,
+                    })
+                remaining = race_time - elapsed
+                if remaining > 0:
+                    gevent.sleep(remaining)
                 # if race still in progress and is still same race
                 if self.race_status == RaceStatus.RACING and self.start_token == start_token:
                     logger.info("Race count-down timer reached expiration")

--- a/src/server/RHRace.py
+++ b/src/server/RHRace.py
@@ -23,7 +23,7 @@ APP.app_context().push()
 
 logger = logging.getLogger(__name__)
 
-RACE_CLOCK_WARNING_THRESHOLDS = (60, 30, 10, 5, 4, 3, 2, 1, 0)
+RACE_CLOCK_CALLOUT_THRESHOLDS = (60, 30, 10, 5, 4, 3, 2, 1, 0)
 
 @dataclass
 class Crossing(dict):
@@ -512,19 +512,23 @@ class RHRace():
             if race_format and race_format.unlimited_time == 0: # count down
                 race_time = race_format.race_time_sec
                 race_end_monotonic = self.start_time_monotonic + race_time
-                for threshold in RACE_CLOCK_WARNING_THRESHOLDS:
+                sync_leadtime = float(self._racecontext.serverconfig.get_item('GENERAL', 'SYNC_LEADTIME_SECS'))
+                for threshold in RACE_CLOCK_CALLOUT_THRESHOLDS:
                     if threshold >= race_time:
                         continue
                     scheduled_at_monotonic = race_end_monotonic - threshold
-                    sleep_time = scheduled_at_monotonic - monotonic()
+                    sleep_time = scheduled_at_monotonic - sync_leadtime - monotonic()
                     if sleep_time > 0:
                         gevent.sleep(sleep_time)
                     if self.race_status != RaceStatus.RACING or self.start_token != start_token:
                         return
-                    self._racecontext.events.trigger(Evt.RACE_CLOCK_WARNING, {
+                    self._racecontext.events.trigger(Evt.RACE_CLOCK_CALLOUT, {
                         'seconds_remaining': threshold,
                         'scheduled_at_monotonic': scheduled_at_monotonic,
                     })
+                sleep_time = race_end_monotonic - monotonic()
+                if sleep_time > 0:
+                    gevent.sleep(sleep_time)
                 # if race still in progress and is still same race
                 if self.race_status == RaceStatus.RACING and self.start_token == start_token:
                     logger.info("Race count-down timer reached expiration")

--- a/src/server/RHRace.py
+++ b/src/server/RHRace.py
@@ -23,6 +23,8 @@ APP.app_context().push()
 
 logger = logging.getLogger(__name__)
 
+RACE_CLOCK_WARNING_THRESHOLDS = (60, 30, 10, 5, 4, 3, 2, 1, 0)
+
 @dataclass
 class Crossing(dict):
     node_index: int = None
@@ -509,22 +511,20 @@ class RHRace():
             race_format = self.format
             if race_format and race_format.unlimited_time == 0: # count down
                 race_time = race_format.race_time_sec
-                elapsed = 0.0
-                for threshold in (60, 30, 10):
+                race_end_monotonic = self.start_time_monotonic + race_time
+                for threshold in RACE_CLOCK_WARNING_THRESHOLDS:
                     if threshold >= race_time:
                         continue
-                    sleep_time = race_time - threshold - elapsed
+                    scheduled_at_monotonic = race_end_monotonic - threshold
+                    sleep_time = scheduled_at_monotonic - monotonic()
                     if sleep_time > 0:
                         gevent.sleep(sleep_time)
-                        elapsed += sleep_time
                     if self.race_status != RaceStatus.RACING or self.start_token != start_token:
                         return
                     self._racecontext.events.trigger(Evt.RACE_CLOCK_WARNING, {
                         'seconds_remaining': threshold,
+                        'scheduled_at_monotonic': scheduled_at_monotonic,
                     })
-                remaining = race_time - elapsed
-                if remaining > 0:
-                    gevent.sleep(remaining)
                 # if race still in progress and is still same race
                 if self.race_status == RaceStatus.RACING and self.start_token == start_token:
                     logger.info("Race count-down timer reached expiration")

--- a/src/server/RHUI.py
+++ b/src/server/RHUI.py
@@ -841,6 +841,7 @@ class RHUI():
                     Evt.RACE_STAGE: self.__('Race Stage'),
                     Evt.RACE_ABORT: self.__('Race Stage Abort'),
                     Evt.RACE_START: self.__('Race Start'),
+                    Evt.RACE_CLOCK_WARNING: self.__('Race Clock Warning'),
                     Evt.RACE_FINISH: self.__('Race Finish'),
                     Evt.RACE_STOP: self.__('Race Stop'),
                     Evt.RACE_WIN: self.__('Race Win'),

--- a/src/server/RHUI.py
+++ b/src/server/RHUI.py
@@ -841,7 +841,7 @@ class RHUI():
                     Evt.RACE_STAGE: self.__('Race Stage'),
                     Evt.RACE_ABORT: self.__('Race Stage Abort'),
                     Evt.RACE_START: self.__('Race Start'),
-                    Evt.RACE_CLOCK_WARNING: self.__('Race Clock Warning'),
+                    Evt.RACE_CLOCK_CALLOUT: self.__('Race Clock Callout'),
                     Evt.RACE_FINISH: self.__('Race Finish'),
                     Evt.RACE_STOP: self.__('Race Stop'),
                     Evt.RACE_WIN: self.__('Race Win'),

--- a/src/server/eventmanager.py
+++ b/src/server/eventmanager.py
@@ -160,6 +160,7 @@ class Evt:
     RACE_ABORT = 'raceAbort' # race stopped during staging
     RACE_STAGE_TONE = 'raceStageTone'
     RACE_START = 'raceStart'
+    RACE_CLOCK_WARNING = 'raceClockWarning'
     RACE_FINISH = 'raceFinish'
     RACE_STOP = 'raceStop'
     RACE_WIN = 'raceWin'

--- a/src/server/eventmanager.py
+++ b/src/server/eventmanager.py
@@ -160,7 +160,7 @@ class Evt:
     RACE_ABORT = 'raceAbort' # race stopped during staging
     RACE_STAGE_TONE = 'raceStageTone'
     RACE_START = 'raceStart'
-    RACE_CLOCK_WARNING = 'raceClockWarning'
+    RACE_CLOCK_CALLOUT = 'raceClockCallout'
     RACE_FINISH = 'raceFinish'
     RACE_STOP = 'raceStop'
     RACE_WIN = 'raceWin'


### PR DESCRIPTION
RotorHazard fires no server-side events during the race clock countdown, plugins that want to react to time milestones have to reimplement the browser timer themselves. This PR adds `Evt.RACE_CLOCK_WARNING`, fired at 60, 30, and 10 seconds remaining in count-down formats, matching the callouts already in `rotorhazard.js`.

## Note
- **Draft:** waiting for #1134 to merge first; RHAPI docs will be added after rebasing.