### PR TITLE
Add section headings for plugin UI fields

### DIFF
--- a/doc/Plugins.md
+++ b/doc/Plugins.md
@@ -485,6 +485,7 @@ Fields are defined in the following format:
     - `UIFieldType.EMAIL`
     - `UIFieldType.TEL`
     - `UIFieldType.URL`
+    - `UIFieldType.SECTION`
 - `value` _optional_ (any): Default value for field
 - `desc` _optional_ (string): additional user-facing text that appears in the RotorHazard frontend interface describing notes or special instructions for use
 - `private` _optional_ (boolean): Prevent automatically generated UI
@@ -510,6 +511,13 @@ If `field_type` is `SELECT`
     - `value` (string): internal identifier used when this option is selected
     - `label` (string): user-facing text that appears in the RotorHazard frontend interface
 - `value` is no longer optional and must match the `value` of an item in `options`.
+
+If `field_type` is `SECTION`
+
+- The field is rendered as a non-interactive section heading in generated UI.
+- `label` is displayed as the heading text.
+- `desc` may be provided as explanatory text below the heading.
+- The field does not store a value in event options or persistent configuration.
 
 Import UI Fields objects from RHUI.
 

--- a/doc/RHAPI.md
+++ b/doc/RHAPI.md
@@ -244,7 +244,7 @@ _Read only_
 Provide a list of options registered by plugins. Does not include built-in options or fields registered as persistent configuration.
 
 #### fields.register_option(field, panel=None, order=0)
-Register an option and optionally assign it to be displayed on a UI panel. By default, options registered this way are event-scoped. If `persistent_section` is true in the UIField, the option will be server-scoped. 
+Register an option and optionally assign it to be displayed on a UI panel. By default, options registered this way are event-scoped. If `persistent_section` is set in the UIField, the option will be server-scoped. `UIFieldType.SECTION` fields are display-only headings and do not store option values.
 
 - `field` (UIField): See [UI Fields](Plugins.md#ui-fields)
 - `panel` _optional_ (string): `name` of panel previously registered with `ui.register_panel`

--- a/src/server/RHUI.py
+++ b/src/server/RHUI.py
@@ -43,6 +43,7 @@ class UIFieldType(Enum):
     EMAIL = "email"
     TEL = "tel"
     URL = "url"
+    SECTION = "section"
 
 @dataclass
 class UIFieldSelectOption():
@@ -237,7 +238,9 @@ class RHUI():
             logger.error(f"UIField '{field.name}' ignored; may not start with '__'")
             return self._general_settings
 
-        if field.persistent_section:
+        if field.field_type is UIFieldType.SECTION:
+            field_internal_id = field.name
+        elif field.persistent_section:
             field_internal_id = f'__{field.persistent_section}_{field.name}'
             if not self._racecontext.serverconfig.item_exists(field.persistent_section, field.name):
                 self._racecontext.serverconfig.set_item(field.persistent_section, field.name, field.value)
@@ -259,6 +262,8 @@ class RHUI():
     def init_setting_defaults(self):
         for setting in self._general_settings:
             field = setting.field
+            if field.field_type is UIFieldType.SECTION:
+                continue
             if not self._racecontext.rhdata.option_exists(field.name):
                 self._racecontext.rhdata.set_option(field.name, field.value)
 
@@ -383,7 +388,9 @@ class RHUI():
                 for setting in panel_settings['settings']:
                     field = setting.field.frontend_repr()
 
-                    if setting.field.persistent_section:
+                    if setting.field.field_type is UIFieldType.SECTION:
+                        db_val = None
+                    elif setting.field.persistent_section:
                         db_val = self._racecontext.serverconfig.get_item(setting.field.persistent_section, setting.field.name)
                     else:
                         db_val = self._racecontext.rhdata.get_option(setting.field.name)

--- a/src/server/static/rh-ui.js
+++ b/src/server/static/rh-ui.js
@@ -42,6 +42,17 @@ var rhui = {
 			wrapper.addClass(settings.wrapperClass);
 		}
 
+		if (settings.field_type == 'section') {
+			wrapper.addClass('ui-field-section');
+			wrapper.append($('<h3>').text(__(settings.label)));
+
+			if (settings.desc) {
+				wrapper.append($('<p class="desc">').html(settings.desc));
+			}
+
+			return wrapper;
+		}
+
 		var labelWrap = $('<div class="label-block"></div>');
 
 		var label = $('<label>')

--- a/src/server/static/rotorhazard.css
+++ b/src/server/static/rotorhazard.css
@@ -383,6 +383,31 @@ ol.form li+li {
 	margin-top: 0.5em;
 }
 
+ol.form>li.ui-field-section,
+.ui-field-section {
+	display: block;
+	padding-top: 0.75rem;
+	border-top: solid 1px #d1d3d4;
+	text-align: left;
+}
+
+@media (prefers-color-scheme: dark) {
+	ol.form>li.ui-field-section,
+	.ui-field-section {
+		border-color: #4c4c4c;
+	}
+}
+
+.ui-field-section h3 {
+	margin: 0;
+	font-size: 1rem;
+	line-height: 1.2;
+}
+
+.ui-field-section .desc {
+	margin-top: 0.25rem;
+}
+
 @media (min-width: 40em) {
 	ol.form>li {
 		display: flex;
@@ -411,6 +436,10 @@ ol.form li+li {
 	ol.form > li > input[type="checkbox"] {
 		flex: 0 0 auto;
 		margin-right: auto;
+	}
+
+	ol.form>li.ui-field-section {
+		display: block;
 	}
 
 	ol.form > li > * + button {


### PR DESCRIPTION
This adds a display-only `UIFieldType.SECTION` for plugin-generated UI fields. Plugin authors can use it to add visual headings inside generated settings panels without creating a stored event option or persistent config value.

The frontend renders section fields as non-interactive headings with optional description text. On the backend, section fields are skipped when initializing option defaults and when resolving stored option values, so they behave as layout-only UI elements.

## Screenshot

<img width="820" height="572" alt="Schermafbeelding 2026-05-27 002624" src="https://github.com/user-attachments/assets/7482185b-4c58-4516-acfd-e51fd265f73b" />

## Notes

`UIFieldType.SECTION` is intended for grouping related generated fields in plugin panels. It does not replace real form inputs and does not store any value.