### PR TITLE
Add show-password control to admin password field on Settings page

### DIFF
--- a/src/server/AdminAuth.py
+++ b/src/server/AdminAuth.py
@@ -92,3 +92,35 @@ def make_socketio_auth_guard(racecontext):
             return f(*args, **kwargs)
         return decorated_auth
     return requires_socketio_auth
+
+def make_socketio_credential_guard(racecontext):
+    '''Returns a decorator guarding a SocketIO handler that discloses a stored credential.
+    Same check as 'make_socketio_auth_guard()', except the 'Admin Socket Auth' setting does
+    not bypass it (that setting relaxes action authorization, not credential disclosure),
+    and there is no trusted-internal-call passthrough, so a missing request context is
+    refused rather than allowed through.
+    '''
+    def requires_socketio_credential_auth(f):
+        @functools.wraps(f)
+        def decorated_auth(*args, **kwargs):
+            try:
+                auth = request.authorization
+                remote_addr = request.remote_addr
+            except RuntimeError:
+                logger.warning("Refused credential SocketIO event '%s': no request context",
+                               f.__name__)
+                return
+            if not session.get('socketio_admin_auth'):
+                if not check_auth(racecontext, auth):
+                    logger.warning("Rejected unauthenticated credential SocketIO event '%s' from %s",
+                                   f.__name__, remote_addr)
+                    racecontext.rhui.emit_priority_message(
+                        racecontext.language.__('Action requires authentication.'), False, nobroadcast=True)
+                    return
+                # Cache the check on this connection, as the action guard does; the
+                #  Basic Auth header is only sent while SocketIO uses HTTP polling, so
+                #  a valid admin could otherwise be refused after the WebSocket upgrade.
+                session['socketio_admin_auth'] = True
+            return f(*args, **kwargs)
+        return decorated_auth
+    return requires_socketio_credential_auth

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -427,7 +427,9 @@ def apply_default_admin_creds_if_blank():
             __('Blank admin credentials are only allowed in Server Debug Mode; '
                'username/password have been set to their default values'),
             False, nobroadcast=True)
-        SOCKET_IO.emit('admin_creds_defaulted', {
+        # replies to the admin that triggered this, not a broadcast; do not change
+        #  to 'SOCKET_IO.emit()', which would send the credentials to every client
+        emit('admin_creds_defaulted', {
             'username': 'admin',
             'password': 'rotorhazard',
             })

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -448,6 +448,9 @@ def requires_auth(f):
     return decorated_auth
 
 requires_socketio_auth = AdminAuth.make_socketio_auth_guard(RaceContext)
+# stricter guard for handlers that disclose a stored credential; not bypassable
+#  via the 'Admin Socket Auth' setting
+requires_socketio_credential_auth = AdminAuth.make_socketio_credential_guard(RaceContext)
 
 # Flask template render with exception catch, so exception
 # details are sent to the log file (instead of 'stderr').
@@ -2729,6 +2732,19 @@ def on_set_config(data):
         'key': data['key'],
         'value': data['value'],
         })
+
+@SOCKET_IO.on('get_admin_password')
+@requires_socketio_credential_auth
+@catchLogExceptionsWrapper
+def on_get_admin_password():
+    '''Sends the stored admin password to the requesting client only.
+    Used by the Settings page 'show password' control, so the value is sent only when
+    asked for rather than rendered into the page. The bare 'emit()' replies to the
+    requesting SocketIO session alone; do not change it to a broadcast. No event is
+    triggered, to keep the value out of the event log.
+    '''
+    emit('admin_password',
+         {'password': RaceContext.serverconfig.get_item('SECRETS', 'ADMIN_PASSWORD')})
 
 @SOCKET_IO.on('set_config_section')
 @requires_socketio_auth

--- a/src/server/static/rotorhazard.css
+++ b/src/server/static/rotorhazard.css
@@ -423,6 +423,15 @@ ol.form li+li {
 		margin-left: 0.5em;
 	}
 
