### PR TITLE
feat: Show live values for UI field range

### DIFF
--- a/src/server/static/rh-ui.js
+++ b/src/server/static/rh-ui.js
@@ -1,5 +1,14 @@
 
 var rhui = {
+	_formatRangeValue: function (settings, value) {
+		var prefix = settings.html_attributes.value_prefix || '';
+		var suffix = settings.html_attributes.value_suffix || '';
+		return prefix + value + suffix;
+	},
+	_updateRangeValue: function (settings, field) {
+		field.closest('.uifield-range').find('output.uifield-range-value')
+			.text(this._formatRangeValue(settings, field.val()));
+	},
 	_modelField: function (field_options) {
 		var settings = {
 			data: {},
@@ -114,6 +123,11 @@ var rhui = {
 			var field = $('<input>')
 				.attr('type', 'range')
 				.attr('placeholder', settings.placeholder);
+			var rangeWrap = $('<div>')
+				.addClass('uifield-range');
+			var valueEl = $('<output>')
+				.addClass('uifield-range-value')
+				.attr('for', settings.id);
 
 			if ('min' in settings.html_attributes) {
 				field.attr('min', settings.html_attributes.min)
@@ -125,7 +139,13 @@ var rhui = {
 				field.attr('step', settings.html_attributes.step)
 			}
 			wrapper.append(labelWrap);
-			wrapper.append(field);
+			rangeWrap.append(field);
+			rangeWrap.append(valueEl);
+			wrapper.append(rangeWrap);
+			var rhuiObj = this;
+			field.on('input change', function () {
+				rhuiObj._updateRangeValue(settings, $(this));
+			});
 		} else if (settings.field_type == 'select') {
 			var field = $('<select>')
 
@@ -266,6 +286,9 @@ var rhui = {
 			element.prop('checked', settings.value);
 		} else {
 			element.val(settings.value);
+		}
+		if (settings.field_type == 'range') {
+			this._updateRangeValue(settings, element);
 		}
 
 		for (var idx in settings.data) {

--- a/src/server/static/rh-ui.js
+++ b/src/server/static/rh-ui.js
@@ -1,13 +1,41 @@
 
 var rhui = {
-	_formatRangeValue: function (settings, value) {
-		var prefix = settings.html_attributes.value_prefix || '';
-		var suffix = settings.html_attributes.value_suffix || '';
+	_formatRangeValue: function (settings, field, value) {
+		var htmlAttributes = settings.html_attributes || {};
+		var prefix = htmlAttributes.value_prefix != null
+			? htmlAttributes.value_prefix
+			: field.attr('data-value-prefix') || '';
+		var suffix = htmlAttributes.value_suffix != null
+			? htmlAttributes.value_suffix
+			: field.attr('data-value-suffix') || '';
+		var decimals = htmlAttributes.value_decimals != null
+			? htmlAttributes.value_decimals
+			: field.attr('data-value-decimals');
+		if (decimals != null && value !== '' && !isNaN(value)) {
+			value = Number(value).toFixed(parseInt(decimals, 10));
+		}
 		return prefix + value + suffix;
 	},
-	_updateRangeValue: function (settings, field) {
+	_updateRangeValue: function (field, settings, value) {
+		settings = settings || field.data('rhui-range-settings') || {};
+		if (value == null) {
+			value = field.val();
+		}
 		field.closest('.uifield-range').find('output.uifield-range-value')
-			.text(this._formatRangeValue(settings, field.val()));
+			.text(this._formatRangeValue(settings, field, value));
+	},
+	updateRangeValue: function (field, value) {
+		this._updateRangeValue(field, null, value);
+	},
+	_bindRangeValue: function (field, settings) {
+		field.data('rhui-range-settings', settings || {});
+		if (!field.data('rhui-range-bound')) {
+			var rhuiObj = this;
+			field.on('input change', function () {
+				rhuiObj.updateRangeValue($(this));
+			});
+			field.data('rhui-range-bound', true);
+		}
 	},
 	_modelField: function (field_options) {
 		var settings = {
@@ -128,6 +156,7 @@ var rhui = {
 			var valueEl = $('<output>')
 				.addClass('uifield-range-value')
 				.attr('for', settings.id);
+			this._bindRangeValue(field, settings);
 
 			if ('min' in settings.html_attributes) {
 				field.attr('min', settings.html_attributes.min)
@@ -142,10 +171,6 @@ var rhui = {
 			rangeWrap.append(field);
 			rangeWrap.append(valueEl);
 			wrapper.append(rangeWrap);
-			var rhuiObj = this;
-			field.on('input change', function () {
-				rhuiObj._updateRangeValue(settings, $(this));
-			});
 		} else if (settings.field_type == 'select') {
 			var field = $('<select>')
 
@@ -288,7 +313,7 @@ var rhui = {
 			element.val(settings.value);
 		}
 		if (settings.field_type == 'range') {
-			this._updateRangeValue(settings, element);
+			this._updateRangeValue(element, settings);
 		}
 
 		for (var idx in settings.data) {
@@ -322,6 +347,11 @@ var rhui = {
 }
 
 $(document).ready(function () {
+	$('.uifield-range input[type="range"]').each(function () {
+		rhui._bindRangeValue($(this));
+		rhui.updateRangeValue($(this));
+	});
+
 	$(document).on('click', '.quickbutton', function (event) {
 		var data = {
 			id: $(this).data('btn_id'),

--- a/src/server/static/rotorhazard.css
+++ b/src/server/static/rotorhazard.css
@@ -379,6 +379,24 @@ ol.form ul {
 	padding: 0;
 }
 
+.uifield-range {
+	display: flex;
+	align-items: center;
+	gap: 0.5em;
+}
+
+.uifield-range input[type="range"] {
+	flex: 1 1 auto;
+	min-width: 0;
+}
+
+.uifield-range-value {
+	display: inline-block;
+	min-width: 3em;
+	text-align: right;
+	font-variant-numeric: tabular-nums;
+}
+
 ol.form li+li {
 	margin-top: 0.5em;
 }
@@ -398,7 +416,8 @@ ol.form li+li {
 
 	ol.form input,
 	ol.form textarea,
-	ol.form select {
+	ol.form select,
+	ol.form .uifield-range {
 		flex: 1 1 0;
 		margin-left: 0.5em;
 	}

--- a/src/server/static/rotorhazard.css
+++ b/src/server/static/rotorhazard.css
@@ -388,6 +388,7 @@ ol.form ul {
 .uifield-range input[type="range"] {
 	flex: 1 1 auto;
 	min-width: 0;
+	margin: 0;
 }
 
 .uifield-range-value {

--- a/src/server/templates/current.html
+++ b/src/server/templates/current.html
@@ -144,13 +144,13 @@
 		$('#voice_race_leader').val(rotorhazard.voice_race_leader);
 		$().articulate('volume', rotorhazard.voice_volume);
 		$('#set_voice_volume').val(volume_logsl.position(rotorhazard.voice_volume));
-		$('#voice_volume_value').html($('#set_voice_volume').val());
+		rhui.updateRangeValue($('#set_voice_volume'));
 		$().articulate('rate', rotorhazard.voice_rate);
-		$('#voice_rate_value').html(rotorhazard.voice_rate.toFixed(2));
 		$('#set_voice_rate').val(rotorhazard.voice_rate);
+		rhui.updateRangeValue($('#set_voice_rate'));
 		$().articulate('pitch', rotorhazard.voice_pitch);
-		$('#voice_pitch_value').html(rotorhazard.voice_pitch.toFixed(2));
 		$('#set_voice_pitch').val(rotorhazard.voice_pitch);
+		rhui.updateRangeValue($('#set_voice_pitch'));
 		$('#display_lap_id').prop("checked", rotorhazard.display_lap_id);
 		$('#display_time_start').prop("checked", rotorhazard.display_time_start);
 		$('#display_time_first_pass').prop("checked", rotorhazard.display_time_first_pass);
@@ -696,7 +696,6 @@
 		$('#set_voice_volume').on('input', function (event) {
 			var val = volume_logsl.value($(this).val());
 			$().articulate('volume', val);
-			$('#voice_volume_value').html($(this).val());
 		});
 
 		$('#set_voice_volume').change(function (event) {
@@ -708,7 +707,6 @@
 		$('#set_voice_rate').on('input', function (event) {
 			val = parseFloat($(this).val())
 			$().articulate('rate', val);
-			$('#voice_rate_value').html(val.toFixed(2));
 		});
 
 		$('#set_voice_rate').on('change', function (event) {
@@ -719,7 +717,6 @@
 		$('#set_voice_pitch').on('input', function (event) {
 			val = parseFloat($(this).val())
 			$().articulate('pitch', val);
-			$('#voice_pitch_value').html(val.toFixed(2));
 		});
 
 		$('#set_voice_pitch').on('change', function (event) {
@@ -988,23 +985,29 @@
 			<li>
 				<div class="label-block">
 					<label for="set_voice_volume">{{ __('Voice Volume') }}</label>
-					<p class="desc">{{ __('Volume') }}: <span id="voice_volume_value"></span></p>
 				</div>
-				<input type="range" id="set_voice_volume" min="0" max="100">
+				<div class="uifield-range">
+					<input type="range" id="set_voice_volume" min="0" max="100" data-value-suffix="%">
+					<output class="uifield-range-value" id="voice_volume_value" for="set_voice_volume"></output>
+				</div>
 			</li>
 			<li>
 				<div class="label-block">
 					<label for="set_voice_rate">{{ __('Voice Rate') }}</label>
-					<p class="desc">{{ __('Rate') }}: <span id="voice_rate_value"></span></p>
 				</div>
-				<input type="range" id="set_voice_rate" min="0" max="2.0" step="0.01">
+				<div class="uifield-range">
+					<input type="range" id="set_voice_rate" min="0" max="2.0" step="0.01" data-value-suffix="×" data-value-decimals="2">
+					<output class="uifield-range-value" id="voice_rate_value" for="set_voice_rate"></output>
+				</div>
 			</li>
 			<li>
 				<div class="label-block">
 					<label for="set_voice_pitch">{{ __('Voice Pitch') }}</label>
-					<p class="desc">{{ __('Pitch') }}: <span id="voice_pitch_value"></span></p>
 				</div>
-				<input type="range" id="set_voice_pitch" min="0" max="2.0" step="0.01">
+				<div class="uifield-range">
+					<input type="range" id="set_voice_pitch" min="0" max="2.0" step="0.01" data-value-suffix="×" data-value-decimals="2">
+					<output class="uifield-range-value" id="voice_pitch_value" for="set_voice_pitch"></output>
+				</div>
 			</li>
 			<li>
 				<div class="label-block">

--- a/src/server/templates/run.html
+++ b/src/server/templates/run.html
@@ -214,9 +214,8 @@
 		$('#display_laps_reversed').prop("checked", rotorhazard.display_laps_reversed);
 
 		if ('{{ getConfig('LED', 'ledBrightness') }}' != 'False') {
-			var ledBrightness = {{ getConfig('LED', 'ledBrightness') }};
-			$('#set_led_brightness').val(brightness_logsl.position(ledBrightness));
-			rhui.updateRangeValue($('#set_led_brightness'), Math.round(ledBrightness / 255 * 100));
+			$('#set_led_brightness').val(brightness_logsl.position( {{ getConfig('LED', 'ledBrightness') }} ));
+			rhui.updateRangeValue($('#set_led_brightness'));
 		}
 
 		// set up node local store
@@ -2011,11 +2010,6 @@
 			})
 		})
 
-		$('#set_led_brightness').on('input', function (event) {
-			var val = brightness_logsl.value($(this).val());
-			rhui.updateRangeValue($(this), Math.round(val / 255 * 100));
-		});
-
 		$('#set_led_brightness').change(function (event) {
 			var val = brightness_logsl.value($(this).val());
 			// emit data
@@ -3359,7 +3353,7 @@
 					<label for="set_led_brightness">{{ __('LED Brightness') }}</label>
 				</div>
 				<div class="uifield-range">
-					<input type="range" id="set_led_brightness" min="1" max="25" data-value-suffix="%">
+					<input type="range" id="set_led_brightness" min="1" max="25">
 					<output class="uifield-range-value" id="led_brightness_value" for="set_led_brightness"></output>
 				</div>
 			</li>

--- a/src/server/templates/run.html
+++ b/src/server/templates/run.html
@@ -166,15 +166,15 @@
 			$('#voice_race_leader').val(rotorhazard.voice_race_leader);
 			$().articulate('volume', rotorhazard.voice_volume);
 			$('#set_voice_volume').val(volume_logsl.position(rotorhazard.voice_volume));
-			$('#voice_volume_value').html($('#set_voice_volume').val());
+			rhui.updateRangeValue($('#set_voice_volume'));
 			$().articulate('rate', rotorhazard.voice_rate);
-			$('#voice_rate_value').html(rotorhazard.voice_rate.toFixed(2));
 			$('#set_voice_rate').val(rotorhazard.voice_rate);
+			rhui.updateRangeValue($('#set_voice_rate'));
 			$().articulate('pitch', rotorhazard.voice_pitch);
-			$('#voice_pitch_value').html(rotorhazard.voice_pitch.toFixed(2));
 			$('#set_voice_pitch').val(rotorhazard.voice_pitch);
+			rhui.updateRangeValue($('#set_voice_pitch'));
 			$('#set_tone_volume').val(volume_logsl.position(rotorhazard.tone_volume));
-			$('#tone_volume_value').html($('#set_tone_volume').val());
+			rhui.updateRangeValue($('#set_tone_volume'));
 			$('#beep_crossing_entered').prop("checked", rotorhazard.beep_crossing_entered);
 			$('#beep_crossing_exited').prop("checked", rotorhazard.beep_crossing_exited);
 			$('#beep_manual_lap_button').prop("checked", rotorhazard.beep_manual_lap_button);
@@ -184,7 +184,7 @@
 			$('#use_mp3_tones').prop("checked", rotorhazard.use_mp3_tones);
 			$('#beep_on_first_pass_button').prop("checked", rotorhazard.beep_on_first_pass_button);
 			$('#set_indicator_volume').val(volume_logsl.position(rotorhazard.indicator_beep_volume));
-			$('#indicator_volume_value').html($('#set_indicator_volume').val());
+			rhui.updateRangeValue($('#set_indicator_volume'));
 			$('#set_voice_string_language').val(rotorhazard.voice_string_language);
 			if (!rotorhazard.voice_language) {  // if no current default then select first English voice
 				rotorhazard.voice_language = get_default_articulate_voice();
@@ -214,8 +214,9 @@
 		$('#display_laps_reversed').prop("checked", rotorhazard.display_laps_reversed);
 
 		if ('{{ getConfig('LED', 'ledBrightness') }}' != 'False') {
-			$('#set_led_brightness').val(brightness_logsl.position( {{ getConfig('LED', 'ledBrightness') }} ));
-			$('#led_brightness_value').html($('#set_led_brightness').val());
+			var ledBrightness = {{ getConfig('LED', 'ledBrightness') }};
+			$('#set_led_brightness').val(brightness_logsl.position(ledBrightness));
+			rhui.updateRangeValue($('#set_led_brightness'), Math.round(ledBrightness / 255 * 100));
 		}
 
 		// set up node local store
@@ -1458,7 +1459,6 @@
 		$('#set_voice_volume').on('input', function (event) {
 			var val = volume_logsl.value($(this).val());
 			$().articulate('volume', val);
-			$('#voice_volume_value').html($(this).val());
 		});
 
 		$('#set_voice_volume').change(function (event) {
@@ -1470,7 +1470,6 @@
 		$('#set_voice_rate').on('input', function (event) {
 			val = parseFloat($(this).val())
 			$().articulate('rate', val);
-			$('#voice_rate_value').html(val.toFixed(2));
 		});
 
 		$('#set_voice_rate').on('change', function (event) {
@@ -1481,7 +1480,6 @@
 		$('#set_voice_pitch').on('input', function (event) {
 			val = parseFloat($(this).val())
 			$().articulate('pitch', val);
-			$('#voice_pitch_value').html(val.toFixed(2));
 		});
 
 		$('#set_voice_pitch').on('change', function (event) {
@@ -1492,7 +1490,6 @@
 		$('#set_tone_volume').on('input', function (event) {
 			var val = volume_logsl.value($(this).val());
 			rotorhazard.tone_volume = val;
-			$('#tone_volume_value').html($(this).val());
 		});
 
 		$('#set_tone_volume').change(function (event) {
@@ -1555,7 +1552,6 @@
 		$('#set_indicator_volume').on('input', function (event) {
 			var val = volume_logsl.value($(this).val());
 			rotorhazard.indicator_beep_volume = val;
-			$('#indicator_volume_value').html($(this).val());
 		});
 
 		$('#set_indicator_volume').change(function (event) {
@@ -2017,7 +2013,7 @@
 
 		$('#set_led_brightness').on('input', function (event) {
 			var val = brightness_logsl.value($(this).val());
-			$('#led_brightness_value').html($(this).val());
+			rhui.updateRangeValue($(this), Math.round(val / 255 * 100));
 		});
 
 		$('#set_led_brightness').change(function (event) {
@@ -3221,30 +3217,38 @@
 			<li>
 				<div class="label-block">
 					<label for="set_voice_volume">{{ __('Voice Volume') }}</label>
-					<p class="desc">{{ __('Volume') }}: <span id="voice_volume_value"></span></p>
 				</div>
-				<input type="range" id="set_voice_volume" min="0" max="100">
+				<div class="uifield-range">
+					<input type="range" id="set_voice_volume" min="0" max="100" data-value-suffix="%">
+					<output class="uifield-range-value" id="voice_volume_value" for="set_voice_volume"></output>
+				</div>
 			</li>
 			<li>
 				<div class="label-block">
 					<label for="set_voice_rate">{{ __('Voice Rate') }}</label>
-					<p class="desc">{{ __('Rate') }}: <span id="voice_rate_value"></span></p>
 				</div>
-				<input type="range" id="set_voice_rate" min="0" max="2.0" step="0.01">
+				<div class="uifield-range">
+					<input type="range" id="set_voice_rate" min="0" max="2.0" step="0.01" data-value-suffix="×" data-value-decimals="2">
+					<output class="uifield-range-value" id="voice_rate_value" for="set_voice_rate"></output>
+				</div>
 			</li>
 			<li>
 				<div class="label-block">
 					<label for="set_voice_pitch">{{ __('Voice Pitch') }}</label>
-					<p class="desc">{{ __('Pitch') }}: <span id="voice_pitch_value"></span></p>
 				</div>
-				<input type="range" id="set_voice_pitch" min="0" max="2.0" step="0.01">
+				<div class="uifield-range">
+					<input type="range" id="set_voice_pitch" min="0" max="2.0" step="0.01" data-value-suffix="×" data-value-decimals="2">
+					<output class="uifield-range-value" id="voice_pitch_value" for="set_voice_pitch"></output>
+				</div>
 			</li>
 			<li>
 				<div class="label-block">
 					<label for="set_tone_volume">{{ __('Tone Volume') }}</label>
-					<p class="desc">{{ __('Volume') }}: <span id="tone_volume_value"></span></p>
 				</div>
-				<input type="range" id="set_tone_volume" min="0" max="100">
+				<div class="uifield-range">
+					<input type="range" id="set_tone_volume" min="0" max="100" data-value-suffix="%">
+					<output class="uifield-range-value" id="tone_volume_value" for="set_tone_volume"></output>
+				</div>
 			</li>
 			<li>
 				<div class="label-block">
@@ -3266,9 +3270,11 @@
 			<li>
 				<div class="label-block">
 					<label for="set_indicator_volume">{{ __('Indicator Beeps Volume') }}</label>
-					<p class="desc">{{ __('Volume') }}: <span id="indicator_volume_value"></span></p>
 				</div>
-				<input type="range" id="set_indicator_volume" min="0" max="100">
+				<div class="uifield-range">
+					<input type="range" id="set_indicator_volume" min="0" max="100" data-value-suffix="%">
+					<output class="uifield-range-value" id="indicator_volume_value" for="set_indicator_volume"></output>
+				</div>
 			</li>
 		</ol>
 		<br>
@@ -3351,9 +3357,11 @@
 			<li>
 				<div class="label-block">
 					<label for="set_led_brightness">{{ __('LED Brightness') }}</label>
-					<p class="desc">{{ __('Level') }}: <span id="led_brightness_value"></span></p>
 				</div>
-				<input type="range" id="set_led_brightness" min="1" max="25">
+				<div class="uifield-range">
+					<input type="range" id="set_led_brightness" min="1" max="25" data-value-suffix="%">
+					<output class="uifield-range-value" id="led_brightness_value" for="set_led_brightness"></output>
+				</div>
 			</li>
 		</ol>
 

--- a/src/server/templates/settings.html
+++ b/src/server/templates/settings.html
@@ -82,15 +82,15 @@
 			$('#voice_race_leader').val(rotorhazard.voice_race_leader);
 			$().articulate('volume', rotorhazard.voice_volume);
 			$('#set_voice_volume').val(volume_logsl.position(rotorhazard.voice_volume));
-			$('#voice_volume_value').html($('#set_voice_volume').val());
+			rhui.updateRangeValue($('#set_voice_volume'));
 			$().articulate('rate', rotorhazard.voice_rate);
-			$('#voice_rate_value').html(rotorhazard.voice_rate.toFixed(2));
 			$('#set_voice_rate').val(rotorhazard.voice_rate);
+			rhui.updateRangeValue($('#set_voice_rate'));
 			$().articulate('pitch', rotorhazard.voice_pitch);
-			$('#voice_pitch_value').html(rotorhazard.voice_pitch.toFixed(2));
 			$('#set_voice_pitch').val(rotorhazard.voice_pitch);
+			rhui.updateRangeValue($('#set_voice_pitch'));
 			$('#set_tone_volume').val(volume_logsl.position(rotorhazard.tone_volume));
-			$('#tone_volume_value').html($('#set_tone_volume').val());
+			rhui.updateRangeValue($('#set_tone_volume'));
 			$('#beep_crossing_entered').prop("checked", rotorhazard.beep_crossing_entered);
 			$('#beep_crossing_exited').prop("checked", rotorhazard.beep_crossing_exited);
 			$('#beep_manual_lap_button').prop("checked", rotorhazard.beep_manual_lap_button);
@@ -100,7 +100,7 @@
 			$('#use_mp3_tones').prop("checked", rotorhazard.use_mp3_tones);
 			$('#beep_on_first_pass_button').prop("checked", rotorhazard.beep_on_first_pass_button);
 			$('#set_indicator_volume').val(volume_logsl.position(rotorhazard.indicator_beep_volume));
-			$('#indicator_volume_value').html($('#set_indicator_volume').val());
+			rhui.updateRangeValue($('#set_indicator_volume'));
 			$('#set_voice_string_language').val(rotorhazard.voice_string_language);
 			if (!rotorhazard.voice_language) {  // if no current default then select first English voice
 				rotorhazard.voice_language = get_default_articulate_voice();
@@ -122,8 +122,9 @@
 		populate_audio_settings();
 
 		if ('{{ getConfig('LED', 'ledBrightness') }}' != 'False') {
-			$('#set_led_brightness').val(brightness_logsl.position( {{ getConfig('LED', 'ledBrightness') }} ));
-			$('#led_brightness_value').html($('#set_led_brightness').val());
+			var ledBrightness = {{ getConfig('LED', 'ledBrightness') }};
+			$('#set_led_brightness').val(brightness_logsl.position(ledBrightness));
+			rhui.updateRangeValue($('#set_led_brightness'), Math.round(ledBrightness / 255 * 100));
 		}
 
 		if ('{{ getConfig('TIMING', 'calibrationMode') }}' == '1') {
@@ -913,7 +914,6 @@
 		$('#set_voice_volume').on('input', function (event) {
 			var val = volume_logsl.value($(this).val());
 			$().articulate('volume', val);
-			$('#voice_volume_value').html($(this).val());
 		});
 
 		$('#set_voice_volume').change(function (event) {
@@ -925,7 +925,6 @@
 		$('#set_voice_rate').on('input', function (event) {
 			val = parseFloat($(this).val())
 			$().articulate('rate', val);
-			$('#voice_rate_value').html(val.toFixed(2));
 		});
 
 		$('#set_voice_rate').on('change', function (event) {
@@ -936,7 +935,6 @@
 		$('#set_voice_pitch').on('input', function (event) {
 			val = parseFloat($(this).val())
 			$().articulate('pitch', val);
-			$('#voice_pitch_value').html(val.toFixed(2));
 		});
 
 		$('#set_voice_pitch').on('change', function (event) {
@@ -947,7 +945,6 @@
 		$('#set_tone_volume').on('input', function (event) {
 			var val = volume_logsl.value($(this).val());
 			rotorhazard.tone_volume = val;
-			$('#tone_volume_value').html($(this).val());
 		});
 
 		$('#set_tone_volume').change(function (event) {
@@ -1000,7 +997,6 @@
 		$('#set_indicator_volume').on('input', function (event) {
 			var val = volume_logsl.value($(this).val());
 			rotorhazard.indicator_beep_volume = val;
-			$('#indicator_volume_value').html($(this).val());
 		});
 
 		$('#set_indicator_volume').change(function (event) {
@@ -1700,7 +1696,7 @@
 
 		$('#set_led_brightness').on('input', function (event) {
 			var val = brightness_logsl.value($(this).val());
-			$('#led_brightness_value').html($(this).val());
+			rhui.updateRangeValue($(this), Math.round(val / 255 * 100));
 		});
 
 		$('#set_led_brightness').change(function (event) {
@@ -2917,30 +2913,38 @@
 			<li>
 				<div class="label-block">
 					<label for="set_voice_volume">{{ __('Voice Volume') }}</label>
-					<p class="desc">{{ __('Volume') }}: <span id="voice_volume_value"></span></p>
 				</div>
-				<input type="range" id="set_voice_volume" min="0" max="100">
+				<div class="uifield-range">
+					<input type="range" id="set_voice_volume" min="0" max="100" data-value-suffix="%">
+					<output class="uifield-range-value" id="voice_volume_value" for="set_voice_volume"></output>
+				</div>
 			</li>
 			<li>
 				<div class="label-block">
 					<label for="set_voice_rate">{{ __('Voice Rate') }}</label>
-					<p class="desc">{{ __('Rate') }}: <span id="voice_rate_value"></span></p>
 				</div>
-				<input type="range" id="set_voice_rate" min="0" max="2.0" step="0.01">
+				<div class="uifield-range">
+					<input type="range" id="set_voice_rate" min="0" max="2.0" step="0.01" data-value-suffix="×" data-value-decimals="2">
+					<output class="uifield-range-value" id="voice_rate_value" for="set_voice_rate"></output>
+				</div>
 			</li>
 			<li>
 				<div class="label-block">
 					<label for="set_voice_pitch">{{ __('Voice Pitch') }}</label>
-					<p class="desc">{{ __('Pitch') }}: <span id="voice_pitch_value"></span></p>
 				</div>
-				<input type="range" id="set_voice_pitch" min="0" max="2.0" step="0.01">
+				<div class="uifield-range">
+					<input type="range" id="set_voice_pitch" min="0" max="2.0" step="0.01" data-value-suffix="×" data-value-decimals="2">
+					<output class="uifield-range-value" id="voice_pitch_value" for="set_voice_pitch"></output>
+				</div>
 			</li>
 			<li>
 				<div class="label-block">
 					<label for="set_tone_volume">{{ __('Tone Volume') }}</label>
-					<p class="desc">{{ __('Volume') }}: <span id="tone_volume_value"></span></p>
 				</div>
-				<input type="range" id="set_tone_volume" min="0" max="100">
+				<div class="uifield-range">
+					<input type="range" id="set_tone_volume" min="0" max="100" data-value-suffix="%">
+					<output class="uifield-range-value" id="tone_volume_value" for="set_tone_volume"></output>
+				</div>
 			</li>
 			<li>
 				<div class="label-block">
@@ -2962,9 +2966,11 @@
 			<li>
 				<div class="label-block">
 					<label for="set_indicator_volume">{{ __('Indicator Beeps Volume') }}</label>
-					<p class="desc">{{ __('Volume') }}: <span id="indicator_volume_value"></span></p>
 				</div>
-				<input type="range" id="set_indicator_volume" min="0" max="100">
+				<div class="uifield-range">
+					<input type="range" id="set_indicator_volume" min="0" max="100" data-value-suffix="%">
+					<output class="uifield-range-value" id="indicator_volume_value" for="set_indicator_volume"></output>
+				</div>
 			</li>
 		</ol>
 		<br>
@@ -3042,9 +3048,11 @@
 			<li>
 				<div class="label-block">
 					<label for="set_led_brightness">{{ __('LED Brightness') }}</label>
-					<p class="desc">{{ __('Level') }}: <span id="led_brightness_value"></span></p>
 				</div>
-				<input type="range" id="set_led_brightness" min="1" max="25">
+				<div class="uifield-range">
+					<input type="range" id="set_led_brightness" min="1" max="25" data-value-suffix="%">
+					<output class="uifield-range-value" id="led_brightness_value" for="set_led_brightness"></output>
+				</div>
 			</li>
 		</ol>
 
@@ -3211,25 +3219,37 @@
 				<div class="label-block">
 					<label for="set_hue_primary">{{ __('Primary Hue') }}</label>
 				</div>
-				<input type="range" id="set_hue_primary" class="hue-control" data-section="UI" data-key="hue_0" value="{{ getConfig('UI', 'hue_0') }}" min="0" max="359">
+				<div class="uifield-range">
+					<input type="range" id="set_hue_primary" class="hue-control" data-section="UI" data-key="hue_0" value="{{ getConfig('UI', 'hue_0') }}" min="0" max="359" data-value-suffix="°">
+					<output class="uifield-range-value" for="set_hue_primary"></output>
+				</div>
 			</li>
 			<li>
 				<div class="label-block">
 					<label for="set_sat_primary">{{ __('Primary Saturation') }}</label>
 				</div>
-				<input type="range" id="set_sat_primary" class="sat-control" data-section="UI" data-key="sat_0" value="{{ getConfig('UI', 'sat_0') }}" min="0" max="100">
+				<div class="uifield-range">
+					<input type="range" id="set_sat_primary" class="sat-control" data-section="UI" data-key="sat_0" value="{{ getConfig('UI', 'sat_0') }}" min="0" max="100" data-value-suffix="%">
+					<output class="uifield-range-value" for="set_sat_primary"></output>
+				</div>
 			</li>
 			<li>
 				<div class="label-block">
 					<label for="set_hue_secondary">{{ __('Secondary Hue') }}</label>
 				</div>
-				<input type="range" id="set_hue_secondary" class="hue-control" data-section="UI" data-key="hue_1" value="{{ getConfig('UI', 'hue_1') }}" min="0" max="359">
+				<div class="uifield-range">
+					<input type="range" id="set_hue_secondary" class="hue-control" data-section="UI" data-key="hue_1" value="{{ getConfig('UI', 'hue_1') }}" min="0" max="359" data-value-suffix="°">
+					<output class="uifield-range-value" for="set_hue_secondary"></output>
+				</div>
 			</li>
 			<li>
 				<div class="label-block">
 					<label for="set_sat_secondary">{{ __('Secondary Saturation') }}</label>
 				</div>
-				<input type="range" id="set_sat_secondary" class="sat-control" data-section="UI" data-key="sat_1" value="{{ getConfig('UI', 'sat_1') }}" min="0" max="100">
+				<div class="uifield-range">
+					<input type="range" id="set_sat_secondary" class="sat-control" data-section="UI" data-key="sat_1" value="{{ getConfig('UI', 'sat_1') }}" min="0" max="100" data-value-suffix="%">
+					<output class="uifield-range-value" for="set_sat_secondary"></output>
+				</div>
 			</li>
 		</ol>
 

--- a/src/server/templates/settings.html
+++ b/src/server/templates/settings.html
@@ -122,9 +122,8 @@
 		populate_audio_settings();
 
 		if ('{{ getConfig('LED', 'ledBrightness') }}' != 'False') {
-			var ledBrightness = {{ getConfig('LED', 'ledBrightness') }};
-			$('#set_led_brightness').val(brightness_logsl.position(ledBrightness));
-			rhui.updateRangeValue($('#set_led_brightness'), Math.round(ledBrightness / 255 * 100));
+			$('#set_led_brightness').val(brightness_logsl.position( {{ getConfig('LED', 'ledBrightness') }} ));
+			rhui.updateRangeValue($('#set_led_brightness'));
 		}
 
 		if ('{{ getConfig('TIMING', 'calibrationMode') }}' == '1') {
@@ -1694,11 +1693,6 @@
 			socket.emit('set_led_event_effect', data);
 		});
 
-		$('#set_led_brightness').on('input', function (event) {
-			var val = brightness_logsl.value($(this).val());
-			rhui.updateRangeValue($(this), Math.round(val / 255 * 100));
-		});
-
 		$('#set_led_brightness').change(function (event) {
 			var val = brightness_logsl.value($(this).val());
 			// emit data
@@ -3050,7 +3044,7 @@
 					<label for="set_led_brightness">{{ __('LED Brightness') }}</label>
 				</div>
 				<div class="uifield-range">
-					<input type="range" id="set_led_brightness" min="1" max="25" data-value-suffix="%">
+					<input type="range" id="set_led_brightness" min="1" max="25">
 					<output class="uifield-range-value" id="led_brightness_value" for="set_led_brightness"></output>
 				</div>
 			</li>


### PR DESCRIPTION
Adds a visible live value display for RHUI field range.

Plugins that use `UIFieldType.RANGE` now render the slider value next to the range input and keep it updated while the user drags the slider. Plugins can optionally provide `value_prefix` and `value_suffix` through `html_attributes`, for example to show `50%` or $50.