### PR TITLE
Add optional requires_auth to RHAPI/RHUI socket_listen for plugin-registered handlers

### DIFF
--- a/doc/RHAPI.md
+++ b/doc/RHAPI.md
@@ -246,10 +246,11 @@ Send a message which appears as a pop-up alert.
 
 ### Sockets
 
-#### ui.socket_listen(message, handler)
+#### ui.socket_listen(message, handler, requires_auth=False)
 Calls function when a socket event is received.
 - `message` (string): Socket event name
 - `handler` (callable): Function to call
+- `requires_auth` (boolean): if True, `handler` is only invoked for clients that have passed the server's admin authentication (the same check used by the server's own destructive/config-mutating socket handlers)
 
 `handler` is passed socket data as an argument.
 

--- a/src/server/AdminAuth.py
+++ b/src/server/AdminAuth.py
@@ -1,0 +1,94 @@
+#
+# Shared admin-authentication check
+#
+# Kept separate from server.py (rather than defined there) so RHUI.py can
+# reuse the exact same check for plugin-registered SocketIO handlers
+# (RHAPI.socket_listen -> RHUI.socket_listen) without a circular import:
+# server.py imports RHUI, so RHUI can't import back from server.py.
+#
+import functools
+import logging
+from flask import request, session
+
+logger = logging.getLogger(__name__)
+
+Auth_succeeded_flag = False
+
+# cached copy of GENERAL/ADMIN_SOCKET_AUTH; kept in sync by server.py's
+# 'on_set_config' handler via set_admin_socket_auth_enabled()
+_admin_socket_auth_enabled = True
+
+def set_admin_socket_auth_enabled(enabled):
+    global _admin_socket_auth_enabled
+    _admin_socket_auth_enabled = enabled
+
+def check_auth(racecontext, auth):
+    '''Check if a username password combination is valid.'''
+    global Auth_succeeded_flag
+    # allow open access if both ADMIN fields set to empty string:
+    if not racecontext.serverconfig.get_item('SECRETS', 'ADMIN_USERNAME') and \
+        not racecontext.serverconfig.get_item('SECRETS', 'ADMIN_PASSWORD'):
+        Auth_succeeded_flag = True
+        return True
+
+    # allow open access if no config has been set:
+    if racecontext.serverconfig.config_file_status == 0:
+        Auth_succeeded_flag = True
+        return True
+
+    # allow access if user/password match
+    if auth and auth.username and auth.password:
+        if (auth.username == racecontext.serverconfig.get_item('SECRETS', 'ADMIN_USERNAME') and \
+                auth.password == racecontext.serverconfig.get_item('SECRETS', 'ADMIN_PASSWORD')):
+            Auth_succeeded_flag = True
+            return True
+    return False
+
+def make_socketio_auth_guard(racecontext):
+    '''Returns a decorator that guards a SocketIO handler with the shared admin-auth check.
+
+    Unlike an HTTP 401, this cannot send a response back over an
+    established SocketIO connection, so it just logs and drops the
+    event instead of invoking the handler.
+
+    Some handler functions are also called directly (as plain Python
+    calls, not via a dispatched SocketIO event) from server startup and
+    background-thread code, which has no Flask request context. In that
+    case `request.authorization` raises RuntimeError; treat that as a
+    trusted internal call and let it through unchecked.
+
+    A successful check is cached in the SocketIO connection's own
+    session (separate from the browser's HTTP cookie session; reset on
+    disconnect/reload) so later events on the same connection don't
+    re-validate the Basic Auth header. That header is a fixed pair
+    cached by the browser and can't be refreshed mid-connection, so if
+    admin credentials are changed via one guarded event, live-rechecking
+    every subsequent event against the new credentials would reject the
+    browser's now-stale header and lock the page out for the rest of
+    that connection.
+
+    Can be turned off via the 'Admin Socket Auth' setting (Advanced
+    Settings | HTTP Server), which sets GENERAL/ADMIN_SOCKET_AUTH to
+    False.
+    '''
+    def requires_socketio_auth(f):
+        @functools.wraps(f)
+        def decorated_auth(*args, **kwargs):
+            if not _admin_socket_auth_enabled:
+                return f(*args, **kwargs)
+            try:
+                auth = request.authorization
+            except RuntimeError:
+                return f(*args, **kwargs)
+            if session.get('socketio_admin_auth'):
+                return f(*args, **kwargs)
+            if not check_auth(racecontext, auth):
+                logger.warning("Rejected unauthenticated SocketIO event '%s' from %s",
+                                f.__name__, request.remote_addr)
+                racecontext.rhui.emit_priority_message(
+                    racecontext.language.__('Action requires authentication.'), False, nobroadcast=True)
+                return
+            session['socketio_admin_auth'] = True
+            return f(*args, **kwargs)
+        return decorated_auth
+    return requires_socketio_auth

