### PR TITLE
Improvements to time-format handling

### DIFF
--- a/src/server/Config.py
+++ b/src/server/Config.py
@@ -105,7 +105,7 @@ class Config:
         self.config['UI']['contrast_1_high'] = '#000000'
         self.config['UI']['currentLanguage'] = ''
         self.config['UI']['timeFormat'] = '{m}:{s}.{d}'
-        self.config['UI']['timeFormatPhonetic'] = '{m} {s}.{d}'
+        self.config['UI']['timeFormatPhonetic'] = '{m} {s} point {d}'
         self.config['UI']['pilotSort'] = 'name'
 
         # timing

--- a/src/server/RHUtils.py
+++ b/src/server/RHUtils.py
@@ -41,11 +41,12 @@ def format_time_to_str(millis, timeformat='{m}:{s}.{d}'):
     seconds = over // 1000
     over = over % 1000
     milliseconds = over
+    total_seconds = millis // 1000
 
     if not timeformat:
         timeformat = '{m}:{s}.{d}'
 
-    return timeformat.format(m=str(minutes), s=str(seconds).zfill(2), d=str(milliseconds).zfill(3))
+    return timeformat.format(m=str(minutes), s=str(seconds).zfill(2), d=str(milliseconds).zfill(3), t=str(total_seconds))
 
 def format_split_time_to_str(millis, timeformat='{m}:{s}.{d}'):
     '''Convert milliseconds to 00:00.000 with leading zeros removed'''
@@ -57,25 +58,33 @@ def format_split_time_to_str(millis, timeformat='{m}:{s}.{d}'):
         s = s[p:]
     return s
 
-def format_phonetic_time_to_str(millis, timeformat='{m} {s}.{d}'):
+def format_phonetic_time_to_str(millis, timeformat='{m} {s} point {d}'):
     '''Convert milliseconds to phonetic callout string'''
     if not isinstance(millis, (int, float)):
         return ''
 
-    millis = int(millis) # strip fractional part
+    millis = int(round(millis, 0))  # round to nearest ms
     minutes = millis // 60000
     over = millis % 60000
     seconds = over // 1000
     over = over % 1000
-    tenths = over // 100 # floor at tenths
+    total_seconds = millis // 1000
+    tenths = int(round(over / 100.0))  # round to nearest tenth
+    if tenths > 9:
+        tenths = 0
+        total_seconds += 1
+        seconds += 1
+        if seconds > 59:
+            seconds = 0
+            minutes += 1
 
     if not timeformat:
-        timeformat = '{m} {s}.{d}'
+        timeformat = '{m} {s} point {d}'
 
     if minutes <= 0:
-        return timeformat.format(m='', s=str(seconds), d=str(tenths))
+        return timeformat.format(m='', s=str(seconds), d=str(tenths), t=str(total_seconds))
     else:
-        return timeformat.format(m=str(minutes), s=str(seconds).zfill(2), d=str(tenths))
+        return timeformat.format(m=str(minutes), s=str(seconds).zfill(2), d=str(tenths), t=str(total_seconds))
 
 # Formats the given seconds value to a time-duration string in the form MM:SS:mmm
 def format_secs_to_duration_str(secs_val):

--- a/src/server/static/rotorhazard.js
+++ b/src/server/static/rotorhazard.js
@@ -73,6 +73,7 @@ function formatTimeMillis(s, timeformat='{m}:{s}.{d}') {
 	s = Math.round(s);
 	var ms = s % 1000;
 	s = (s - ms) / 1000;
+	var total_secs = s;
 	var secs = s % 60;
 	var mins = (s - secs) / 60;
 
@@ -82,6 +83,7 @@ function formatTimeMillis(s, timeformat='{m}:{s}.{d}') {
 	var formatted_time = timeformat.replace('{d}', pad(ms, 3));
 	formatted_time = formatted_time.replace('{s}', pad(secs));
 	formatted_time = formatted_time.replace('{m}', mins)
+	formatted_time = formatted_time.replace('{t}', total_secs)
 
 	return formatted_time;
 }

--- a/src/server/templates/settings.html
+++ b/src/server/templates/settings.html
@@ -3185,12 +3185,15 @@
 			<li>
 				<div class="label-block">
 					<label for="set_time_format">{{ __('Time Format') }}</label>
+					<p class="desc">{{ __('Format tokens: {m}=minutes, {s}=seconds (00-59), {d}=milliseconds (000-999), {t}=total seconds from start') }}</p>
+					<p class="desc">{{ __('Example: 1:10.691 with {t}.{d} displays 70.691') }}</p>
 				</div>
 				<input type="text" id="set_time_format" class="set-config" data-section="UI" data-key="timeFormat" value="{{ getConfig('UI', 'timeFormat') }}">
 			</li>
 			<li>
 				<div class="label-block">
 					<label for="set_time_format_phonetic">{{ __('Phonetic Time Format') }}</label>
+					<p class="desc">{{ __('Phonetic {d} uses rounded tenths (0-9); 1:10.691 with {t}.{d} is read as 70.7') }}</p>
 				</div>
 				<input type="text" id="set_time_format_phonetic" class="set-config" data-section="UI" data-key="timeFormatPhonetic" value="{{ getConfig('UI', 'timeFormatPhonetic') }}">
 			</li>

--- a/tools/rhPortableFiles/RotorHazardRun/rh-data/config.json
+++ b/tools/rhPortableFiles/RotorHazardRun/rh-data/config.json
@@ -43,7 +43,7 @@
     "contrast_1_high": "#000000",
     "currentLanguage": "",
     "timeFormat": "{m}:{s}.{d}",
-    "timeFormatPhonetic": "{m} {s}.{d}",
+    "timeFormatPhonetic": "{m} {s} point {d}",
     "pilotSort": "name"
   },
   "USER": {


### PR DESCRIPTION
On the run page and results page there are lots of "zeros" as no lap times are longer than a minute and even "3 consecutive" laps do not add up to a minute. The current time formatting does not consider seconds only from the start. 

This PR introduces the {t} format which is the total time in seconds since the start. e.g. 1:10.691 in {m}:{s}.{d} becomes 70.691 in {t}.{d} format.

A summary has been added to the settings.html

Also the voice call out was truncating the time rather than rounding correctly. Pilots are listening for the lap times being called out and when adding together the numbers they heard against the final board time there was inconsistencies. So this PR includes proper rounding for of the numbers for the call outs.

The voice call out was calling "." as dot but actually "point" is better so this is updated as the default.

1:10.691 in "{m} {s} point {d}" format is read out as  "1 {pause} 10 point 7"
70.691 in "{t} point {d}" format is read out as "70 point 7"



