### PR TITLE
Store split times and speeds with saved race data

### DIFF
--- a/doc/RHAPI.md
+++ b/doc/RHAPI.md
@@ -1059,6 +1059,37 @@ All lap records. Returns `list[SavedRaceLap]`.
 Lap records matching the provided pilot run ID. Returns `list[SavedRaceLap]`.
 - `run_id` (int): ID of pilot run used to retrieve laps
 
+### Saved Race &rarr; Pilot Run &rarr; Lap Splits
+Lap splits store data related to split-timer crossings reported by secondary timers running in `split` mode. Each pilot run may have zero or more lap splits associated with it. Splits are only recorded when split timers are in use, and `split_speed` is only populated when the secondary timer is configured with a `distance` value.
+
+Lap splits are represented with the `SavedRaceLapSplit` class, which has the following properties:
+- `id` (int): Internal identifier
+- `race_id` (int): ID of associated saved race
+- `pilotrace_id` (int): ID of associated pilot run
+- `node_index` (int): Seat number
+- `pilot_id` (int): ID of associated pilot
+- `lap_id` (int): Number of the lap during which the split was recorded
+- `split_id` (int): Index of the split timer that recorded the crossing
+- `split_time_stamp` (float): Milliseconds since race start time
+- `split_time` (float): Milliseconds since previous split (or since the start of the lap)
+- `split_time_formatted` (string): Formatted user-facing text
+- `split_speed` (float): Recorded speed, or `None` if not available
+- `speed_only` (boolean): True if the record was generated for a speed callout and is not part of the lap's split sequence
+
+Lap splits are stored against the pilot run and lap number rather than against an individual `SavedRaceLap` record, so they are not renumbered when a race is marshaled.
+
+#### db.saved_lap_splits
+_Read only_
+All saved lap split records. Returns `list[SavedRaceLapSplit]`.
+
+#### db.saved_lap_splits_by_pilotrun(run_id)
+Saved lap split records matching the provided pilot run ID. Returns `list[SavedRaceLapSplit]`.
+- `run_id` (int): ID of pilot run used to retrieve lap splits
+
+#### db.saved_lap_splits_by_race(race_id)
+Saved lap split records matching the provided saved race ID. Returns `list[SavedRaceLapSplit]`.
+- `race_id` (int): ID of saved race used to retrieve lap splits
+
 
 ### Options
 Options are settings that apply to a server globally.

--- a/src/server/ClusterNodeSet.py
+++ b/src/server/ClusterNodeSet.py
@@ -525,6 +525,7 @@ class SecondaryNode:
                                         'speed_callout_flag': self.speedCalloutFlag,
                                         'name_callout_flag': self.nameCalloutFlag
                                     }
+                                    self._racecontext.race.add_split_speed_record(split_data)
                                     self._racecontext.rhui.emit_phonetic_split(split_data)
                                     eventStr = self.info.get('event')
                                     if eventStr and len(eventStr) > 0:

--- a/src/server/ClusterNodeSet.py
+++ b/src/server/ClusterNodeSet.py
@@ -420,6 +420,9 @@ class SecondaryNode:
                             # convert split timestamp (epoch ms since 1970-01-01) to equivalent local 'monotonic' time value
                             split_ts = split_ts_epoch_ms - self._racecontext.race.start_time_epoch_ms
 
+                            # a speed after the pilot is done is called out but not stored
+                            pilot_done_flag = bool(self._racecontext.race.get_node_finished_flag(node_index))
+
                             act_laps_list = self._racecontext.race.get_active_laps(late_lap_flag=True)[node_index]
                             lap_count = max(0, len(act_laps_list) - 1)
                             split_id = self.id
@@ -485,7 +488,8 @@ class SecondaryNode:
                                     'name_callout_flag': self.nameCalloutFlag
                                 }
 
-                                self._racecontext.rhdata.add_lapSplit(split_data)
+                                self._racecontext.rhdata.add_lapSplit(
+                                        dict(split_data, split_speed=None) if pilot_done_flag else split_data)
                                 self._racecontext.rhui.emit_split_pass_info(split_data)
                                 eventStr = self.info.get('event')
                                 if eventStr and len(eventStr) > 0:
@@ -525,7 +529,8 @@ class SecondaryNode:
                                         'speed_callout_flag': self.speedCalloutFlag,
                                         'name_callout_flag': self.nameCalloutFlag
                                     }
-                                    self._racecontext.race.add_split_speed_record(split_data)
+                                    if not pilot_done_flag:
+                                        self._racecontext.race.add_split_speed_record(split_data)
                                     self._racecontext.rhui.emit_phonetic_split(split_data)
                                     eventStr = self.info.get('event')
                                     if eventStr and len(eventStr) > 0:

--- a/src/server/Database.py
+++ b/src/server/Database.py
@@ -366,6 +366,24 @@ class SavedRaceLap(Base):
     def __repr__(self):
         return '<SavedRaceLap %r>' % self.id
 
