### PR TITLE
Mirror Mode Bug Fixes

### DIFF
--- a/src/server/EventActions.py
+++ b/src/server/EventActions.py
@@ -16,6 +16,7 @@ class EventActions:
         self._racecontext = RaceContext
         self.Events = eventmanager
         self.logger = logging.getLogger(self.__class__.__name__)
+        self._missing_effect_warned = set()
 
         self.Events.trigger(Evt.ACTIONS_INITIALIZE, {
             'register_fn': self.registerEffect
@@ -27,6 +28,7 @@ class EventActions:
 
     def registerEffect(self, effect):
         self.effects[effect.name] = effect
+        self._missing_effect_warned.discard(effect.name)
         return True
 
     def getRegisteredEffects(self):
@@ -63,9 +65,24 @@ class EventActions:
                 self.runEffect(action, args)
 
     def runEffect(self, action, args):
+        effect_name = action.get('effect')
+        if not effect_name or effect_name not in self.effects:
+            if effect_name:
+                if effect_name not in self._missing_effect_warned:
+                    self._missing_effect_warned.add(effect_name)
+                    self.logger.warning("Skipping unregistered event action effect '{}' for event '{}' "
+                                        "(plugin may not be installed on this timer)".format(
+                                            effect_name, action.get('event', '?')))
+                else:
+                    self.logger.debug("Skipping unregistered event action effect '{}' for event '{}'".format(
+                                        effect_name, action.get('event', '?')))
+            else:
+                self.logger.warning("Skipping event action with no effect for event '{}'".format(
+                                    action.get('event', '?')))
+            return
         self.logger.debug("Calling effect '{}', node {}".format(action, \
                             getNumericEntry(args, 'node_index', -1) + 1))
-        self.effects[action['effect']].runEffect(action, args)
+        self.effects[effect_name].runEffect(action, args)
 
 class ActionEffect():
     def __init__(self, label, effect_fn, fields:List[UIField], name=None):

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -1,5 +1,5 @@
 '''RotorHazard server script'''
-RELEASE_VERSION = "4.4.1-dev.1" # Public release version code
+RELEASE_VERSION = "4.4.0" # Public release version code
 SERVER_API = 49 # Server API version
 NODE_API_SUPPORTED = 18 # Minimum supported node version
 NODE_API_BEST = 36 # Most recent node API
@@ -147,7 +147,7 @@ _DB_URI = 'sqlite:///' + os.path.join(DATA_DIR, DB_FILE_NAME)
 
 sys.path.append(PROGRAM_DIR + '/util')
 
-APP = Flask(__name__, template_folder=PROGRAM_DIR+'/templates', static_folder=PROGRAM_DIR+'/static', static_url_path='/static')
+APP = Flask(__name__, static_url_path='/static')
 APP.app_context().push()
 
 import FlaskAppObj
@@ -826,6 +826,7 @@ def on_cluster_event_trigger(data):
     evtArgs = json.loads(data['evt_args']) if 'evt_args' in data else None
 
     # set mirror timer state
+    mirror_evt_handled = False
     if Server_secondary_mode == SecondaryNode.MIRROR_MODE:
         if evtName == Evt.RACE_STAGE:
             RaceContext.race.results = None
@@ -841,17 +842,22 @@ def on_cluster_event_trigger(data):
                 'correction_ms': data['correction_ms'] if 'correction_ms' in data else 0,
             }
             RaceContext.race.stage(start_race_args)
+            mirror_evt_handled = True  # race.stage() already triggers events locally
 
         elif evtName == Evt.RACE_STOP:
             RaceContext.race.stop()
+            mirror_evt_handled = True  # race.stop() already triggers events locally
+
         elif evtName == Evt.LAPS_CLEAR:
             RaceContext.race.discard_laps()
+            mirror_evt_handled = True  # discard_laps() already triggers events locally
+
         elif evtName == Evt.RACE_LAP_RECORDED:
             RaceContext.race.results = evtArgs['results']
 
     evtArgs.pop('RACE', None) # remove race if exists
 
-    if evtName not in [Evt.STARTUP,  Evt.RACE_START, Evt.LED_SET_MANUAL]:
+    if evtName not in [Evt.STARTUP,  Evt.RACE_START, Evt.LED_SET_MANUAL] and not mirror_evt_handled:
         Events.trigger(evtName, evtArgs)
     # special handling for LED Control via primary timer
     elif 'effect' in evtArgs and RaceContext.led_manager.isEnabled():
@@ -2624,7 +2630,7 @@ def on_set_consecutives_count(data):
 
 @SOCKET_IO.on('get_race_scheduled')
 @catchLogExceptionsWrapper
-def get_race_scheduled(*args):
+def get_race_elapsed(*args):
     # get current race status; never broadcasts to all
     emit('race_scheduled', {
         'scheduled': RaceContext.race.scheduled,
@@ -2967,8 +2973,8 @@ def heartbeat_thread_function():
             # check if race is to be started
             if RaceContext.race.scheduled:
                 if time_now > RaceContext.race.scheduled_time:
-                    RaceContext.race.scheduled = False
                     RaceContext.race.stage(from_scheduler=True)
+                    RaceContext.race.scheduled = False
 
             # if any comm errors then log them (at defined intervals; faster if debug mode)
             if time_now > heartbeat_thread_function.last_error_rep_time + \


### PR DESCRIPTION
When starting a race on the main timer the mirror timer would throw an error relating to double firing an event. The changes in server.py are to prevent this.

When starting a race on the main timer the mirror timer would throw errors at the start or end when it didn't recognise event names called by the main timer. This could be due to different plugins across the timers. The changes to EventActions.py are to be more robust to this situation.