--- a/src/server/RHAPI.py
+++ b/src/server/RHAPI.py
@@ -3,7 +3,7 @@ import functools
 from Database import LapSource
 
 API_VERSION_MAJOR = 1
-API_VERSION_MINOR = 4
+API_VERSION_MINOR = 5
 
 import dataclasses
 import json
@@ -101,8 +101,8 @@ class UserInterfaceAPI():
         self._racecontext.rhui.emit_clear_priority_messages()
 
     # Socket
-    def socket_listen(self, message, handler):
-        self._racecontext.rhui.socket_listen(message, handler)
+    def socket_listen(self, message, handler, requires_auth=False):
+        self._racecontext.rhui.socket_listen(message, handler, requires_auth)
 
     def socket_send(self, message, data):
         self._racecontext.rhui.socket_send(message, data)

--- a/src/server/RHUI.py
+++ b/src/server/RHUI.py
@@ -22,6 +22,7 @@ from RHUtils import catchLogExceptionsWrapper
 from Database import ProgramMethod, RoundType
 from RHRace import RacingMode, RaceStatus
 from filtermanager import Flt
+import AdminAuth
 import logging
 
 logger = logging.getLogger(__name__)
@@ -344,7 +345,14 @@ class RHUI():
         self._app.register_blueprint(blueprint)
 
     # Socket generics
-    def socket_listen(self, message, handler):
+    def socket_listen(self, message, handler, requires_auth=False):
+        '''Registers a SocketIO event handler.
+        :param requires_auth: If True, the handler is guarded by the same
+        admin-authentication check used for the server's own
+        destructive/config-mutating SocketIO handlers.
+        '''
+        if requires_auth:
+            handler = AdminAuth.make_socketio_auth_guard(self._racecontext)(handler)
         self._socket.on_event(message, handler)
 
     def socket_send(self, message, data):

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -65,7 +65,7 @@ import signal
 import werkzeug
 import urllib3
 
-from flask import Flask, send_from_directory, request, make_response, Response, templating, redirect, abort, copy_current_request_context, session
+from flask import Flask, send_from_directory, request, make_response, Response, templating, redirect, abort, copy_current_request_context
 from flask.blueprints import Blueprint
 from flask_socketio import SocketIO, emit
 
@@ -171,6 +171,7 @@ import EventActions
 import RaceContext
 import RHData
 import RHUI
+import AdminAuth
 import calibration
 import heat_automation
 import RHAPI
@@ -232,7 +233,6 @@ Server_ipaddress_str = None
 ShutdownButtonInputHandler = None
 Server_secondary_mode = None
 HardwareHelpers = {}
-Auth_succeeded_flag = False
 
 SERVER_PROCESS_RESTART_FLAG = False
 HEARTBEAT_THREAD = None
@@ -240,7 +240,7 @@ BACKGROUND_THREADS_ENABLED = True
 HEARTBEAT_DATA_RATE_FACTOR = 5
 
 # cached copy of GENERAL/ADMIN_SOCKET_AUTH; kept in sync by 'on_set_config'