+class SavedRaceLapSplit(Base):
+    __tablename__ = 'saved_race_lap_split'
+    id = DB.Column(DB.Integer, primary_key=True)
+    race_id = DB.Column(DB.Integer, DB.ForeignKey("saved_race_meta.id"), nullable=False)
+    pilotrace_id = DB.Column(DB.Integer, DB.ForeignKey("saved_pilot_race.id"), nullable=False)
+    node_index = DB.Column(DB.Integer, nullable=False)
+    pilot_id = DB.Column(DB.Integer, DB.ForeignKey("pilot.id"), nullable=True)
+    lap_id = DB.Column(DB.Integer, nullable=False)
+    split_id = DB.Column(DB.Integer, nullable=False)
+    split_time_stamp = DB.Column(DB.Float, nullable=False)
+    split_time = DB.Column(DB.Float, nullable=False)
+    split_time_formatted = DB.Column(DB.String, nullable=True)
+    split_speed = DB.Column(DB.Float, nullable=True)
+    speed_only = DB.Column(DB.Boolean, nullable=False, default=False)
+
+    def __repr__(self):
+        return '<SavedRaceLapSplit %r>' % self.id
+
 class LapSource:
     REALTIME = 0
     MANUAL = 1

--- a/src/server/PageCache.py
+++ b/src/server/PageCache.py
@@ -123,6 +123,9 @@ class PageCache:
             ))
             for heat in all_heats:
                 if self._racecontext.rhdata.savedRaceMetas_has_heat(heat.id):
+                    # a class format overrides the format saved with the race
+                    race_class = self._racecontext.rhdata.get_raceClass(heat.class_id)
+                    class_format_id = race_class.format_id if race_class else None
                     rounds = []
                     for race in self._racecontext.rhdata.get_savedRaceMetas_by_heat(heat.id):    
                         pilotraces = []
@@ -163,9 +166,12 @@ class PageCache:
                             })
 
                         results = self._racecontext.rhdata.get_results_savedRaceMeta(race)
+                        race_format = self._racecontext.rhdata.get_raceFormat(
+                                            class_format_id if class_format_id else race.format_id)
                         rounds.append({
                             'id': race.round_id,
                             'start_time_formatted': race.start_time_formatted,
+                            'format_name': race_format.name if race_format else None,
                             'nodes': pilotraces,
                             'leaderboard': results
                         })

--- a/src/server/PageCache.py
+++ b/src/server/PageCache.py
@@ -128,7 +128,14 @@ class PageCache:
                         pilotraces = []
                         for pilotrace in self._racecontext.rhdata.get_savedPilotRaces_by_savedRaceMeta(race.id):
                             gevent.sleep(0.001)
+                            # use first recorded speed for each lap, by index among the non-deleted laps
+                            lap_speeds = {}
+                            for lap_split in self._racecontext.rhdata.get_savedRaceLapSplits_by_savedPilotRace(pilotrace.id):
+                                if lap_split.split_speed is not None and lap_split.lap_id not in lap_speeds:
+                                    lap_speeds[lap_split.lap_id] = lap_split.split_speed
+
                             laps = []
+                            lap_index = 0
                             for lap in self._racecontext.rhdata.get_savedRaceLaps_by_savedPilotRace(pilotrace.id):
                                 laps.append({
                                     'id': lap.id,
@@ -136,8 +143,11 @@ class PageCache:
                                     'lap_time': lap.lap_time,
                                     'lap_time_formatted': lap.lap_time_formatted,
                                     'source': lap.source,
-                                    'deleted': lap.deleted
+                                    'deleted': lap.deleted,
+                                    'speed': None if lap.deleted else lap_speeds.get(lap_index)
                                 })
+                                if not lap.deleted:
+                                    lap_index += 1
 
                             pilot_data = self._racecontext.rhdata.get_pilot(pilotrace.pilot_id)
                             if pilot_data:

--- a/src/server/RHAPI.py
+++ b/src/server/RHAPI.py
@@ -3,7 +3,7 @@ import functools
 from Database import LapSource
 
 API_VERSION_MAJOR = 1
-API_VERSION_MINOR = 5
+API_VERSION_MINOR = 6
 
 import dataclasses
 import json
@@ -828,6 +828,19 @@ class DatabaseAPI():
     @callWithDatabaseWrapper
     def lap_splits(self):
         return self._racecontext.rhdata.get_lapSplits()
+
+    @property
+    @callWithDatabaseWrapper
+    def saved_lap_splits(self):
+        return self._racecontext.rhdata.get_savedRaceLapSplits()
+
+    @callWithDatabaseWrapper
+    def saved_lap_splits_by_pilotrun(self, run_id):
+        return self._racecontext.rhdata.get_savedRaceLapSplits_by_savedPilotRace(run_id)
+
+    @callWithDatabaseWrapper
+    def saved_lap_splits_by_race(self, race_id):
+        return self._racecontext.rhdata.get_savedRaceLapSplits_by_savedRaceMeta(race_id)
 
     # Options
 

--- a/src/server/RHData.py
+++ b/src/server/RHData.py
@@ -3676,6 +3676,21 @@ class RHData():
         self.commit()
         return True
 