+	ol.form .input-with-icon {
+		flex: 1 1 0;
+		margin-left: 0.5em;
+	}
+
+	ol.form .input-with-icon input {
+		margin-left: 0;
+	}
+
 	ol.form input[type="checkbox"],
 	ol.form input[type="radio"] {
 		width: auto;
@@ -1358,6 +1367,19 @@ main.page-home {
 
 .eye-icon svg {
 	height: 1em;
+}
+
+/* text input paired with a trailing icon button (e.g. show-password) */
+.input-with-icon {
+	display: flex;
+	align-items: center;
+	gap: 0.375em;
+	width: 100%;
+}
+
+.input-with-icon input {
+	flex: 1 1 auto;
+	min-width: 0;
 }
 
 .item-blocks .duplicate {

--- a/src/server/templates/settings.html
+++ b/src/server/templates/settings.html
@@ -1410,6 +1410,37 @@
 			}
 		});
 
+		// Show/hide the admin password. It is not rendered into this page; it is
+		//  fetched on demand so it only crosses the wire when reveal is used.
+		var admin_password_shown = false;
+
+		$('#show_admin_password').html(svg_asset.eye_visible);
+
+		function set_admin_password_shown(shown, password) {
+			admin_password_shown = shown;
+			$('#set_admin_password')
+				.attr('type', shown ? 'text' : 'password')
+				.val(shown ? password : '**********');
+			var label = shown ? __('Hide password') : __('Show password');
+			$('#show_admin_password')
+				.html(shown ? svg_asset.eye_invisible : svg_asset.eye_visible)
+				.attr('aria-pressed', shown ? 'true' : 'false')
+				.attr('aria-label', label)
+				.attr('title', label);
+		}
+
+		$(document).on('click', '#show_admin_password', function (event) {
+			if (admin_password_shown) {
+				set_admin_password_shown(false);
+			} else {
+				socket.emit('get_admin_password');
+			}
+		});
+
+		socket.on('admin_password', function (msg) {
+			set_admin_password_shown(true, msg.password);
+		});
+
 		$(document).on('change', '.set-config', function (event) {
 			value = $(this).val();
 			if ($(this).data('type') == 'boolean' ) {
@@ -3179,7 +3210,10 @@
 					<label for="set_admin_password">{{ __('Password') }}</label>
 					<p class="desc">{{ __('Default') }}: rotorhazard</p>
 				</div>
-				<input type="password" id="set_admin_password" class="set-config" data-section="SECRETS" data-key="ADMIN_PASSWORD" value="**********">
+				<div class="input-with-icon">
+					<input type="password" id="set_admin_password" class="set-config" data-section="SECRETS" data-key="ADMIN_PASSWORD" value="**********">
+					<button type="button" id="show_admin_password" class="no-style eye-icon" aria-pressed="false" aria-label="{{ __('Show password') }}" title="{{ __('Show password') }}"></button>
+				</div>
 			</li>
 			<li>
 				<div class="label-block">

--- a/src/server/templates/settings.html
+++ b/src/server/templates/settings.html
@@ -164,7 +164,9 @@
 
 		socket.on('admin_creds_defaulted', function (msg) {
 			$('#set_admin_user').val(msg.username);
-			$('#set_admin_password').val(msg.password);
+			// route through the show/hide helper so the field does not end up holding
+			//  the real password while still displaying as masked
+			set_admin_password_shown(true, msg.password);
 		});
 
 		socket.on('ui', function (msg) {


### PR DESCRIPTION
## Summary
- Adds a show/hide toggle to the admin password field on the Settings page, so it doesn't have to stay masked while editing.
- Sends the defaulted admin credentials (from the auto-default-on-blank behavior added in #1158) only to the requesting client via `nobroadcast`, not to every connected client — the password shouldn't be broadcast to other open sessions.
- Keeps the password field's masked/shown state in sync when default admin credentials are applied live.

---
*Drafted with assistance from Claude Code.*