-ADMIN_SOCKET_AUTH_ENABLED = RaceContext.serverconfig.get_item('GENERAL', 'ADMIN_SOCKET_AUTH')
+AdminAuth.set_admin_socket_auth_enabled(RaceContext.serverconfig.get_item('GENERAL', 'ADMIN_SOCKET_AUTH'))
 
 ERROR_REPORT_INTERVAL_SECS = 600  # delay between comm-error reports to log
 
@@ -304,7 +304,7 @@ def log_error_callback_fn(*args):
         RaceContext.rhui.set_ui_message("errors-logged",\
                    f'{__("Error messages have been logged.")} (<a href=\"/hardwarelog?log_level=ERROR\">{__("View error log")}</a>)',\
                    header="Notice", subclass="errors-logged")
-        if Auth_succeeded_flag:
+        if AdminAuth.Auth_succeeded_flag:
             SOCKET_IO.emit('update_server_messages', RaceContext.rhui.get_ui_server_messages_str())
     if check_log_error_alert():  # show alert popup if not previously shown
         log.set_log_level_callback(logging.NOTSET)  # if popup shown then clear callback function
@@ -386,7 +386,7 @@ def getFwfileProctypeStr(fileStr):
 
 # Shows an alert popup if error messages have been logged and popup was not previously shown
 def check_log_error_alert():
-    if Auth_succeeded_flag and log.get_log_error_alert_flag():
+    if AdminAuth.Auth_succeeded_flag and log.get_log_error_alert_flag():
         gevent.spawn_later(1.0, RaceContext.rhui.emit_priority_message,\
                 f'{__("An error has occurred.")}<br /><a href="/hardwarelog?log_level=ERROR">{__("View error log")}</a>',\
                 True, False, True)  # admin_only=True
@@ -396,28 +396,9 @@ def check_log_error_alert():
 #
 # Authentication
 #
-
-def check_auth(auth):
-    '''Check if a username password combination is valid.'''
-    global Auth_succeeded_flag
-    # allow open access if both ADMIN fields set to empty string:
-    if not RaceContext.serverconfig.get_item('SECRETS', 'ADMIN_USERNAME') and \
-        not RaceContext.serverconfig.get_item('SECRETS', 'ADMIN_PASSWORD'):
-        Auth_succeeded_flag = True
-        return True
-
-    # allow open access if no config has been set:
-    if RaceContext.serverconfig.config_file_status == 0:
-        Auth_succeeded_flag = True
-        return True
-
-    # allow access if user/password match
-    if auth and auth.username and auth.password:
-        if (auth.username == RaceContext.serverconfig.get_item('SECRETS', 'ADMIN_USERNAME') and \
-                auth.password == RaceContext.serverconfig.get_item('SECRETS', 'ADMIN_PASSWORD')):
-            Auth_succeeded_flag = True
-            return True
-    return False
+# check_auth() and the SocketIO auth guard live in AdminAuth.py so RHUI.py
+# can reuse them for plugin-registered handlers (RHAPI.socket_listen)
+# without a circular import back to this module.
 
 def authenticate():
     '''Sends a 401 response that enables basic auth.'''
@@ -429,51 +410,12 @@ def authenticate():
 def requires_auth(f):
     @functools.wraps(f)
     def decorated_auth(*args, **kwargs):
-        if not check_auth(request.authorization):
+        if not AdminAuth.check_auth(RaceContext, request.authorization):
             return authenticate()
         return f(*args, **kwargs)
     return decorated_auth
 