+    def shift_lapSplits(self, node_index, from_lap_id, delta):
+        '''Shifts split lap ids to track laps renumbered by a lap delete or restore.'''
+        lap_splits = Database.LapSplit.query.filter(
+            Database.LapSplit.node_index == node_index,
+            Database.LapSplit.lap_id >= from_lap_id
+            ).all()
+        # apply lowest first when shifting down, highest first when shifting up,
+        #  so no row ever lands on a lap id still held by another
+        lap_splits.sort(key=lambda lap_split: lap_split.lap_id, reverse=(delta > 0))
+        for lap_split in lap_splits:
+            lap_split.lap_id += delta
+            Database.DB_session.flush()
+        self.commit()
+        return len(lap_splits)
+
     def clear_lapSplits(self):
         Database.DB_session.query(Database.LapSplit).delete()
         self.commit()

--- a/src/server/RHData.py
+++ b/src/server/RHData.py
@@ -433,6 +433,7 @@ class RHData():
             raceMeta_query_data = self.get_legacy_table_data(engine, metadata, 'saved_race_meta')
             racePilot_query_data = self.get_legacy_table_data(engine, metadata, 'saved_pilot_race')
             raceLap_query_data = self.get_legacy_table_data(engine, metadata, 'saved_race_lap')
+            raceLapSplit_query_data = self.get_legacy_table_data(engine, metadata, 'saved_race_lap_split')
             pilotAttribute_query_data = self.get_legacy_table_data(engine, metadata, 'pilot_attribute')
             heatAttribute_query_data = self.get_legacy_table_data(engine, metadata, 'heat_attribute')
             raceClassAttribute_query_data = self.get_legacy_table_data(engine, metadata, 'race_class_attribute')
@@ -806,6 +807,12 @@ class RHData():
                         self.restore_table(Database.SavedRaceLap, raceLap_query_data, defaults={
                             'source': None,
                             'deleted': False
+                        })
+
+                        self.restore_table(Database.SavedRaceLapSplit, raceLapSplit_query_data, defaults={
+                            'split_time_formatted': None,
+                            'split_speed': None,
+                            'speed_only': False
                         })
 
                         self.restore_table(Database.SavedRaceMetaAttribute, savedRaceAttribute_query_data, defaults={
@@ -1414,6 +1421,9 @@ class RHData():
                     for race_lap in Database.SavedRaceLap.query.filter_by(race_id=race_meta.id):
                         if race_lap.node_index == slot.node_index:
                             race_lap.pilot_id = data['pilot']
+                    for lap_split in Database.SavedRaceLapSplit.query.filter_by(race_id=race_meta.id):
+                        if lap_split.node_index == slot.node_index:
+                            lap_split.pilot_id = data['pilot']
 
                     self.clear_results_savedRaceMeta(race_meta)
 
@@ -3252,6 +3262,8 @@ class RHData():
                     pilot_race.pilot_id = np.pilot_id
                     for lap in self.get_savedRaceLaps_by_savedPilotRace(pilot_race.id):
                         lap.pilot_id = np.pilot_id
+                    for lap_split in self.get_savedRaceLapSplits_by_savedPilotRace(pilot_race.id):
+                        lap_split.pilot_id = np.pilot_id
                     break
 
                 if pilot_race.node_index == np.node_index:
@@ -3503,6 +3515,19 @@ class RHData():
     def get_active_savedRaceLaps_by_savedPilotRace(self, pilotrace_id):
         return Database.SavedRaceLap.query.filter(Database.SavedRaceLap.deleted != 1, Database.SavedRaceLap.pilotrace_id == pilotrace_id).order_by(Database.SavedRaceLap.lap_time_stamp).all()
 
+    # Race Lap Splits
+    def get_savedRaceLapSplits(self):
+        return Database.SavedRaceLapSplit.query.all()
+
+    def get_savedRaceLapSplits_by_savedPilotRace(self, pilotrace_id):
+        return Database.SavedRaceLapSplit.query.filter_by(pilotrace_id=pilotrace_id) \
+            .order_by(Database.SavedRaceLapSplit.lap_id, Database.SavedRaceLapSplit.split_id).all()
+
+    def get_savedRaceLapSplits_by_savedRaceMeta(self, race_id):
+        return Database.SavedRaceLapSplit.query.filter_by(race_id=race_id) \
+            .order_by(Database.SavedRaceLapSplit.node_index, Database.SavedRaceLapSplit.lap_id, \
+                      Database.SavedRaceLapSplit.split_id).all()
+
     # Race general
     def replace_savedRaceLaps(self, data):
         Database.SavedRaceLap.query.filter_by(pilotrace_id=data['pilotrace_id']).delete()
@@ -3558,12 +3583,28 @@ class RHData():
                     peak_rssi=lap.peak_rssi
                 ))
 
+            for split in node_data.get('splits') or []:
+                Database.DB_session.add(Database.SavedRaceLapSplit(
+                    race_id=node_data['race_id'],
+                    pilotrace_id=new_pilotrace.id,
+                    node_index=node_index,
+                    pilot_id=node_data['pilot_id'],
+                    lap_id=split['lap_id'],
+                    split_id=split['split_id'],
+                    split_time_stamp=split['split_time_stamp'],
+                    split_time=split['split_time'],
+                    split_time_formatted=split.get('split_time_formatted'),
+                    split_speed=split.get('split_speed'),
+                    speed_only=split.get('speed_only', False)
+                ))
+
         self.commit()
         return True
 
     def clear_race_data(self):
         Database.DB_session.query(Database.SavedRaceMetaAttribute).delete()
         Database.DB_session.query(Database.LapSplit).delete()
