### PR TITLE
Add debug-only Cancel button to dismiss the restart-required notice

### DIFF
--- a/src/server/RHUI.py
+++ b/src/server/RHUI.py
@@ -2069,6 +2069,10 @@ class RHUI():
         ''' Emits restart required message to all clients '''
         self._socket.emit('restart_required')
 
+    def emit_restart_not_required(self, **params):
+        ''' Emits restart-not-required message to all clients '''
+        self._socket.emit('restart_not_required')
+
     def emit_refresh_page(self, **params):
         ''' Emits refresh-page message '''
         self._socket.emit('refresh_page')

--- a/src/server/RaceContext.py
+++ b/src/server/RaceContext.py
@@ -337,3 +337,10 @@ class ServerState:
             if self._racecontext.rhui:
                 self._racecontext.rhui.emit_upd_cfg_files_list()
                 self._racecontext.rhui.emit_restart_required()
+
+    def clear_restart_required(self):
+        if self.restart_required:
+            self.restart_required = False
+            self.restart_sleep_secs = None
+            if self._racecontext.rhui:
+                self._racecontext.rhui.emit_restart_not_required()

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -1923,6 +1923,11 @@ def on_restart_server():
                 ), True, caller='shutdown')
     gevent.spawn(SOCKET_IO.stop)  # shut down flask http server
 
+@SOCKET_IO.on('cancel_restart_required')
+def on_cancel_restart_required():
+    '''Cancels the pending-restart-required condition.'''
+    RaceContext.serverstate.clear_restart_required()
+
 @SOCKET_IO.on('kill_server')
 @catchLogExceptionsWrapper
 def on_kill_server(*args):

--- a/src/server/static/rotorhazard.js
+++ b/src/server/static/rotorhazard.js
@@ -1736,6 +1736,15 @@ jQuery(document).ready(function($){
 		$('.restart-warning').slideDown();
 	});
 
+	$('button#cancel_restart_required').click(function (event) {
+		socket.emit('cancel_restart_required');
+		return false;
+	});
+
+	socket.on('restart_not_required', function (msg) {
+		$('.restart-warning').slideUp();
+	});
+
 	// load needed data from server when required
 	socket.on('load_all', function (msg) {
 		if (!reloading) {

--- a/src/server/templates/layout.html
+++ b/src/server/templates/layout.html
@@ -109,6 +109,7 @@
 
 	<aside class="restart-warning" {% if not restart_flag %}style="display:none"{% endif %}>
 		{{ __('System settings modified. Restart to apply and avoid unexpected behavior.') }} <a href="#restart_confirm" class="admin-hide btn-danger button-like open-mfp-popup">{{ __('Restart') }}</a>
+		{% if Debug %}<button id="cancel_restart_required" class="admin-hide">{{ __('Cancel') }}</button>{% endif %}
 	</aside>
 
 	<!--Child template content-->


### PR DESCRIPTION
## Summary
- Adds a Cancel button to the "System settings modified..." restart-warning banner that clears the pending restart-required state instead of restarting.
- Button only renders when Server Debug Mode is enabled, alongside the existing admin-only Restart link.
- New `cancel_restart_required` socket event clears the restart flag and broadcasts `restart_not_required` so the banner hides live on all connected clients.

---
Drafted with assistance from Claude Code.