-def requires_socketio_auth(f):
-    '''Guards administrative/destructive SocketIO event handlers.
-    Unlike @requires_auth, this cannot return an HTTP 401 (there is no
-    HTTP response to send back over an established SocketIO connection),
-    so it just logs and drops the event instead of invoking the handler.
-    Several of these handler functions are also called directly (as plain
-    Python calls, not via a dispatched SocketIO event) from server startup
-    and background-thread code, which has no Flask request context. In
-    that case `request.authorization` raises RuntimeError; treat that as
-    a trusted internal call and let it through unchecked.
-    A successful check is cached in the SocketIO connection's own session
-    (separate from the browser's HTTP cookie session; reset on
-    disconnect/reload) so later events on the same connection don't
-    re-validate the Basic Auth header. That header is a fixed pair cached
-    by the browser and can't be refreshed mid-connection, so if admin
-    credentials are changed via one guarded event, live-rechecking every
-    subsequent event against the new credentials would reject the
-    browser's now-stale header and lock the page out for the rest of
-    that connection.
-    Can be turned off via the 'Admin Socket Auth' setting (Advanced
-    Settings | HTTP Server), which sets GENERAL/ADMIN_SOCKET_AUTH to False.
-    '''
-    @functools.wraps(f)
-    def decorated_auth(*args, **kwargs):
-        if not ADMIN_SOCKET_AUTH_ENABLED:
-            return f(*args, **kwargs)
-        try:
-            auth = request.authorization
-        except RuntimeError:
-            return f(*args, **kwargs)
-        if session.get('socketio_admin_auth'):
-            return f(*args, **kwargs)
-        if not check_auth(auth):
-            logger.warning("Rejected unauthenticated SocketIO event '%s' from %s",
-                            f.__name__, request.remote_addr)
-            RaceContext.rhui.emit_priority_message(__('Action requires authentication.'), False, nobroadcast=True)
-            return
-        session['socketio_admin_auth'] = True
-        return f(*args, **kwargs)
-    return decorated_auth
+requires_socketio_auth = AdminAuth.make_socketio_auth_guard(RaceContext)
 
 # Flask template render with exception catch, so exception
 # details are sent to the log file (instead of 'stderr').
@@ -2743,8 +2685,7 @@ def on_set_option(data):
 def on_set_config(data):
     RaceContext.serverconfig.set_item(data['section'], data['key'], data['value'])
     if data['section'] == 'GENERAL' and data['key'] == 'ADMIN_SOCKET_AUTH':
-        global ADMIN_SOCKET_AUTH_ENABLED
-        ADMIN_SOCKET_AUTH_ENABLED = data['value']
+        AdminAuth.set_admin_socket_auth_enabled(data['value'])
     Events.trigger(Evt.CONFIG_SET, {
         'section': data['section'],
         'key': data['key'],


### PR DESCRIPTION
## Summary
- `RHUI.socket_listen()` — the mechanism behind `RHAPI.socket_listen()`, which plugins use to register their own SocketIO event handlers — registered handlers with no authentication at all, entirely outside the admin-auth guard added in #1152 (already merged). That work only covers the ~90 hardcoded handlers in `server.py`; any plugin-registered handler (e.g. the FPVTrackSide connector) was still fully unauthenticated regardless.
- Adds `requires_auth=False` to both `RHAPI.socket_listen()` and `RHUI.socket_listen()`. When `True`, the handler is wrapped with the same admin-auth check used by the server's own guarded handlers — including the "Admin Socket Auth" live toggle and the per-connection session-caching behavior from #1152.
- Extracted the shared check into `AdminAuth.py` (`check_auth()` + `make_socketio_auth_guard()`), following the existing `FlaskAppObj.py` pattern for avoiding circular imports back into `server.py`. `server.py`'s own `requires_socketio_auth` is now a one-line `AdminAuth.make_socketio_auth_guard(RaceContext)` assignment — no changes needed at any of its ~90 existing call sites.
- Bumped `RHAPI.API_VERSION_MINOR` 4 → 5 and updated `doc/RHAPI.md`, matching this project's existing convention of bumping the minor version for every additive RHAPI change, so plugins can correctly declare `required_rhapi_version` and get a clean load-time rejection on older servers instead of a raw `TypeError`.
- Fully backward compatible: the new parameter defaults to `False`, and `RHUI.socket_listen()`'s code path when unset is identical to before.

---
*Drafted with assistance from Claude Code.*