+        Database.DB_session.query(Database.SavedRaceLapSplit).delete()
         Database.DB_session.query(Database.SavedRaceLap).delete()
         Database.DB_session.query(Database.SavedPilotRace).delete()
         Database.DB_session.query(Database.SavedRaceMeta).delete()
@@ -3584,6 +3625,11 @@ class RHData():
             node_index=node_index,
             lap_id=lap_id
             ).all()
+
+    def get_lapSplits_by_node(self, node_index):
+        return Database.LapSplit.query.filter_by(
+            node_index=node_index
+            ).order_by(Database.LapSplit.lap_id, Database.LapSplit.split_id).all()
 
     def get_lapSplit_by_params(self, node_index, lap_id, split_id):
         return Database.LapSplit.query.filter_by(

--- a/src/server/RHRace.py
+++ b/src/server/RHRace.py
@@ -1281,6 +1281,8 @@ class RHRace():
                 if lap_splits and len(lap_splits) > 0:
                     for lap_split in lap_splits:
                         self._racecontext.rhdata.clear_lapSplit(lap_split)
+                if deleted_lap_number is not None:  # move later splits down to match renumbered laps
+                    self._racecontext.rhdata.shift_lapSplits(node_index, deleted_lap_number + 1, -1)
             except:
                 logger.exception("Error deleting split laps")
 
@@ -1355,6 +1357,12 @@ class RHRace():
             lap_obj.late_lap = False
 
             self.calc_lap_times(node_index, lap_index)
+
+            try:  # move later splits up to match renumbered laps
+                if lap_obj.lap_number is not None:
+                    self._racecontext.rhdata.shift_lapSplits(node_index, lap_obj.lap_number, 1)
+            except:
+                logger.exception("Error shifting split laps")
 
             self._racecontext.events.trigger(Evt.LAP_RESTORE_DELETED, {
                 'node_index': node_index,

--- a/src/server/RHRace.py
+++ b/src/server/RHRace.py
@@ -77,6 +77,7 @@ class RHRace():
         self.coop_best_time = 0.0  # best time achieved in co-op racing mode (seconds)
         self.coop_num_laps = 0     # best # of laps in co-op racing mode
         self.node_laps = {} # current race lap objects, by node
+        self.node_split_speeds = {} # speed-only split records not tracked in the lap-splits table, by node
         self.node_has_finished = {}     # True if pilot for node has finished race
         self.node_finished_effect = {}  # True if effect for pilot-finished for node has been triggered
         self.node_fin_effect_wait_count = 0  # number of finished effects waiting for all crossings completed
@@ -728,6 +729,7 @@ class RHRace():
                             'exit_at': self._racecontext.interface.nodes[node_index].exit_at_level,
                             'frequency': self._racecontext.interface.nodes[node_index].frequency,
                             'laps': self.node_laps[node_index],
+                            'splits': self.build_splits_save_list(node_index),
                             'marshal_type': self._racecontext.interface.node_map[node_index].interface.marshal_type
                             }
 
@@ -1436,8 +1438,10 @@ class RHRace():
     def reset_current_laps(self):
         '''Resets database current laps to default.'''
         self.node_laps = {}
+        self.node_split_speeds = {}
         for idx in range(self.num_nodes):
             self.node_laps[idx] = []
+            self.node_split_speeds[idx] = []
 
         self.clear_results()
         logger.debug('Database current laps reset')
@@ -1794,6 +1798,40 @@ class RHRace():
                             'split_time': '-'
                         }
                     splits.append(split_payload)
+        return splits
+
+    def add_split_speed_record(self, split_data):
+        '''Stores a speed-only split record, which is not tracked in the lap-splits table.'''
+        node_index = split_data['node_index']
+        if node_index not in self.node_split_speeds:
+            self.node_split_speeds[node_index] = []
+        self.node_split_speeds[node_index].append(split_data)
+
+    def build_splits_save_list(self, node_index):
+        '''Builds the list of split records for a node to be stored with the saved race.'''
+        splits = []
+        for split in self._racecontext.rhdata.get_lapSplits_by_node(node_index):
+            # rebuild the formatted time
+            splits.append({
+                'lap_id': split.lap_id,
+                'split_id': split.split_id,
+                'split_time_stamp': split.split_time_stamp,
+                'split_time': split.split_time,
+                'split_time_formatted': RHUtils.format_split_time_to_str(split.split_time, \
+                                        self._racecontext.serverconfig.get_item('UI', 'timeFormat')),
+                'split_speed': split.split_speed,
+                'speed_only': False
+                })
+        for split in self.node_split_speeds.get(node_index) or []:
+            splits.append({
+                'lap_id': split['lap_id'],
+                'split_id': split['split_id'],
+                'split_time_stamp': split['split_time_stamp'],
+                'split_time': split['split_time'],
+                'split_time_formatted': split.get('split_time_formatted'),
+                'split_speed': split.get('split_speed'),
+                'speed_only': True
+                })
         return splits
 
     def get_lap_results(self):

--- a/src/server/RHRace.py
+++ b/src/server/RHRace.py
@@ -1226,6 +1226,9 @@ class RHRace():
         '''Delete a false lap.'''
 
         with self._racecontext.rhdata.get_db_session_handle():  # make sure DB session/connection is cleaned up
+            # save lap number before it is cleared by the renumbering below
+            deleted_lap_number = self.node_laps[node_index][lap_index].lap_number
+
             # mark lap deleted
             self.node_laps[node_index][lap_index].deleted = True
 
@@ -1274,7 +1277,7 @@ class RHRace():
                 lap_following.lap_time_formatted = RHUtils.format_time_to_str(lap_following.lap_time, self._racecontext.serverconfig.get_item('UI', 'timeFormat'))
 
             try:  # delete any split laps for deleted lap
-                lap_splits = self._racecontext.rhdata.get_lapSplits_by_lap(node_index, lap_number)
+                lap_splits = self._racecontext.rhdata.get_lapSplits_by_lap(node_index, deleted_lap_number)
                 if lap_splits and len(lap_splits) > 0:
                     for lap_split in lap_splits:
                         self._racecontext.rhdata.clear_lapSplit(lap_split)

--- a/src/server/Results.py
+++ b/src/server/Results.py
@@ -449,6 +449,27 @@ def _do_calc_leaderboard(racecontext, **params):
                 })
 
     do_gevent_sleep()
+
+    # speeds for each pilot, from the saved split records
+    top_speeds = {}
+    speed_sums = {}
+    if not USE_CURRENT:
+        for lap_split in rhDataObj.get_savedRaceLapSplits_by_savedRaceMeta(raceObj.id):
+            if lap_split.split_speed is not None:
+                if lap_split.split_speed > top_speeds.get(lap_split.pilot_id, float('-inf')):
+                    top_speeds[lap_split.pilot_id] = lap_split.split_speed
+                # non-positive speeds come from a bad reference timestamp
+                if lap_split.split_speed > 0:
+                    speed_total, speed_count = speed_sums.get(lap_split.pilot_id, (0.0, 0))
+                    speed_sums[lap_split.pilot_id] = (speed_total + lap_split.split_speed, speed_count + 1)
+    else:
+        # live splits, which hold only the race in progress
+        for lap_split in rhDataObj.get_lapSplits():
+            if lap_split.split_speed is not None and \
+                    lap_split.split_speed > top_speeds.get(lap_split.pilot_id, float('-inf')):
+                top_speeds[lap_split.pilot_id] = lap_split.split_speed
+
+    do_gevent_sleep()
     # find leader for each lap in race
     if USE_CURRENT:
         leader_laps = {}
@@ -551,6 +572,15 @@ def _do_calc_leaderboard(racecontext, **params):
         result_pilot['fastest_lap_source'] = source
         result_pilot['consecutives_source'] = source
 
+        result_pilot['top_speed'] = top_speeds.get(result_pilot['pilot_id'])
+        result_pilot['speed_total'], result_pilot['speed_count'] = \
+            speed_sums.get(result_pilot['pilot_id'], (0.0, 0))
+        result_pilot['top_speed_source'] = {
+            'round': round_num,
+            'heat': current_heat_id,
+            'displayname': heat_displayname,
+        } if result_pilot['top_speed'] is not None else None
+
     do_gevent_sleep()
 
     # Combine leaderboard
@@ -597,6 +627,9 @@ def _do_calc_leaderboard(racecontext, **params):
 
     if meta_points_flag:
         leaderboard_output['meta']['primary_points'] = True
+
+    if top_speeds:
+        leaderboard_output['meta']['speed_data'] = True
 
     leaderboard_output = sort_and_rank_leaderboards(racecontext, leaderboard_output)
     leaderboard_output = format_leaderboard_times(racecontext, leaderboard_output)
@@ -832,6 +865,9 @@ def build_incremental(racecontext, merge_input, source_input, transient=False):
                     elif meta_key == 'primary_points':
                         output_result['meta']['primary_points'] = False
 
+            if merge_result['meta'].get('speed_data'):
+                output_result['meta']['speed_data'] = True
+
         else:
             for lb_line in merge_result[key]:
                 for idx, item in enumerate(source_result[key]):
@@ -842,7 +878,9 @@ def build_incremental(racecontext, merge_input, source_input, transient=False):
                             'starts': item['starts'] + lb_line['starts'],
                             'total_time_raw': item['total_time_raw'] + lb_line['total_time_raw'],
                             'total_time_laps_raw': item['total_time_laps_raw'] + lb_line['total_time_laps_raw'],
-                            'points': (item['points'] if 'points' in item else 0) + (lb_line['points'] if 'points' in lb_line else 0)
+                            'points': (item['points'] if 'points' in item else 0) + (lb_line['points'] if 'points' in lb_line else 0),
+                            'speed_total': item.get('speed_total', 0.0) + lb_line.get('speed_total', 0.0),
+                            'speed_count': item.get('speed_count', 0) + lb_line.get('speed_count', 0)
                         }
 
                         # average lap
@@ -864,6 +902,12 @@ def build_incremental(racecontext, merge_input, source_input, transient=False):
                             race_result_updates['consecutives_raw'] = lb_line['consecutives_raw']
                             race_result_updates['consecutive_lap_start'] = lb_line['consecutive_lap_start']
                             race_result_updates['consecutives_source'] = lb_line['consecutives_source']
+
+                        # top speed & source
+                        if lb_line.get('top_speed') is not None and \
+                            (item.get('top_speed') is None or lb_line['top_speed'] > item['top_speed']):
+                            race_result_updates['top_speed'] = lb_line['top_speed']
+                            race_result_updates['top_speed_source'] = lb_line['top_speed_source']
 
                         output_result[key][idx].update(race_result_updates)
                         output_result[key][idx].pop('time_behind', None)

--- a/src/server/static/rotorhazard.js
+++ b/src/server/static/rotorhazard.js
@@ -1776,7 +1776,46 @@ jQuery(document).ready(function($){
 }
 
 /* Leaderboards */
-function build_leaderboard(leaderboard, display_type, meta, display_starts=false) {
+function format_top_speed(speed) {
+	if (speed === null || typeof(speed) === 'undefined')
+		return '&#8212;';
+	return speed.toFixed(2);
+}
+
+function format_avg_speed(row) {
+	if (!row.speed_count)
+		return '&#8212;';
+	return (row.speed_total / row.speed_count).toFixed(2);
+}
+
+function format_source_text(source) {
+	if (!source)
+		return 'None';
+	if (source.round)
+		return source.displayname + ' / ' + __('Round') + ' ' + source.round;
+	return source.displayname;
+}
+
+function sort_by_top_speed(leaderboard) {
+	// ranked copies for the "Fastest Speeds" board, pilots without a speed omitted
+	var rows = [];
+	for (var i in leaderboard) {
+		if (leaderboard[i].top_speed != null) {
+			rows.push(Object.assign({}, leaderboard[i]));
+		}
+	}
+	rows.sort(function(a, b){ return b.top_speed - a.top_speed; });
+	var last_speed = null;
+	var last_position = null;
+	for (var i = 0; i < rows.length; i++) {
+		rows[i].position = (rows[i].top_speed === last_speed) ? last_position : i + 1;
+		last_speed = rows[i].top_speed;
+		last_position = rows[i].position;
+	}
+	return rows;
+}
+
+function build_leaderboard(leaderboard, display_type, meta, display_starts=false, display_avg_speed=false, display_top_speed=false) {
 	if (typeof(display_type) === 'undefined')
 		var display_type = 'by_race_time';
 	if (typeof(meta) === 'undefined') {
@@ -1818,6 +1857,9 @@ function build_leaderboard(leaderboard, display_type, meta, display_starts=false
 		header_row.append('<th class="laps">' + __('Laps') + '</th>');
 		header_row.append('<th class="total">' + total_label + '</th>');
 		header_row.append('<th class="avg">' + __('Avg.') + '</th>');
+		if (display_avg_speed && meta.speed_data) {
+			header_row.append('<th class="avg-speed">' + __('Avg. Speed') + '</th>');
+		}
 	}
 	if (display_type == 'by_fastest_lap' ||
 		display_type == 'heat' ||
@@ -1828,6 +1870,10 @@ function build_leaderboard(leaderboard, display_type, meta, display_starts=false
 			header_row.append('<th class="source">' + __('Source') + '</th>');
 		}
 	}
+	if (display_type == 'by_fastest_speed') {
+		header_row.append('<th class="speed">' + __('Top Speed') + '</th>');
+		header_row.append('<th class="source">' + __('Source') + '</th>');
+	}
 	if (display_type == 'by_consecutives' ||
 		display_type == 'heat' ||
 		display_type == 'round' ||
@@ -1836,6 +1882,12 @@ function build_leaderboard(leaderboard, display_type, meta, display_starts=false
 		if (display_type == 'by_consecutives') {
 			header_row.append('<th class="source">' + __('Source') + '</th>');
 		}
+	}
+	if (meta.speed_data &&
+		(display_type == 'heat' ||
+		display_type == 'round' ||
+		(display_type == 'current' && display_top_speed))) {
+		header_row.append('<th class="speed">' + __('Top Speed') + '</th>');
 	}
 	if (show_points && 'primary_points' in meta) {
 		header_row.append('<th class="points">' + __('Points') + '</th>');
@@ -1878,6 +1930,10 @@ function build_leaderboard(leaderboard, display_type, meta, display_starts=false
 			if (!lap || lap == '0:00.000')
 				lap = '&#8212;';
 			row.append('<td class="avg">'+ lap +'</td>');
+
+			if (display_avg_speed && meta.speed_data) {
+				row.append('<td class="avg-speed">'+ format_avg_speed(leaderboard[i]) +'</td>');
+			}
 		}
 		if (display_type == 'by_fastest_lap' ||
 		display_type == 'heat' ||
@@ -1919,6 +1975,10 @@ function build_leaderboard(leaderboard, display_type, meta, display_starts=false
 				row.append('<td class="source">'+ source_text +'</td>');
 			}
 		}
+		if (display_type == 'by_fastest_speed') {
+			row.append('<td class="speed">'+ format_top_speed(leaderboard[i].top_speed) +'</td>');
+			row.append('<td class="source">'+ format_source_text(leaderboard[i].top_speed_source) +'</td>');
+		}
 		if (display_type == 'by_consecutives' ||
 		display_type == 'heat' ||
 		display_type == 'round' ||
@@ -1953,6 +2013,12 @@ function build_leaderboard(leaderboard, display_type, meta, display_starts=false
 			if (display_type == 'by_consecutives') {
 				row.append('<td class="source">'+ source_text +'</td>');
 			}
+		}
+		if (meta.speed_data &&
+			(display_type == 'heat' ||
+			display_type == 'round' ||
+			(display_type == 'current' && display_top_speed))) {
+			row.append('<td class="speed">'+ format_top_speed(leaderboard[i].top_speed) +'</td>');
 		}
 
 		if (show_points && 'primary_points' in meta) {

--- a/src/server/templates/current.html
+++ b/src/server/templates/current.html
@@ -452,7 +452,7 @@
 
 			leaderboard_type = race.leaderboard.meta.primary_leaderboard;
 			$('#leaderboard').empty();
-			$('#leaderboard').append(build_leaderboard(race.leaderboard[leaderboard_type], 'current', race.leaderboard.meta));
+			$('#leaderboard').append(build_leaderboard(race.leaderboard[leaderboard_type], 'current', race.leaderboard.meta, false, false, true));
 
 			$('#team_leaderboard').empty();
 			if (race.team_leaderboard && 'meta' in race.team_leaderboard) {

--- a/src/server/templates/results.html
+++ b/src/server/templates/results.html
@@ -151,6 +151,33 @@
 		md_output = event_converter.makeHtml({{ getOption('eventDescription')|tojson }});
 		$('#description').html($(md_output));
 
+		// drop race format name from round header if too narrow to fit it
+		function fit_round_header(el) {
+			var format_el = $(el).children('.race-format');
+			if (!format_el.length || !el.clientWidth)
+				return;
+			format_el.hide();
+			var bare_height = el.offsetHeight;
+			format_el.show();
+			if (el.offsetHeight > bare_height)
+				format_el.hide();
+		}
+
+		function fit_round_headers() {
+			$('.round > .panel-header button').each(function() { fit_round_header(this); });
+		}
+
+		var fit_timer = null;
+		function fit_round_headers_soon(delay) {
+			clearTimeout(fit_timer);
+			fit_timer = setTimeout(fit_round_headers, delay);
+		}
+
+		$(window).on('resize', function() { fit_round_headers_soon(100); });
+
+		// a header is unmeasurable until its panel finishes opening
+		$(document).on('click', '.collapsing .panel-header', function() { fit_round_headers_soon(450); });
+
 		socket.on('result_data', function (msg) {
 			function lap_speed_text(lap) {
 				if (lap.speed === null || typeof(lap.speed) === 'undefined')
@@ -295,7 +322,7 @@
 									var round = heat.rounds[round_i];
 									var round_div = $('<div id="class_' + class_id + '_heat_' + class_heat + '_round_' + round.id + '" class="round panel collapsing open">');
 
-									round_div.append('<div class="panel-header"><h4><button class="no-style">' + __('Round') + ' ' + round.id + ' (' + round.start_time_formatted + ')</button></h4></div>')
+									round_div.append('<div class="panel-header"><h4><button class="no-style">' + __('Round') + ' ' + round.id + ' (' + round.start_time_formatted + ')' + (round.format_name ? '<span class="race-format"> - ' + round.format_name + '</span>' : '') + '</button></h4></div>')
 
 									var round_content = $('<div class="panel-content">');
 									// race leaderboards
@@ -399,6 +426,8 @@
 						panel_obj.children('.panel-content').stop().slideUp();
 					}
 				}
+
+				fit_round_headers_soon(450);
 			} else {
 				page.append('<p>' + __('There is no saved race data available to view.') + '</p>');
 			}

--- a/src/server/templates/results.html
+++ b/src/server/templates/results.html
@@ -152,6 +152,18 @@
 		$('#description').html($(md_output));
 
 		socket.on('result_data', function (msg) {
+			function lap_speed_text(lap) {
+				if (lap.speed === null || typeof(lap.speed) === 'undefined')
+					return '';
+				return ' (' + lap.speed.toFixed(2) + ')';
+			}
+
+			function lap_speed_span(lap) {
+				if (lap.speed === null || typeof(lap.speed) === 'undefined')
+					return '';
+				return '<span class="from_start">(' + lap.speed.toFixed(2) + ')</span>';
+			}
+
 			function order_boards(primary) {
 				var boards = ['by_race_time', 'by_fastest_lap', 'by_consecutives']
 				boards.sort(function(x,y){ return x == primary ? -1 : y == primary ? 1 : 0; });
@@ -317,9 +329,9 @@
 														} else {
 															var timestamp = formatTimeMillis(lap.lap_time_stamp, {{ getConfig('UI', 'timeFormat')|tojson }})
 														}
-														tbody.append('<tr class="lap_' + lap_index + '"><td>' + lap_index + '</td><td><span class="from_start">' + timestamp + '</span>' + formatTimeMillis(lap.lap_time, {{ getConfig('UI', 'timeFormat')|tojson }}) + '</td></tr>')
+														tbody.append('<tr class="lap_' + lap_index + '"><td>' + lap_index + '</td><td><span class="from_start">' + timestamp + lap_speed_text(lap) + '</span>' + formatTimeMillis(lap.lap_time, {{ getConfig('UI', 'timeFormat')|tojson }}) + '</td></tr>')
 													} else {
-														tbody.append('<tr class="lap_0"><td>0</td><td>' + formatTimeMillis(lap.lap_time, {{ getConfig('UI', 'timeFormat')|tojson }}) + '</td></tr>')
+														tbody.append('<tr class="lap_0"><td>0</td><td>' + lap_speed_span(lap) + formatTimeMillis(lap.lap_time, {{ getConfig('UI', 'timeFormat')|tojson }}) + '</td></tr>')
 													}
 													lap_index++;
 												}
@@ -357,11 +369,18 @@
 				var panel_content = $('<div class="panel-content" style="display: none">');
 				var event_leaderboard = $('<div class="event-leaderboards">');
 				event_leaderboard.append('<h3>' + __('Race Totals') + '</h3>');
-				event_leaderboard.append(build_leaderboard(msg.event_leaderboard.by_race_time, 'by_race_time', msg.event_leaderboard.meta, true));
+				event_leaderboard.append(build_leaderboard(msg.event_leaderboard.by_race_time, 'by_race_time', msg.event_leaderboard.meta, true, true));
 				event_leaderboard.append('<h3>' + __('Fastest Laps') + '</h3>');
 				event_leaderboard.append(build_leaderboard(msg.event_leaderboard.by_fastest_lap, 'by_fastest_lap', msg.event_leaderboard.meta));
 				event_leaderboard.append('<h3>' + __('Fastest Consecutive Laps') + '</h3>');
 				event_leaderboard.append(build_leaderboard(msg.event_leaderboard.by_consecutives, 'by_consecutives', msg.event_leaderboard.meta));
+				if (msg.event_leaderboard.meta.speed_data) {
+					var speed_board = sort_by_top_speed(msg.event_leaderboard.by_race_time);
+					if (speed_board.length) {
+						event_leaderboard.append('<h3>' + __('Fastest Speeds') + '</h3>');
+						event_leaderboard.append(build_leaderboard(speed_board, 'by_fastest_speed', msg.event_leaderboard.meta));
+					}
+				}
 				panel_content.append(event_leaderboard);
 				panel.append(panel_content);
 

--- a/src/tests/test_server.py
+++ b/src/tests/test_server.py
@@ -307,7 +307,7 @@ class ServerTest(unittest.TestCase):
 
     def test_api_root(self):
         self.assertEqual(server.RHAPI.API_VERSION_MAJOR, 1)
-        self.assertEqual(server.RHAPI.API_VERSION_MINOR, 5)
+        self.assertEqual(server.RHAPI.API_VERSION_MINOR, 6)
         self.assertEqual(server.RHAPI.__, server.RHAPI.language.__)
 
     def test_ui_api(self):


### PR DESCRIPTION
Split-timer crossings and their recorded speeds currently live only in the scratch `lap_split` table, which is wiped when the next race stages — so they are gone the moment a race is saved. This adds a `saved_race_lap_split` table populated at save time, and surfaces the stored speeds on the Results and Current pages.

### Storage

Splits are keyed to the pilot run and lap number rather than to an individual saved lap record, so marshaling a race does not orphan them. The table carries no unique constraint, since a speed-only record can share a lap/split key with a rejected out-of-order split and a constraint violation would abort the race save.

Speed-only records from the secondary-timer fallback path were previously announced and discarded; they are now saved with a `speed_only` flag. They never enter the live lap-splits table, so displayed lap data is unchanged.

`create_db_all` adds the table to existing databases at startup, so no migration is required. `API_VERSION_MINOR` moves 5 → 6 for the new `RHAPI` accessors.

### Two latent bugs this exposes

**`delete_lap()` cleared splits using the wrong lap number** — the renumbering loop above it had already overwritten `lap_number` with the count of surviving laps. Harmless while splits were scratch data; now it would write an orphaned split attached to a lap that no longer exists.

**Renumbering left split lap ids behind.** Deleting a lap renumbers those that follow, but their splits kept their original ids, so they were looked up under the wrong lap; restoring a lap had the same problem in reverse. `RHData.shift_lapSplits()` shifts lowest-first when moving down and highest-first when moving up, so no row lands on an id another row still holds.

### Display

A **Top Speed** column on the Heat Summary, Round and Current-race leaderboards, right of Consecutive, plus each lap's first recorded speed beside its race-time value. On Event Totals, an **Avg. Speed** column in Race Totals and a **Fastest Speeds** section matching Fastest Laps.

All of it is gated on a `speed_data` flag in the leaderboard meta, so a database with no split-timer speeds produces exactly the page it did before. The Run page and stream overlays are unchanged — the Current page opts in via a new `display_top_speed` argument rather than widening the shared `current` display type.

Per-pilot top speeds and a running total/count are merged upward by `build_incremental`, so heat, class and event figures are a true mean of every recorded speed rather than an average of averages. Non-positive speeds come from a bad reference timestamp rather than from flying and are excluded from the average.

---

Drafted with assistance from Claude Code.
